### PR TITLE
make versions easier to find

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -101,6 +101,7 @@ html_theme = 'sphinx_rtd_theme'
 # documentation.
 #
 html_theme_options = {
+  'includehidden': False
 } 
 
 html_context = {

--- a/source/index.rst
+++ b/source/index.rst
@@ -24,6 +24,13 @@ oneAPI Specification
    elements/oneVPL/source/index
    elements/oneMKL/source/index
    contributors
+   versions
    notices
 
-   
+.. sphinx warns about rst files that are not reachable from the top
+   level toc. Put them here:
+
+.. toctree::
+   :hidden:
+
+   404

--- a/source/introduction.rst
+++ b/source/introduction.rst
@@ -120,25 +120,6 @@ If you agree to the above, every contribution of your feedback must
 include the following line using your real name and email address:
 Signed-off-by: Joe Smith joe.smith@email.com
 
-Versions
---------
-
-========  ==========  =========
-Version   Date        View                                                                                                            
-========  ==========  =========
-0.6.0_    01/31/2019  `HTML <https://spec.oneapi.com/versions/0.6.0/>`__ `PDF <https://spec.oneapi.com/versions/0.6.0/oneAPI-spec.pdf>`__
-0.5.0_    11/17/2019  `HTML <https://spec.oneapi.com/versions/0.5.0/>`__                                                                
-========  ==========  =========
-
-0.6.0
-+++++
-
-Open source release
-
-0.5.0
-+++++
-
-Initial public release
 
 .. todolist::
 

--- a/source/versions.rst
+++ b/source/versions.rst
@@ -1,0 +1,28 @@
+..
+  Copyright 2020 Intel Corporation
+
+
+HTML and PDF Versions
+=====================
+
+These are the versions that were available at time of publication. See
+the `latest spec
+<https://spec.oneapi.com/versions/latest/versions.html>`__ for newer
+versions.
+
+========  ==========  =========
+Version   Date        View                                                                                                            
+========  ==========  =========
+0.6.0_    01/31/2019  `HTML <https://spec.oneapi.com/versions/0.6.0/>`__ `PDF <https://spec.oneapi.com/versions/0.6.0/oneAPI-spec.pdf>`__
+0.5.0_    11/17/2019  `HTML <https://spec.oneapi.com/versions/0.5.0/>`__                                                                
+========  ==========  =========
+
+0.6.0
++++++
+
+Open source release
+
+0.5.0
++++++
+
+Initial public release


### PR DESCRIPTION
The place to download pdf and older versions of the spec is not apparent. I made it a separate section so it will appear near the bottom of the TOC in the left pane.