### PR TITLE
make external links absolute

### DIFF
--- a/source/elements/l0/source/index.rst
+++ b/source/elements/l0/source/index.rst
@@ -42,4 +42,4 @@ Detailed API Descriptions
 
 The detailed specification for Level Zero is available `online`_.
 
-.. _`online`: ../../../oneL0/index.html
+.. _`online`: https://spec.oneapi.com/versions/0.6.0/oneL0/index.html

--- a/source/elements/oneDAL/source/index.rst
+++ b/source/elements/oneDAL/source/index.rst
@@ -124,5 +124,5 @@ The detailed specification for oneDAL is available `online`_.
 
 .. _`open source implementation`: https://github.com/intel/daal
 .. _`README`: https://github.com/intel/daal/blob/master/README.md
-.. _`online`: ../../../oneDAL/index.html
+.. _`online`: https://spec.oneapi.com/versions/0.6.0/oneDAL/index.html
 

--- a/source/elements/oneMKL/source/index.rst
+++ b/source/elements/oneMKL/source/index.rst
@@ -35,4 +35,4 @@ Detailed API Descriptions
 The detailed list of functions and their specification can be found in
 the `oneMKL specification`_.
 
-.. _`oneMKL specification`: ../../../oneMKL/index.htm
+.. _`oneMKL specification`: https://spec.oneapi.com/versions/0.6.0/oneMKL/index.htm


### PR DESCRIPTION
Eliminate relative external links because they will not work in the PDF.