### PR TITLE
make latex silent and stop on error

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,4 +6,6 @@ build:
     - export NO_PROXY=$no_proxy
     - export http_proxy=http://proxy-us.intel.com:911
     - export https_proxy=$http_proxy
-    - python3 scripts/oneapi.py --branch $CI_COMMIT_REF_NAME ci
+    - python3 scripts/oneapi.py spec-venv
+    - source spec-venv/bin/activate
+    - python scripts/oneapi.py --branch $CI_COMMIT_REF_NAME ci

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@
 aws-shell # Only needed for deploying the site
 breathe
 gitpython
-sphinx
+Sphinx>=2.4.0
 sphinx-notfound-page
 sphinx-rtd-theme

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y \
                     python3-pip \
+                    python3-venv \
                     python3 \
                     wget
 apt-get install -y  \

--- a/scripts/oneapi.py
+++ b/scripts/oneapi.py
@@ -90,6 +90,8 @@ def makedirs(path):
     os.makedirs(path)
 
 def sphinx(root, target):
+    os.environ['LATEXMKOPTS'] = '--silent'
+    os.environ['LATEXOPTS'] = '-interaction=nonstopmode -halt-on-error'
     shell('%s -M %s %s %s %s' % (sphinx_build,
                                  target,
                                  join(root,source_dir),

--- a/scripts/oneapi.py
+++ b/scripts/oneapi.py
@@ -224,7 +224,7 @@ def spec_venv(root, target=None):
     root_only(root)
     venv.create('spec-venv', with_pip=True, clear=True)
     pip = 'spec-venv\Scripts\pip' if platform.system() == 'Windows' else 'spec-venv/bin/pip'
-    shell('%s install -r requirements.txt' % pip)
+    shell('%s install --quiet -r requirements.txt' % pip)
     
 @action
 def clones(root='.', target=None):


### PR DESCRIPTION
Add options to make latex silent and stop on first error instead of waiting for input. For some errors, latex will emit an error and wait for a response to the terminal. This caused CI system to hang. Requires sphinx 2.4.0, but earlier versions of sphinx will ignore the extra options.