### PR TITLE
Update links to oneCCL repo

### DIFF
--- a/source/elements/oneCCL/source/introduction.rst
+++ b/source/elements/oneCCL/source/introduction.rst
@@ -35,6 +35,6 @@ Intel has published an `open source implementation`_ with the Apache
 license. The `open source implementation`_ includes a comprehensive
 test suite.  Consult the `README`_ for directions.
 
-.. _`open source implementation`: https://github.com/intel/oneccl
-.. _`README`: https://github.com/intel/oneccl/blob/master/README.md
+.. _`open source implementation`: https://github.com/oneapi-src/oneCCL
+.. _`README`: https://github.com/oneapi-src/oneCCL/blob/master/README.md
 


### PR DESCRIPTION
oneCCL moved to another repository. The redirects from the old repo are enabled, but the links should be updated at some point.