### PR TITLE
Remove TBB_USE_CAPTURED_EXCEPTION

### DIFF
--- a/source/elements/oneTBB/source/configuration/feature_macros.rst
+++ b/source/elements/oneTBB/source/configuration/feature_macros.rst
@@ -36,39 +36,6 @@ enabled in the compiler, and 0 otherwise.
    ``TBB_USE_EXCEPTIONS=0``.
 
 
-TBB_USE_CAPTURED_EXCEPTION macro
---------------------------------
-
-The macro 
-``TBB_USE_CAPTURED_EXCEPTION`` controls rethrow of
-exceptions within the library. Because C++03 does not support catching an
-exception on one thread and rethrowing it on another thread, the library
-sometimes resorts to rethrowing an approximation called 
-``tbb::captured_exception``.
-
-* Define 
-  ``TBB_USE_CAPTURED_EXCEPTION=1`` to make the library
-  rethrow an approximation. This is useful for uniform behavior across platforms.
-* Define 
-  ``TBB_USE_CAPTURED_EXCEPTION=0`` to request rethrow of
-  the exact exception. This setting is valid only on platforms that support the
-  std::exception_ptr feature of C++11. Otherwise a compile-time diagnostic is
-  issued.
-
-On Windows* , Linux* and macOS* operating systems,
-the default value is 
-``1`` for supported host compilers with 
-``std::exception_ptr``, and 
-``0`` otherwise. On IA-64 architecture processors the
-default value is 
-``0``.
-
-.. caution::
-
-   In order for exact exception propagation to work
-   properly an appropriate library binary should be used.
-
-
 C++11 Support
 -------------
 


### PR DESCRIPTION
With the switch to C++11, this macro deprecated and will be removed from oneTBB