### PR TITLE
start restructuring oneDNN spec

### DIFF
--- a/source/elements/oneDNN/include/dnnl.hpp
+++ b/source/elements/oneDNN/include/dnnl.hpp
@@ -17,36 +17,50 @@
 /// @file dnnl.hpp
 /// oneDNN API
 
-/// @addtogroup onednn_api oneDNN API
-/// @{
-
 #ifndef DNNL_HPP
 #define DNNL_HPP
 
 /// @cond DO_NOT_DOCUMENT_THIS
 #include <algorithm>
-#include <cstdint>
 #include <cstdlib>
 #include <iterator>
 #include <memory>
 #include <vector>
 #include <unordered_map>
 
-#include "CL/sycl.hpp"
+#include <CL/sycl.hpp>
 /// @endcond
 
+/// @addtogroup dnnl_api DNNL API
+/// @{
+
+/// DNNL namespace
 namespace dnnl {
 
-/// Exception class.
+/// @addtogroup dnnl_api_utils Utilities
+/// Utility types and definitions.
+/// @{
+
+/// The exception class.
 struct error : public std::exception {};
+
+/// @} dnnl_api_utils
 
 struct stream;
 struct memory;
+struct primitive_desc_base;
+
+/// @addtogroup dnnl_api_primitives Primitives
+/// Compute primitives
+/// @{
+
+/// @addtogroup dnnl_api_primitives_common Common
+/// Common operations to create, destroy and inspect primitives
+/// @{
 
 /// Base class for all computational primitives.
-class primitive {
-public:
-    /// Kinds of primitives supported of oneDNN.
+struct primitive {
+    /// Kinds of primitives supported by the library.
     enum class kind {
         /// Undefined primitive
         undef,
@@ -80,27 +94,56 @@ public:
         rnn,
         /// A binary primitive.
         binary,
+        /// A logsoftmax primitive.
+        logsoftmax,
+        /// A matmul (matrix multiplication) primitive.
+        matmul,
+        /// A resampling primitive.
+        resampling,
     };
+
+    /// Default constructor. Constructs an empty object.
+    primitive();
+
+    /// Constructs a primitive from a primitive descriptor.
+    ///
+    /// @param pd Primitive descriptor.
+    primitive(const primitive_desc_base &pd);
+
+    /// Returns the kind of the primitive.
+    ///
+    /// @returns The primitive kind.
+    inline kind get_kind() const;
 
     /// Executes computations specified by the primitive in a specified stream.
     ///
-    /// @param stream Stream object. The stream must belong to the same engine
-    ///               as the primitive.
-    /// @param args Arguments map.
+    /// Arguments are passed via an arguments map containing <index,
+    /// memory object> pairs. The index must be one of the `DNNL_ARG_*` values
+    /// such as `DNNL_ARG_SRC`, and the memory must have a memory descriptor
+    /// matching the one returned by
+    /// primitive_desc::query_md(#query::exec_arg_md, index) unless using
+    /// dynamic shapes (see #DNNL_RUNTIME_DIM_VAL).
     ///
+    /// @param stream Stream object. The stream must belong to the same engine
+    ///     as the primitive.
+    /// @param args Arguments map.
     void execute(
             stream &stream, const std::unordered_map<int, memory> &args) const;
 
-    /// Executes computations specified by the primitive in a specified stream
-    /// (SYCL-aware version).
+    /// Executes computations specified by the primitive in a specified stream.
+    ///
+    /// Arguments are passed via an arguments map containing <index,
+    /// memory object> pairs. The index must be one of the `DNNL_ARG_*` values
+    /// such as `DNNL_ARG_SRC`, and the memory must have a memory descriptor
+    /// matching the one returned by
+    /// primitive_desc::query_md(#query::exec_arg_md, index) unless using
+    /// dynamic shapes (see #DNNL_RUNTIME_DIM_VAL).
     ///
     /// @param stream Stream object. The stream must belong to the same engine
-    ///               as the primitive.
+    ///     as the primitive.
     /// @param args Arguments map.
-    /// @param deps Vector of SYCL events that the execution should depend on.
+    /// @param deps Optional vector with `cl::sycl::event` dependencies.
     ///
-    /// @returns SYCL event that corresponds to the SYCL queue underlying the
-    ///          @p stream.
     cl::sycl::event execute_sycl(stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<cl::sycl::event> &deps = {}) const;
@@ -109,11 +152,211 @@ public:
     primitive &operator=(const primitive &rhs);
 };
 
+/// Source argument #0.
+#define DNNL_ARG_SRC_0 1
+/// A special mnemonic for source argument for primitives that have a
+/// single source. An alias for #DNNL_ARG_SRC_0.
+#define DNNL_ARG_SRC DNNL_ARG_SRC_0
+/// A special mnemonic for RNN input vector. An alias for
+/// #DNNL_ARG_SRC_0.
+#define DNNL_ARG_SRC_LAYER DNNL_ARG_SRC_0
+/// A special mnemonic for reorder source argument. An alias for
+/// #DNNL_ARG_SRC_0.
+#define DNNL_ARG_FROM DNNL_ARG_SRC_0
+
+/// Source argument #1.
+#define DNNL_ARG_SRC_1 2
+/// A special mnemonic for RNN input recurrent hidden state vector. An alias
+/// for #DNNL_ARG_SRC_1.
+#define DNNL_ARG_SRC_ITER DNNL_ARG_SRC_1
+
+/// Source argument #2.
+#define DNNL_ARG_SRC_2 3
+/// A special mnemonic for RNN input recurrent cell state vector. An alias for
+/// #DNNL_ARG_SRC_2.
+#define DNNL_ARG_SRC_ITER_C DNNL_ARG_SRC_2
+
+/// Destination argument #0.
+#define DNNL_ARG_DST_0 17
+/// A special mnemonic for destination argument for primitives that have a
+/// single destination. An alias for #DNNL_ARG_DST_0.
+#define DNNL_ARG_DST DNNL_ARG_DST_0
+/// A special mnemonic for reorder destination argument. An alias for
+/// #DNNL_ARG_DST_0.
+#define DNNL_ARG_TO DNNL_ARG_DST_0
+/// A special mnemonic for RNN output vector. An alias for #DNNL_ARG_DST_0.
+#define DNNL_ARG_DST_LAYER DNNL_ARG_DST_0
+
+/// Destination argument #1.
+#define DNNL_ARG_DST_1 18
+/// A special mnemonic for RNN input recurrent hidden state vector. An
+/// alias for #DNNL_ARG_DST_1.
+#define DNNL_ARG_DST_ITER DNNL_ARG_DST_1
+
+/// Destination argument #2.
+#define DNNL_ARG_DST_2 19
+/// A special mnemonic for LSTM output recurrent cell state vector. An
+/// alias for #DNNL_ARG_DST_2.
+#define DNNL_ARG_DST_ITER_C DNNL_ARG_DST_2
+
+/// Weights argument #0.
+#define DNNL_ARG_WEIGHTS_0 33
+/// A special mnemonic for primitives that have a single weights
+/// argument. Alias for #DNNL_ARG_WEIGHTS_0.
+#define DNNL_ARG_WEIGHTS DNNL_ARG_WEIGHTS_0
+/// A special mnemonic for scale and shift argument of normalization
+/// primitives. Alias for #DNNL_ARG_WEIGHTS_0.
+#define DNNL_ARG_SCALE_SHIFT DNNL_ARG_WEIGHTS_0
+/// A special mnemonic for RNN weights applied to the layer input. An
+/// alias for #DNNL_ARG_WEIGHTS_0.
+#define DNNL_ARG_WEIGHTS_LAYER DNNL_ARG_WEIGHTS_0
+
+/// Weights argument #1.
+#define DNNL_ARG_WEIGHTS_1 34
+/// A special mnemonic for RNN weights applied to the recurrent input.
+/// An alias for #DNNL_ARG_WEIGHTS_1.
+#define DNNL_ARG_WEIGHTS_ITER DNNL_ARG_WEIGHTS_1
+
+/// Bias tensor argument.
+#define DNNL_ARG_BIAS 41
+
+/// Mean values tensor argument.
+#define DNNL_ARG_MEAN 49
+/// Variance values tensor argument.
+#define DNNL_ARG_VARIANCE 50
+
+/// Workspace tensor argument. Workspace is used to pass information
+/// from forward propagation to backward propagation computations.
+#define DNNL_ARG_WORKSPACE 64
+/// Scratchpad (temporary storage) tensor argument.
+#define DNNL_ARG_SCRATCHPAD 80
+
+/// Gradient (diff) of the source argument #0.
+#define DNNL_ARG_DIFF_SRC_0 129
+/// A special mnemonic for primitives that have a single diff source argument.
+/// An alias for #DNNL_ARG_DIFF_SRC_0.
+#define DNNL_ARG_DIFF_SRC DNNL_ARG_DIFF_SRC_0
+/// A special mnemonic for gradient (diff) of RNN input vector. An alias for
+/// #DNNL_ARG_DIFF_SRC_0.
+#define DNNL_ARG_DIFF_SRC_LAYER DNNL_ARG_DIFF_SRC_0
+
+/// Gradient (diff) of the source argument #1.
+#define DNNL_ARG_DIFF_SRC_1 130
+/// A special mnemonic for gradient (diff) of RNN input recurrent hidden state
+/// vector. An alias for #DNNL_ARG_DIFF_SRC_1.
+#define DNNL_ARG_DIFF_SRC_ITER DNNL_ARG_DIFF_SRC_1
+
+/// Gradient (diff) of the source argument #2.
+#define DNNL_ARG_DIFF_SRC_2 131
+/// A special mnemonic for gradient (diff) of RNN input recurrent cell state
+/// vector. An alias for #DNNL_ARG_DIFF_SRC_1.
+#define DNNL_ARG_DIFF_SRC_ITER_C DNNL_ARG_DIFF_SRC_2
+
+/// Gradient (diff) of the destination argument #0.
+#define DNNL_ARG_DIFF_DST_0 145
+/// A special mnemonic for primitives that have a single diff destination
+/// argument. An alias for #DNNL_ARG_DIFF_DST_0.
+#define DNNL_ARG_DIFF_DST DNNL_ARG_DIFF_DST_0
+/// A special mnemonic for gradient (diff) of RNN output vector. An alias for
+/// #DNNL_ARG_DIFF_DST_0.
+#define DNNL_ARG_DIFF_DST_LAYER DNNL_ARG_DIFF_DST_0
+
+/// Gradient (diff) of the destination argument #1.
+#define DNNL_ARG_DIFF_DST_1 146
+/// A special mnemonic for gradient (diff) of RNN input recurrent hidden state
+/// vector. An alias for #DNNL_ARG_DIFF_DST_1.
+#define DNNL_ARG_DIFF_DST_ITER DNNL_ARG_DIFF_DST_1
+
+/// Gradient (diff) of the destination argument #2.
+#define DNNL_ARG_DIFF_DST_2 147
+/// A special mnemonic for gradient (diff) of RNN input recurrent cell state
+/// vector. An alias for #DNNL_ARG_DIFF_DST_2.
+#define DNNL_ARG_DIFF_DST_ITER_C DNNL_ARG_DIFF_DST_2
+
+/// Gradient (diff) of the weights argument #0.
+#define DNNL_ARG_DIFF_WEIGHTS_0 161
+/// A special mnemonic for primitives that have a single diff weights
+/// argument. Alias for #DNNL_ARG_DIFF_WEIGHTS_0.
+#define DNNL_ARG_DIFF_WEIGHTS DNNL_ARG_DIFF_WEIGHTS_0
+/// A special mnemonic for diff of scale and shift argument of normalization
+/// primitives. Alias for #DNNL_ARG_DIFF_WEIGHTS_0.
+#define DNNL_ARG_DIFF_SCALE_SHIFT DNNL_ARG_DIFF_WEIGHTS_0
+/// A special mnemonic for diff of RNN weights applied to the layer input. An
+/// alias for #DNNL_ARG_DIFF_WEIGHTS_0.
+#define DNNL_ARG_DIFF_WEIGHTS_LAYER DNNL_ARG_DIFF_WEIGHTS_0
+
+/// Gradient (diff) of the weights argument #1.
+#define DNNL_ARG_DIFF_WEIGHTS_1 162
+/// A special mnemonic for diff of RNN weights applied to the recurrent input.
+/// An alias for #DNNL_ARG_DIFF_WEIGHTS_1.
+#define DNNL_ARG_DIFF_WEIGHTS_ITER DNNL_ARG_DIFF_WEIGHTS_1
+
+/// Gradient (diff) of the bias tensor argument.
+#define DNNL_ARG_DIFF_BIAS 169
+
+/// Output scaling factors provided at execution time.
+#define DNNL_ARG_ATTR_OUTPUT_SCALES 513
+
+/// Starting index for source arguments for primitives that take a variable
+/// number of source arguments.
+#define DNNL_ARG_MULTIPLE_SRC 1024
+/// Starting index for destination arguments for primitives that produce a
+/// variable number of destination arguments.
+#define DNNL_ARG_MULTIPLE_DST 2048
+
+/// Zero points provided at execution time.
+#define DNNL_ARG_ATTR_ZERO_POINTS 4096
+
+/// A wildcard value for dimensions that are unknown at a primitive creation
+/// time.
+#define DNNL_RUNTIME_DIM_VAL INT64_MIN
+
+/// A `size_t` counterpart of the #DNNL_RUNTIME_DIM_VAL.
+/// For instance, this value is returned by #dnnl::memory::desc::get_size() if
+/// either of the dimensions or strides equal to #DNNL_RUNTIME_DIM_VAL.
+#define DNNL_RUNTIME_SIZE_VAL ((size_t)DNNL_RUNTIME_DIM_VAL)
+
+/// @cond DO_NOT_DOCUMENT_THIS
+/// Hex representation for a **special** quiet NAN (!= NAN from math.h)
+static const union {
+    unsigned u;
+    float f;
+} DNNL_RUNTIME_F32_VAL_REP = {0x7fc000d0};
+/// @endcond
+
+/// A wildcard value for floating point values that are unknown at a primitive
+/// creation time.
+#define DNNL_RUNTIME_F32_VAL (DNNL_RUNTIME_F32_VAL_REP.f)
+
+/// @cond DO_NOT_DOCUMENT_THIS
+static const int DNNL_RUNTIME_S32_VAL_REP = INT32_MIN;
+/// @endcond
+
+/// A wildcard value for int32_t values that are unknown at a primitive creation
+/// time.
+#define DNNL_RUNTIME_S32_VAL DNNL_RUNTIME_S32_VAL_REP
+
+/// @} dnnl_api_primitives_common
+
+/// @addtogroup dnnl_api_attributes
+///
+/// A container for parameters that extend primitives behavior.
+///
+/// Attributes can also contain Post-ops, which are computations executed
+/// after the primitive.
+///
+/// @{
+
 /// Scratchpad mode.
 enum class scratchpad_mode {
-    /// The library manages scratchpad (default).
+    /// The library manages the scratchpad allocation. There may be multiple
+    /// implementation-specific policies that can be configured via mechanisms
+    /// that fall outside of the scope of this specification.
     library,
-    /// A user shall provide the scratchpad memory to primitives.
+    /// User manages the scratchpad allocation. They shall query and provide
+    /// the scratchpad memory to primitives This mode is thread-safe as long
+    /// as the scratchpad buffers are not used concurrently by two primitive
+    /// executions.
     user,
 };
 
@@ -144,10 +387,11 @@ enum class prop_kind {
     backward_bias
 };
 
-/// Algorithm kinds
+/// Kinds of algorithms.
 enum class algorithm {
+    /// Undefined algorithm
     undef,
-    /// Convolution algorithm(either direct or Winograd) is chosen just in time
+    /// Convolution algorithm (either direct or Winograd) to be chosen just in time
     convolution_auto,
     /// Direct convolution
     convolution_direct,
@@ -157,32 +401,50 @@ enum class algorithm {
     deconvolution_direct,
     /// Winograd deconvolution
     deconvolution_winograd,
-    /// Eltwise: ReLU
+    /// Elementwise: rectified linear unit (ReLU)
     eltwise_relu,
-    /// Eltwise: hyperbolic tangent non-linearity (tanh)
+    /// Elementwise: hyperbolic tangent non-linearity (tanh)
     eltwise_tanh,
-    /// Eltwise: parametric exponential linear unit (elu)
+    /// Elementwise: parametric exponential linear unit (ELU)
     eltwise_elu,
-    /// Eltwise: square
+    /// Elementwise: square
     eltwise_square,
-    /// Eltwise: abs
+    /// Elementwise: abs
     eltwise_abs,
-    /// Eltwise: square root
+    /// Elementwise: square root
     eltwise_sqrt,
-    /// Eltwise: x*sigmoid(a*x)
+    /// Elementwise: swish (\f$x \cdot sigmoid(a \cdot x)\f$)
     eltwise_swish,
-    /// Eltwise: linear
+    /// Elementwise: linear
     eltwise_linear,
-    /// Eltwise: bounded_relu
+    /// Elementwise: bounded_relu
     eltwise_bounded_relu,
-    /// Eltwise: soft_relu
+    /// Elementwise: soft_relu
     eltwise_soft_relu,
-    /// Eltwise: logistic
+    /// Elementwise: logistic
     eltwise_logistic,
-    /// Eltwise: exponent
+    /// Elementwise: exponent
     eltwise_exp,
-    /// Eltwise: gelu
+    /// Elementwise: gelu
     eltwise_gelu,
+    /// Elementwise: natural logarithm
+    eltwise_log,
+    /// Elementwise: clip
+    eltwise_clip,
+    /// Elementwise: pow
+    eltwise_pow,
+    /// Elementwise: rectified linar unit (ReLU) (dst for backward)
+    eltwise_relu_use_dst_for_bwd,
+    /// Elementwise: hyperbolic tangent non-linearity (tanh) (dst for backward)
+    eltwise_tanh_use_dst_for_bwd,
+    /// Elementwise: exponential linear unit (ELU) (dst for backward)
+    eltwise_elu_use_dst_for_bwd,
+    /// Elementwise: square root (dst for backward)
+    eltwise_sqrt_use_dst_for_bwd,
+    /// Elementwise: logistic (dst for backward)
+    eltwise_logistic_use_dst_for_bwd,
+    /// Elementwise: exponent (dst for backward)
+    eltwise_exp_use_dst_for_bwd,
     /// Local response normalization (LRN) across multiple channels
     lrn_across_channels,
     /// LRN within a single channel
@@ -202,63 +464,61 @@ enum class algorithm {
     vanilla_lstm,
     /// GRU cell
     vanilla_gru,
-    /// GRU cell with linear before reset
-    ///
-    /// Modification of original GRU cell. Differs from
-    /// #dnnl::algorithm::vanilla_gru in how the new memory gate is
-    /// calculated:
-    /// \f[ c_t = tanh(W_c*x_t + b_{c_x} + r_t*(U_c*h_{t-1}+b_{c_h})) \f]
-    /// Primitive expects 4 biases on input:
+    /// GRU cell with linear before reset. Differs from original GRU
+    /// in how the new memory gate is calculated:
+    /// \f$c_t = tanh(W_c*x_t + b_{c_x} + r_t*(U_c*h_{t-1}+b_{c_h})) \f$
+    /// LRB GRU expects 4 bias tensors on input:
     /// \f$[b_{u}, b_{r}, b_{c_x}, b_{c_h}]\f$
     lbr_gru,
     /// Binary add
     binary_add,
     /// Binary mul
     binary_mul,
+    /// Binary max
+    binary_max,
+    /// Binary min
+    binary_min,
+    /// Nearest Neighbor resampling method
+    resampling_nearest,
+    /// Linear (Bilinear, Trilinear) resampling method
+    resampling_linear,
 };
+
+/// @} dnnl_api_attributes
+
+/// @addtogroup dnnl_api_primitives_common
+/// @{
 
 /// Flags for batch normalization primitive (can be combined via '|')
 enum class normalization_flags : unsigned {
-    /// Use global statistics
-    ///
-    /// If specified
-    ///  - on forward propagation use mean and variance provided by user (input)
-    ///  - on backward propagation reduces the amount of computations, since
-    ///    mean and variance are considered as constants
-    ///
-    ///  If not specified:
-    ///   - on forward propagation mean and variance are computed and stored in
-    ///     output
-    ///   - on backward propagation compute full derivative wrt to data
-    use_global_stats,
+    /// Use global statistics. If specified, the library uses mean and
+    /// variance provided by user as an input on forward propagation and does
+    /// not compute their derivatives on backward propagation. Otherwise, the
+    /// library computes and outputs mean and variance on forward propagation,
+    /// and their derivatives on backward propagation.
+    use_global_stats = 0x1u,
 
-    /// Use scale and shift parameters
-    ///
-    /// If specified:
-    ///  - on forward propagation use scale and shift (aka scale and bias) for
-    ///    the batch normalization results
-    ///  - on backward propagation
-    ///    (for prop_kind == #dnnl::prop_kind::backward) compute
-    ///    diff wrt to scale and shift (hence one extra output used)
-    ///
-    /// If not specified:
-    ///  - on backward propagation
-    ///    prop_kind == #dnnl::prop_kind::backward_data has the
-    ///    same behavior as prop_kind == #dnnl::prop_kind::backward
-    use_scale_shift,
+    /// Use scale and shift parameters. If specified, user is expected to pass
+    /// scale and shift as inputs on forward propagation. On backward
+    /// propagation of type #dnnl::prop_kind::backward, the library computes
+    /// their derivatives. If not specified, the scale and shift parameters
+    /// are not used by the library in any way.
+    use_scale_shift = 0x2u,
 
-    /// Fuse with ReLU
-    ///
-    /// If specified:
-    ///  - on inference this option behaves the same as if the primitive were
-    ///    fused with ReLU via post ops API
-    ///  - on training primitive requires workspace (required to be able to
-    ///    perform backward propagation)
-    fuse_norm_relu
+    /// Fuse normalization with ReLU. On training, normalization will require
+    /// workspace to implement backward propagation. On inference, the
+    /// workspace is not require and behavior is the same as when
+    /// normalization is fused with ReLU using the post-ops API.
+    fuse_norm_relu = 0x4u,
 };
 
 /// Bitwise OR operation for batch normalization flags.
 normalization_flags operator|(normalization_flags lhs, normalization_flags rhs);
+
+/// @} dnnl_api_primitives_common
+
+/// @addtogroup dnnl_api_rnn
+/// @{
 
 /// RNN cell flags.
 enum class rnn_flags : unsigned {
@@ -284,6 +544,11 @@ enum class rnn_direction {
     /// Alias for #dnnl::rnn_direction::unidirectional_left2right
     unidirectional = unidirectional_left2right,
 };
+
+/// @} dnnl_api_rnn
+
+/// @addtogroup dnnl_api_primitives_common
+/// @{
 
 /// Primitive descriptor query specification.
 enum class query {
@@ -320,6 +585,9 @@ enum class query {
     /// implementation name
     impl_info_str,
 
+    /// propagation kind
+    prop_kind,
+
     /// operation descriptor
     op_d,
     /// convolution descriptor
@@ -346,6 +614,12 @@ enum class query {
     rnn_d,
     /// binary descriptor
     binary_d,
+    /// logsoftmax descriptor
+    logsoftmax_d,
+    /// matmul descriptor
+    matmul_d,
+    /// resampling descriptor
+    resampling_d,
 
     /// source memory desc
     src_md,
@@ -363,85 +637,93 @@ enum class query {
     workspace_md,
     /// scratchpad memory desc
     scratchpad_md,
+    /// memory desc of an execute argument
+    exec_arg_md,
 };
+
+/// @} dnnl_api_primitives_common
+
+/// @addtogroup dnnl_api_attributes Attributes
+///
+/// A container for parameters that extend primitives behavior.
+///
+/// @{
 
 /// Post-ops.
 ///
-/// Post-ops are performed after the computation specified by a primitive and
-/// allow optimizing away bandwidth-bound operations.
+/// Post-ops are computations executed after the main primitive computations
+/// and are attached to the primitive via primitive attributes.
+///
 struct post_ops {
-    /// Constructs an empty sequence of post operations.
+    /// Constructs an empty sequence of post-ops.
     post_ops();
 
     /// Returns the number of post-ops entries.
     int len() const;
 
     /// Returns the primitive kind of post-op at entry with a certain index.
-    ///
     /// @param index Index of the post-op to return the kind for.
-    ///
-    /// @returns primitive kind of the postop at the specified index.
+    /// @returns Primitive kind of the post-op at the specified index.
     primitive::kind kind(int index) const;
 
-    /// Appends an accumulation (sum) post operation. Prior to accumulating the
+    /// Appends an accumulation (sum) post-op. Prior to accumulating the
     /// result, the previous value would be multiplied by a scaling factor
     /// @p scale.
     ///
-    /// The kind of this post operation is #dnnl::primitive::kind::sum.
+    /// The kind of this post-op is #dnnl::primitive::kind::sum.
     ///
-    /// This feature might improve performance for cases like residual learning
-    /// blocks, where the result of convolution is accumulated to the previously
-    /// computed activations. The parameter @p scale might be extreme for the
-    /// integer-based computations when the result and previous activations have
-    /// different logical scaling factors.
+    /// This feature may improve performance for cases like residual learning
+    /// blocks, where the result of convolution is accumulated to the
+    /// previously computed activations. The parameter @p scale may be used
+    /// for the integer-based computations when the result and previous
+    /// activations have different logical scaling factors.
     ///
-    /// In the simplest case when the accumulation is the only post operation,
-    /// the computations would be:
-    ///
-    /// dst[] <- scale * dst[] + op(...) instead of dst[] <- op(...)
+    /// In the simplest case when the accumulation is the only post-op,
+    /// the computations would be `dst[:] := scale * dst[:] + op(...)`
+    /// instead of `dst[:] := op(...)`.
     ///
     /// @note
-    ///     This post operation (as well as all the others) disregards the
-    ///     original layout of the destination; that is, the layout of the
-    ///     original destination is expected to be the same as the layout of the
-    ///     stored destination.
+    ///     This post-op executes in-place and does not change the
+    ///     destination layout.
     ///
     /// @param scale Scaling factor.
     void append_sum(float scale = 1.);
 
-    /// Returns the parameters of a sum post-op.
+    /// Returns the parameters of an accumulation (sum) post-op.
     ///
     /// @param index Index of the sum post-op.
     /// @param scale Scaling factor of the sum post-op.
     void get_params_sum(int index, float &scale) const;
 
-    /// Appends an eltwise post operation.
+    /// Appends an elementwise post-op.
     ///
-    /// The kind of this post operation is #dnnl::primitive::kind::eltwise.
+    /// The kind of this post-op is #dnnl::primitive::kind::eltwise.
     ///
-    /// In the simplest case when the eltwise is the only post operation, the
-    /// computations would be:
-    /// dst[] <- scale * eltwise_op ( op(...) ) instead of dst[] <- op(...)
+    /// In the simplest case when the elementwise is the only post-op, the
+    /// computations would be `dst[:] := scale * eltwise_op (op(...))`
+    /// instead of `dst[:] <- op(...)`.
+    ///
     /// where eltwise_op is configured with the given parameters.
     ///
     /// @param scale Scaling factor.
-    /// @param alg Eltwise algorithm.
-    /// @param alpha Alpha parameter for the eltwise algorithm.
-    /// @param beta Beta parameter for the eltwise algorithm.
-    void append_eltwise(float scale, algorithm alg, float alpha, float beta);
+    /// @param algorithm Elementwise algorithm.
+    /// @param alpha Alpha parameter for the elementwise algorithm.
+    /// @param beta Beta parameter for the elementwise algorithm.
+    void append_eltwise(
+            float scale, algorithm algorithm, float alpha, float beta);
 
-    /// Returns the eltwise parameters of a post-up.
+    /// Returns parameters of an elementwise post-up.
     ///
     /// @param index Index of the post-op.
-    /// @param scale Scaling factor.
-    /// @param alg Eltwise algorithm.
-    /// @param alpha Alpha parameter for the eltwise algorithm.
-    /// @param beta Beta parameter for the eltwise algorithm.
-    void get_params_eltwise(int index, float &scale, algorithm &alg,
+    /// @param scale Output scaling factor.
+    /// @param algorithm Output elementwise algorithm kind.
+    /// @param alpha Output alpha parameter for the elementwise algorithm.
+    /// @param beta Output beta parameter for the elementwise algorithm.
+    void get_params_eltwise(int index, float &scale, algorithm &algorithm,
             float &alpha, float &beta) const;
 };
 
-/// Primitive attributes
+/// Primitive attributes.
 struct primitive_attr {
     /// Constructs default (empty) primitive attributes.
     primitive_attr();
@@ -450,42 +732,140 @@ struct primitive_attr {
     scratchpad_mode get_scratchpad_mode() const;
 
     /// Sets scratchpad mode.
+    ///
+    /// @param mode Specified scratchpad mode.
     void set_scratchpad_mode(scratchpad_mode mode);
 
-    /// Returns the output scaling factors correspondence mask and vector.
+    /// Returns output scaling factors correspondence mask and values.
     ///
     /// @param mask Scaling factors correspondence mask that defines the
-    ///             correspondence between the output tensor dimensions and
-    ///             the @p scales vector. The set i-th bit indicates that a
-    ///             dedicated scaling factor should be used for any dimension
-    ///             j with j >= i. The mask value of 0 implies a common
-    ///             scaling factor for the whole output tensor.
+    ///     correspondence between the output tensor dimensions and the @p
+    ///     scales vector. The set i-th bit indicates that a dedicated output
+    ///     scaling factor is used for each index along that dimension. The
+    ///     mask value of 0 implies a common output scaling factor for the
+    ///     whole output tensor.
     /// @param scales Vector of output scaling factors.
     void get_output_scales(int &mask, std::vector<float> &scales) const;
 
-    /// Sets the output scale correspondence mask and values.
+    /// Sets output scaling factors correspondence mask and values.
     ///
-    /// @param mask Scaling factors correspondence mask that defines the
-    ///             correspondence between the output tensor dimensions and
-    ///             the @p scales vector. The set i-th bit indicates that a
-    ///             dedicated scaling factor should be used for any dimension
-    ///             j with j >= i. Set the mask to 0 to use a common scaling
-    ///             factor for the whole output tensor.
-    /// @param scales Vector of output scaling factors.
+    /// Example usage:
+    /// @code
+    ///     int mb = 32, oc = 32,
+    ///         oh = 14, ow = 14; // convolution output params
+    ///     // unique output scales per output channel
+    ///     vector<float> scales = { ... };
+    ///     int oc_dim = 1; // mb_dim = 0, channel_dim = 1, height_dim = 2, ...
+    ///
+    ///     // construct a convolution descriptor
+    ///     dnnl::convolution::desc conv_d;
+    ///
+    ///     dnnl::primitive_attr attr;
+    ///     attr.set_output_scales(attr, oc, 1 << oc_dim, scales);
+    ///
+    ///     dnnl::primitive_desc conv_pd(conv_d, attr, engine);
+    /// @endcode
     ///
     /// @note
-    ///      The order of dimensions does not depend on how elements are laid
-    ///      out in memory. For example:
-    ///       - for a 2D CNN activations tensor the order is always (n, c)
-    ///       - for a 4D CNN activations tensor the order is always (n, c, h, w)
-    ///       - for a 5D CNN weights tensor the order is always
-    ///         (g, oc, ic, kh, kw)
+    ///     The order of dimensions does not depend on how elements are laid
+    ///     out in memory. For example:
+    ///     - for a 2D CNN activations tensor the order is always (n, c)
+    ///     - for a 4D CNN activations tensor the order is always (n, c, h, w)
+    ///     - for a 5D CNN weights tensor the order is always
+    ///        (g, oc, ic, kh, kw)
+    ///
+    /// @param mask Defines the correspondence between the output tensor
+    ///     dimensions and the @p scales vector. The set i-th bit indicates
+    ///     that a dedicated scaling factor is used for each index along that
+    ///     dimension. Set the mask to 0 to use a common output scaling factor
+    ///     for the whole output tensor.
+    /// @param scales Constant vector of output scaling factors. If the
+    ///     scaling factors are known at the time of this call, the following
+    ///     equality must hold:
+    ///     \f$scales.size() = \prod\limits_{d \in mask} output.dims[d].\f$
+    ///     Violations can only be detected when the attributes
+    ///     are used to create a primitive descriptor.
+    ///     If the scaling factors are not known at the time of the call,
+    ///     this vector must contain a single #DNNL_RUNTIME_F32_VAL value and
+    ///     the output scaling factors must be passed at execution time as an
+    ///     argument with index #DNNL_ARG_ATTR_OUTPUT_SCALES.
     void set_output_scales(int mask, const std::vector<float> &scales);
+    /// Returns scaling factors correspondence mask and values for a given
+    /// memory argument.
+    ///
+    /// @param arg Parameter argument index as passed to the
+    ///     primitive::execute() call.
+    /// @param mask Scaling factors correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the @p
+    ///     scales vector. The set i-th bit indicates that a dedicated scaling
+    ///     factor is used for each index along that dimension. Set the mask to
+    ///     0 to use a common scaling factor for the whole output tensor.
+    /// @param scales Output vector of scaling factors.
+    void get_scales(int arg, int &mask, std::vector<float> &scales) const;
 
-    /// @returns post-ops previously set via set_post_ops().
+    /// Sets scaling factors for primitive operations for a given memory
+    /// argument.
+    ///
+    /// @sa dnnl::primitive_attr::set_output_scales
+    ///
+    /// @param arg Parameter argument index as passed to the
+    ///     primitive::execute() call.
+    /// @param mask Scaling factors correspondence mask that defines the
+    ///     correspondence between the tensor dimensions and the @p scales
+    ///     vector. The set i-th bit indicates that a dedicated scaling factor
+    ///     is used for each index along that dimension. Set the mask to 0 to
+    ///     use a common scaling factor for the whole output tensor.
+    /// @param scales Constant vector of scaling factors. The following equality
+    ///     must hold:
+    ///     \f$scales.size() = \prod\limits_{d \in mask} argument.dims[d].\f$
+    void set_scales(int arg, int mask, const std::vector<float> &scales);
+
+    /// Returns zero points correspondence mask and values.
+    ///
+    /// @param arg Parameter argument index as passed to the
+    ///     primitive::execute() call.
+    /// @param mask Zero points correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the @p
+    ///     zero_points vector. The set i-th bit indicates that a dedicated
+    ///     zero point is used for each index along that dimension. Set the
+    ///     mask to 0 to use a common zero point for the whole output tensor.
+    /// @param zero_points Output vector of zero points.
+    void get_zero_points(
+            int arg, int &mask, std::vector<int32_t> &zero_points) const;
+
+    /// Sets zero points for primitive operations for a given memory argument.
+    ///
+    /// @sa dnnl::primitive_attr::set_output_scales
+    ///
+    /// @param arg Parameter argument index as passed to the
+    ///     primitive::execute() call.
+    /// @param mask Zero point correspondence mask that defines the
+    ///     correspondence between the tensor dimensions and the @p
+    ///     zero_points vector. The set i-th bit indicates that a dedicated
+    ///     zero point is used for each index along that dimension. Set the
+    ///     mask to 0 to use a common zero point for the whole output tensor.
+    /// @param zero_points Constant vector of zero points. If the zero points
+    ///     are known at the time of this call, the following equality must
+    ///     hold: \f$zero\_points.size() = \prod\limits_{d \in mask}
+    ///     argument.dims[d].\f$ If the zero points are not known at the time
+    ///     of the call, this vector must contain a single
+    ///     #DNNL_RUNTIME_F32_VAL value and the zero points must be passed at
+    ///     execution time as an argument with index
+    ///     #DNNL_ARG_ATTR_ZERO_POINTS.
+    void set_zero_points(
+            int arg, int mask, const std::vector<int32_t> &zero_points);
+
+    /// Returns post-ops previously set via set_post_ops().
+    ///
+    /// @returns Post-ops.
     const post_ops get_post_ops() const;
 
     /// Sets post-ops.
+    ///
+    /// @note
+    ///     There is no way to check whether the post-ops would be supported
+    ///     by the target primitive. Any error will be reported
+    ///     by the respective primitive descriptor constructor.
     ///
     /// @param ops Post-ops object to copy post-ops from.
     void set_post_ops(const post_ops ops);
@@ -493,13 +873,32 @@ struct primitive_attr {
     /// Sets quantization scale and shift parameters for RNN data tensors.
     ///
     /// For performance reasons, the low-precision configuration of the RNN
-    /// primitive expects input activations to have the unsigned 8-bit integer
+    /// primitives expect input activations to have the unsigned 8-bit integer
     /// data type. The scale and shift parameters are used to quantize
-    /// floating-point data to unsigned integer must be passed to the RNN
-    /// primitive using attributes.  The quantization formula is scale * (data
-    /// + shift).
+    /// floating-point data to unsigned integer and must be passed to the RNN
+    /// primitive using attributes.
     ///
-    /// @note Quantization scale and shift are common for src_layer, src_iter,
+    /// The quantization formula is `scale * (data + shift)`.
+    ///
+    /// Example usage:
+    /// @code
+    ///     // RNN parameters
+    ///     int l = 2, t = 2, mb = 32, sic = 32, slc = 32, dic = 32, dlc = 32;
+    ///     // Activations quantization parameters
+    ///     float scale = 2.0f, shift = 0.5f;
+    ///
+    ///     primitive_attr attr;
+    ///
+    ///     // Set scale and shift for int8 quantization of activation
+    ///     attr.set_rnn_data_qparams(scale, shift);
+    ///
+    ///     // Create and configure rnn op_desc
+    ///     vanilla_rnn_forward::desc rnn_d(/* arguments */);
+    ///     vanilla_rnn_forward::primitive_desc rnn_d(rnn_d, attr, engine);
+    /// @endcode
+    ///
+    /// @note
+    ///     Quantization scale and shift are common for src_layer, src_iter,
     ///     dst_iter, and dst_layer.
     ///
     /// @param scale The value to scale the data by.
@@ -507,37 +906,46 @@ struct primitive_attr {
     void set_rnn_data_qparams(float scale, float shift);
 
     /// Sets quantization scaling factors for RNN weights tensors. The
-    /// low-precision configuration of the RNN primitive expects input weights
-    /// to have the signed int8 data type. The scaling factors are used to
-    /// quantize floating-point data to signed integer and need to be passed
-    /// to RNN primitives using attributes.
-    ///
-    /// @param mask Scaling factors correspondence mask that defines the
-    ///             correspondence between the output tensor dimensions and
-    ///             the @p scales vector. The set i-th bit indicates that a
-    ///             dedicated scaling factor should be used for any dimension
-    ///             j with j >= i. Set the mask to 0 to use a common scaling
-    ///             factor for the whole output tensor.
-    /// @param scales Vector of output scaling factors.
+    /// low-precision configuration of the RNN primitives expect input weights
+    /// to use the signed 8-bit integer data type. The scaling factors are
+    /// used to quantize floating-point data to signed integer and must be
+    /// passed to RNN primitives using attributes.
     ///
     /// @note
-    ///      The dimension order is always native and does not depend on the
-    ///      actual layout used. For example, five-dimensional weights always
-    ///      have (l, d, i, g, o) logical dimension ordering.
+    ///     The dimension order is always native and does not depend on the
+    ///     actual layout used. For example, five-dimensional weights always
+    ///     have (l, d, i, g, o) logical dimension ordering.
     ///
     /// @note
     ///     Quantization scales are common for weights_layer and
     ///     weights_iteration
     ///
-    /// @note
-    ///     There is no way to check whether @p count corresponds to @p mask
-    ///     until an actual primitive descriptor is created, so it is the user's
-    ///     responsibility to set proper values. The following formula must
-    ///     hold:
-    ///
-    ///     \f[count = \prod\limits_{d \in mask} output.dims[d]\f]
+    /// @param mask Scaling factors correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the @p
+    ///     scales vector. The set i-th bit indicates that a dedicated scaling
+    ///     factor should be used each index along that dimension. Set the
+    ///     mask to 0 to use a common scaling factor for the whole output
+    ///     tensor.
+    /// @param scales Constant vector of output scaling factors. The following
+    ///     equality must hold:
+    ///     \f$scales.size() = \prod\limits_{d \in mask} weights.dims[d].\f$
+    ///     Violations can only be detected when the attributes are used to
+    ///     create a primitive descriptor.
     void set_rnn_weights_qparams(int mask, const std::vector<float> &scales);
 };
+
+/// @} dnnl_api_attributes
+
+/// @} dnnl_api_primitives
+
+/// @addtogroup dnnl_api_engine Engine
+///
+/// An abstraction of a computational device: a CPU, a specific GPU
+/// card in the system, etc. Most primitives are created to execute
+/// computations on one specific engine. The only exceptions are reorder
+/// primitives that transfer data between two different engines.
+///
+/// @{
 
 /// An execution engine.
 struct engine {
@@ -558,14 +966,14 @@ struct engine {
     /// Returns the number of engines of a certain kind.
     ///
     /// @param kind The kind of engines to count.
+    /// @returns The number of engines of the specified kind.
     static size_t get_count(kind kind);
 
     /// Constructs an engine.
     ///
     /// @param kind The kind of engine to construct.
     /// @param index The index of the engine. Must be less than the value
-    ///              returned by #get_count() for this particular kind
-    ///              of engine.
+    ///     returned by #get_count() for this particular kind of engine.
     engine(kind kind, size_t index);
 
     /// Constructs an engine from SYCL device and context objects.
@@ -576,7 +984,8 @@ struct engine {
     engine(kind kind, const cl::sycl::device &dev,
             const cl::sycl::context &ctx);
 
-    /// @returns the kind of the engine.
+    /// Returns the kind of the engine.
+    /// @returns The kind of the engine.
     kind get_kind() const;
 
     /// Returns the underlying SYCL context object.
@@ -585,6 +994,14 @@ struct engine {
     /// Returns the underlying SYCL device object.
     cl::sycl::device get_sycl_device() const;
 };
+
+/// @} dnnl_api_engine
+
+/// @addtogroup dnnl_api_stream Stream
+///
+/// An encapsulation of execution context tied to a particular engine.
+///
+/// @{
 
 /// An execution stream.
 struct stream {
@@ -606,7 +1023,7 @@ struct stream {
     stream();
 
     /// Constructs a stream for the specified engine and with behavior
-    /// controlled by the specified flags
+    /// controlled by the specified flags.
     ///
     /// @param engine Engine to create the stream on.
     /// @param flags Flags controlling stream behavior.
@@ -614,16 +1031,80 @@ struct stream {
 
     /// Constructs a stream for the specified engine and the SYCL queue.
     ///
-    /// @param engine Engine to create the stream on.
+    /// @param engine Engine object to use for the stream.
     /// @param queue SYCL queue to use for the stream.
     stream(const engine &engine, cl::sycl::queue &queue);
 
-    /// @returns the underlying SYCL queue object.
+    /// Returns the underlying SYCL queue object.
+    /// @returns SYCL queue object.
     cl::sycl::queue get_sycl_queue() const;
 
     /// Waits for all primitives executing in the stream to finish.
+    /// @returns The stream itself.
     stream &wait();
 };
+
+/// @} dnnl_api_stream
+
+/// @addtogroup dnnl_api_memory Memory
+///
+/// A container that describes and stores data. Memory objects can contain
+/// data of various data types and formats. There are two levels of
+/// abstraction:
+///
+/// 1. **Memory descriptor** -- engine-agnostic logical description of data
+///     (number of dimensions, dimension sizes, and data type), and,
+///     optionally, the information about the physical format of data in
+///     memory. If this information is not known yet, a memory descriptor can
+///     be created with #dnnl::memory::format_tag::any. This allows
+///     compute-intensive primitives to chose the most appropriate format for
+///     the computations.  The user is then responsible for reordering their
+///     data into the new format if the formats do not match.
+///
+///     A memory descriptor can be initialized either by specifying
+///     dimensions, and memory format tag or strides for each of them.
+///
+///     User can query amount of memory required by a memory descriptor using
+///     the #dnnl::memory::desc::get_size() function. The size of data in
+///     general cannot be computed as the product of dimensions multiplied by
+///     the size of the data type. So users are required to use this function
+///     for better code portability.
+///
+///     Two memory descriptors can be compared using the equality and
+///     inequality operators.  The comparison is especially useful when
+///     checking whether it is necessary to reorder data from the user's data
+///     format to a primitive's format.
+///
+/// 2. **Memory object** -- an engine-specific object that handles the data
+///     and its description (a memory descriptor). With USM, the data handle
+///     is simply a pointer to @c void. The data handle can be queried using
+///     #dnnl::memory::get_data_handle() and set using
+///     #dnnl::memory::set_data_handle(). The underlying SYCL buffer, when
+///     used, can be queried using #dnnl::memory::get_sycl_buffer and and set
+///     using #dnnl::memory::set_sycl_buffer. A memory object can also be
+///     queried for the underlying memory descriptor and for its engine using
+///     #dnnl::memory::get_desc() and dnnl::memory::get_engine().
+///
+/// Along with ordinary memory descriptors with all dimensions being positive,
+/// the library supports *zero-volume* (or just *zero*) memory descriptors
+/// with one or more dimensions set to zero.  This is used to support the
+/// NumPy\* convention.  If a zero memory is passed to a primitive, the
+/// primitive typically does not perform any computations with this memory.
+/// For example:
+///
+/// - A concatenation primitive would ignore all memory object with zeroes in
+///   the concat dimension / axis.
+///
+/// - A forward convolution with a source memory object with zero in the
+///   minibatch dimension would always produce a detination memory object with
+///   a zero in the minibatch dimension and perform no computations.
+///
+/// - However, a forward convolution with a zero in one of the weights
+///   dimensions is ill-defined considered to be an error by the library
+///   because there is no clear definition on what the output values should
+///   be.
+///
+/// @{
 
 /// Memory object.
 ///
@@ -638,7 +1119,7 @@ struct memory {
     /// vector's length.
     using dims = std::vector<dim>;
 
-    /// Data type of elements stored in a memory object.
+    /// Data type specification.
     enum class data_type {
         /// Undefined data type (used for empty memory descriptors).
         undef,
@@ -660,29 +1141,29 @@ struct memory {
     ///
     /// Memory format tags can be further divided into two categories:
     ///
-    ///  - Domain-agnostic names, i.e. names the do not depend on the tensor
+    ///  - Domain-agnostic names, i.e. names that do not depend on the tensor
     ///    usage in the specific primitive. These names use letters from `a`
     ///    to `l` to denote logical dimensions and form the order in which the
     ///    dimensions are laid in memory. For example,
-    ///    #dnnl::memory::format_tag::ab is used to denote 2D tensor where the
-    ///    second logical dimension (aka `b`) is the innermost, i.e. has
-    ///    stride = 1, and the first logical dimension (`a`) laid out in
-    ///    memory with stride equal to the size of second dimension. On the
+    ///    #dnnl::memory::format_tag::ab is used to denote a 2D tensor where the
+    ///    second logical dimension (denoted as `b`) is the innermost, i.e.
+    ///    has stride = 1, and the first logical dimension (`a`) is laid out in
+    ///    memory with stride equal to the size of the second dimension. On the
     ///    other hand, #dnnl::memory::format_tag::ba is the transposed version
     ///    of the same tensor: the outermost dimension (`a`) becomes the
     ///    innermost one.
     ///
     ///  - Domain-specific names, i.e. names that make sense only in the
-    ///    context of a certain domain, such as CNN. This names are
+    ///    context of a certain domain, such as CNN. These names are
     ///    aliases to the corresponding domain-agnostic tags and used mostly
-    ///    for the convenience. For example, #dnnl::memory::format_tag::nc
+    ///    for convenience. For example, #dnnl::memory::format_tag::nc
     ///    is used to denote 2D CNN activations tensor memory format, where
     ///    the channels dimension is the innermost one and the batch dimension
     ///    is the outermost one. Moreover, #dnnl::memory::format_tag::nc is
-    ///    an alias for #dnnl::memory::format_tag::ab, since for oneDNN
+    ///    an alias for #dnnl::memory::format_tag::ab, because for
     ///    CNN primitives the logical dimensions of activations tensors come
     ///    in order: batch, channels, spatial.  In other words, batch
-    ///    corresponds to the first logical dimension (`a`), channels
+    ///    corresponds to the first logical dimension (`a`), and channels
     ///    correspond to the second one (`b`).
     ///
     /// The following domain-specific notation applies to memory format tags:
@@ -691,6 +1172,7 @@ struct memory {
     ///  - When there are multiple channel dimensions (for example,
     ///    in convolution weights tensor), @c 'i' and @c 'o' denote dimensions
     ///    of input and output channels
+    ///  - @c 'g' denotes a groups dimension for convolution weights
     ///  - @c 'd', @c 'h', and @c 'w' denote spatial depth, height, and width
     ///    respectively
     ///
@@ -747,6 +1229,10 @@ struct memory {
         decab,
         /// plain 6D tensor
         abcdef,
+        /// plain 6D tensor
+        acbdef,
+        /// plain 6D tensor
+        defcab,
 
         /// 1D tensor; an alias for #dnnl::memory::format_tag::a
         x = a,
@@ -814,6 +1300,10 @@ struct memory {
         giohw = acbde,
         /// 6D CNN weights tensor with groups; an alias for #dnnl::memory::format_tag::abcdef
         goidhw = abcdef,
+        /// 6D CNN weights tensor with groups; an alias for #dnnl::memory::format_tag::abcdef
+        giodhw = acbdef,
+        /// 6D CNN weights tensor with groups; an alias for #dnnl::memory::format_tag::defcab
+        dhwigo = defcab,
 
         /// 3D RNN data tensor in the format (seq_length, batch, input channels).
         tnc = abc,
@@ -847,64 +1337,175 @@ struct memory {
 
     /// A memory descriptor.
     struct desc {
-        /// Constructs a zero (empty) memory descriptor. Such memory
-        /// descriptor may be used to indicate absence of an argument.
+        /// Constructs a zero (empty) memory descriptor. Such a memory
+        /// descriptor can be used to indicate absence of an argument.
         desc();
 
         /// Constructs a memory descriptor.
         ///
-        /// @param dims Tensor dimensions.
-        /// @param data_type Data precision/type.
-        /// @param format_tag Memory format tag.
-        desc(const memory::dims &dims, data_type data_type,
-                format_tag format_tag);
-
-        /// Constructs a memory descriptor by strides.
+        /// @note
+        ///     The logical order of dimensions corresponds to the `abc...`
+        ///     format tag, and the physical meaning of the dimensions depends
+        ///     on both the primitive that consumes the memory and the context
+        ///     of that consumption.
         ///
         /// @param dims Tensor dimensions.
         /// @param data_type Data precision/type.
-        /// @param strides Strides for each of the dimensions.
+        /// @param format_tag Memory format tag.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case a
+        ///     zero memory descriptor will be constructed. This flag is
+        ///     optional and defaults to false.
         desc(const memory::dims &dims, data_type data_type,
-                const memory::dims &strides);
+                format_tag format_tag, bool allow_empty = false);
 
-        /// Constructs a sub-memory descriptor.
-        //
-        /// @param dims Sizes of a sub-memory.
-        /// @param offsets Offsets of a sub-memory from the encompassing
-        ///                memory object in each dimension
-        desc submemory_desc(
-                const memory::dims &dims, const memory::dims &offsets);
+        /// Constructs a memory descriptor by strides.
+        ///
+        /// @note
+        ///     The logical order of dimensions corresponds to the `abc...`
+        ///     format tag, and the physical meaning of the dimensions depends
+        ///     on both the primitive that consumes the memory and the context
+        ///     of that consumption.
+        ///
+        /// @param dims Tensor dimensions.
+        /// @param data_type Data precision/type.
+        /// @param strides Strides for each dimension.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case a
+        ///     zero memory descriptor will be constructed. This flag is
+        ///     optional and defaults to false.
+        desc(const memory::dims &dims, data_type data_type,
+                const memory::dims &strides, bool allow_empty = false);
 
-        /// Constructs a memory descriptor by reshaping existing one.
+        /// Constructs a memory descriptor for a region inside an area
+        /// described by this memory descriptor.
         //
+        /// @param dims Sizes of the region.
+        /// @param offsets Offsets to the region from the encompassing
+        ///     memory object in each dimension.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case a
+        ///     zero memory descriptor will be returned. This flag is optional
+        ///     and defaults to false.
+        /// @returns A memory descriptor for the region.
+        desc submemory_desc(const memory::dims &dims,
+                const memory::dims &offsets, bool allow_empty = false) const;
+
+        /// Constructs a memory descriptor by reshaping an existing one. The
+        /// new memory descriptor inherits the data type.
+        ///
+        /// The operation ensures that the transformation of the physical memory
+        /// format corresponds to the transformation of the logical dimensions.
+        /// If such transformation is impossible, the function either throws an
+        /// exception (default) or returns a zero memory descriptor depending on
+        /// the `allow_empty` flag.
+        ///
+        /// The reshape operation can be described as a combination of the
+        /// following basic operations:
+        /// 1. Add a dimension of size `1`. This is always possible.
+        /// 2. Remove a dimension of size `1`. This is possible only if the
+        ///    dimension has no padding (i.e.
+        ///    `padded_dims[dim] == dims[dim] && dims[dim] == 1`).
+        /// 3. Split a dimension into multiple ones. This is possible only if
+        ///    the size of the dimension is exactly equal to the product of the
+        ///    split ones and the dimension does not have padding (i.e.
+        ///    `padded_dims[dim] = dims[dim]`).
+        /// 4. Joining multiple consecutive dimensions into a single one. As in
+        ///    the cases above, this requires that the dimensions do not have
+        ///    padding and that the memory format is such that in physical
+        ///    memory these dimensions are dense and have the same order as
+        ///    their logical counterparts. This also assumes that these
+        ///    dimensions are not blocked.
+        ///    - Here, dense means:
+        ///      `stride for dim[i] == (stride for dim[i + 1]) * dim[i + 1]`;
+        ///    - And same order means:
+        ///      `i < j` if and only if `stride for dim[i] < stride for dim[j]`.
+        ///
+        /// @warning
+        ///     Some combinations of physical memory layout and/or offsets or
+        ///     dimensions may result in a failure to make a reshape.
+        ///
         /// @param dims New dimensions. The product of dimensions must
-        /// remain constant.
-        desc reshape(const memory::dims &dims);
+        ///     remain constant.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case a
+        ///     zero memory descriptor will be returned. This flag is optional
+        ///     and defaults to false.
+        /// @returns A new memory descriptor with new dimensions.
+        desc reshape(const memory::dims &dims, bool allow_empty = false) const;
 
-        /// Returns the number of bytes required to allocate memory buffer for
-        /// the memory object described by this memory descriptor including
-        /// the padding area.
+        /// Constructs a memory descriptor by permuting axes in an existing
+        /// one.
+        ///
+        /// The physical memory layout representation is adjusted accordingly
+        /// to maintain the consistency between the logical and physical parts
+        /// of the memory descriptor. The new memory descriptor inherits the
+        /// data type.
+        ///
+        /// The logical axes will be permuted in the following manner:
+        /// @code
+        /// for (i = 0; i < ndims(); i++)
+        ///     new_desc.dims()[permutation[i]] = dims()[i];
+        /// @endcode
+        ///
+        /// Example:
+        /// @code
+        ///     std::vector<int> permutation = {1, 0}; // swap the first and
+        ///                                            // the second axes
+        ///     dnnl::memory::desc in_md(
+        ///             {2, 3}, data_type, memory::format_tag::ab);
+        ///     dnnl::memory::desc expect_out_md(
+        ///             {3, 2}, data_type, memory::format_tag::ba);
+        ///
+        ///     assert(in_md.permute_axes(permutation) == expect_out_md);
+        /// @endcode
+        ///
+        /// @param permutation Axes permutation.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case a
+        ///     zero memory descriptor will be returned. This flag is optional
+        ///     and defaults to false.
+        /// @returns A new memory descriptor with new dimensions.
+        desc permute_axes(const std::vector<int> &permutation,
+                bool allow_empty = false) const;
+
+        /// Returns dimensions of the memory descriptor.
+        ///
+        /// Potentially expensive due to the data copy involved.
+        /// @returns A copy of the dimensions vector.
+        memory::dims dims() const;
+
+        /// Returns the data type of the memory descriptor.
+        /// @returns The data type.
+        memory::data_type data_type() const;
+
+        /// Returns size of the memory descriptor in bytes.
+        /// @returns The number of bytes required to allocate a memory buffer
+        ///     for the memory object described by this memory descriptor
+        ///     including the padding area.
         size_t get_size() const;
 
-        /// Returns true if the memory descriptor describes an empty memory.
+        /// Checks whether the memory descriptor is zero (empty).
+        /// @returns @c true if the memory descriptor describes an empty
+        ///     memory and @c false otherwise.
         bool is_zero() const;
 
         /// An equality operator.
         /// @param other Another memory descriptor.
         /// @returns Whether this and the other memory descriptors have
-        ///          the same format tag, dimensions, strides, blocking, etc.
+        ///     the same format tag, dimensions, strides, blocking, etc.
         bool operator==(const desc &other) const;
 
         /// An inequality operator.
         /// @param other Another memory descriptor.
         /// @returns Whether this and the other memory descriptors describe
-        ///          different memory.
+        ///     different memory.
         bool operator!=(const desc &other) const;
     };
 
     // Default constructor.
     //
-    // Constructs an empty memory object which can be used to indicate absence
+    // Constructs an empty memory object, which can be used to indicate absence
     // of a parameter.
     memory();
 
@@ -913,20 +1514,19 @@ struct memory {
     /// @param md Memory descriptor.
     /// @param engine Engine to store the data on.
     /// @param handle Handle of the memory buffer to use as an underlying
-    ///               storage. On CPU this is a pointer.
+    ///     storage. On CPU this is a pointer.
     memory(const desc &md, const engine &engine, void *handle);
 
-    /// Constructs a memory object using a SYCL buffer as the underlying
-    /// storage.
+    /// Constructs a memory object from a SYCL buffer.
     ///
     /// @param md Memory descriptor.
-    /// @param engine Engine to store the data on.
-    /// @param buf SYCL buffer as the underlying store.
+    /// @param engine Engine.
+    /// @param buf SYCL buffer.
     template <typename T, int ndims = 1>
     memory(const desc &md, const engine &engine,
             cl::sycl::buffer<T, ndims> &buf);
 
-    /// Constructs a memory.
+    /// Constructs a memory object.
     ///
     /// The underlying storage for the memory will be allocated by the library.
     ///
@@ -949,7 +1549,7 @@ struct memory {
     /// Sets memory buffer.
     ///
     /// @param handle Memory buffer to use as the underlying storage. It must
-    ///               have at least get_desc().get_size() bytes allocated.
+    ///     have at least get_desc().get_size() bytes allocated.
     void set_data_handle(void *handle) const;
 
     /// Returns the underlying SYCL buffer object.
@@ -970,86 +1570,230 @@ struct memory {
     void set_sycl_buffer(cl::sycl::buffer<T, ndims> &buf);
 };
 
+/// @} dnnl_api_memory
+
+/// @addtogroup dnnl_api_primitives
+/// @{
+
+/// @addtogroup dnnl_api_primitives_common
+/// @{
+
 /// Base class for all primitive descriptors.
 struct primitive_desc_base {
     /// Default constructor. Produces an empty object.
-    ///
-    /// Constructs an empty primitive descriptor base.
     primitive_desc_base();
 
     /// Returns the engine of the primitive descriptor.
+    /// @returns The engine of the primitive descriptor.
     engine get_engine() const;
 
     /// Returns implementation name.
+    /// @returns the implementation name.
     const char *impl_info_str() const;
 
-    /// Queries for an memory::dim value (same as int64_t).
+    /// Returns a memory::dim value (same as int64_t).
+    /// @param what The value to query.
+    /// @returns The result of the query.
     memory::dim query_s64(query what) const;
 
-    /// Queries for and returns requested memory descriptor.
+    /// Returns a memory descriptor.
+    ///
+    /// @note
+    ///     There are convenience methods
+    ///     #dnnl::primitive_desc_base::src_desc(),
+    ///     #dnnl::primitive_desc_base::dst_desc(), and others.
+    ///
+    /// @param what The kind of parameter to query; can be
+    ///     #dnnl::query::src_md, #dnnl::query::dst_md, etc.
+    /// @param idx Index of the parameter. For example, convolution bias can
+    ///     be queried with what = #dnnl::query::weights_md and idx = 1.
+    /// @returns The requested memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     parameter of the specified kind or index.
     memory::desc query_md(query what, int idx = 0) const;
 
+    /// Returns a source memory descriptor.
+    /// @param idx Source index.
+    /// @returns Source memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     source parameter with index @p pdx.
+    memory::desc src_desc(int idx) const;
+
+    /// Returns a destination memory descriptor.
+    /// @param idx Destination index.
+    /// @returns Destination memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     destination parameter with index @p pdx.
+    memory::desc dst_desc(int idx) const;
+
+    /// Returns a weights memory descriptor.
+    /// @param idx Weights index.
+    /// @returns Weights memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     weights parameter with index @p pdx.
+    memory::desc weights_desc(int idx) const;
+
+    /// Returns a diff source memory descriptor.
+    /// @param idx Diff source index.
+    /// @returns Diff source memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     diff source parameter with index @p pdx.
+    memory::desc diff_src_desc(int idx) const;
+
+    /// Returns a diff destination memory descriptor.
+    /// @param idx Diff destination index.
+    /// @returns Diff destination memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     diff destination parameter with index @p pdx.
+    memory::desc diff_dst_desc(int idx) const;
+
+    /// Returns a diff weights memory descriptor.
+    /// @param idx Diff weights index.
+    /// @returns Diff weights memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     diff weights parameter with index @p pdx.
+    memory::desc diff_weights_desc(int idx) const;
+
+    // Separate versions without the index argument for documentation
+    // purposes.
+
+    /// Returns a source memory descriptor.
+    /// @returns Source memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     source parameter.
+    memory::desc src_desc() const;
+
+    /// Returns a destination memory descriptor.
+    /// @returns Destination memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     destination parameter.
+    memory::desc dst_desc() const;
+
+    /// Returns a weights memory descriptor.
+    /// @returns Weights memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     weights parameter.
+    memory::desc weights_desc() const;
+
+    /// Returns a diff source memory descriptor.
+    /// @returns Diff source memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     diff source memory with.
+    memory::desc diff_src_desc() const;
+
+    /// Returns a diff destination memory descriptor.
+    /// @returns Diff destination memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     diff destination parameter.
+    memory::desc diff_dst_desc() const;
+
+    /// Returns a diff weights memory descriptor.
+    /// @returns Diff weights memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     diff weights parameter.
+    memory::desc diff_weights_desc() const;
+
+    /// Returns the workspace memory descriptor.
+    /// @returns Workspace memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not require
+    ///     workspace parameter.
+    memory::desc workspace_desc() const;
+    /// Returns the scratchpad memory descriptor.
     /// @returns scratchpad memory descriptor.
-    ///
-    /// @returns a zero_md if no scratchpad is required by the primitive
-    /// descriptor.
+    /// @returns A zero memory descriptor if the primitive does not require
+    ///     scratchpad parameter.
     memory::desc scratchpad_desc() const;
 
-    /// @returns the engine that owns the scratchpad memory.
+    /// Returns the engine on which the scratchpad memory is located.
+    /// @returns The engine on which the scratchpad memory is located.
     engine scratchpad_engine() const;
 
     /// Returns the primitive attributes.
+    /// @returns The primitive attributes.
     primitive_attr get_primitive_attr() const;
 };
 
+/// @} dnnl_api_primitives_common
+
+/// @addtogroup dnnl_api_reorder Reorder
+///
+/// A primitive to copy data between two memory objects. This primitive is
+/// typically used to change the way the data is laid out in memory.
+///
+/// @{
+
 /// Reorder primitive.
 struct reorder : public primitive {
-    /// Primitive descriptor for reorder primitive.
+    /// Primitive descriptor for a reorder primitive.
     struct primitive_desc : public dnnl::primitive_desc_base {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a reorder primitive using the description of the source
-        /// (@p src_engine and @p src_md) and destination (@p dst_engine and
-        /// @p dst_md) memory, and an @p attr attributes.
+        /// Constructs a primitive descriptor for reorder primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///
+        /// @param src_engine Engine on which the source memory object will be
+        ///     located.
+        /// @param src_md Source memory descriptor.
+        /// @param dst_engine Engine on which the destination memory object
+        ///     will be located.
+        /// @param dst_md Destination memory descriptor.
+        /// @param attr Primitive attributes to use (optional).
         primitive_desc(const engine &src_engine, const memory::desc &src_md,
                 const engine &dst_engine, const memory::desc &dst_md,
                 const primitive_attr &attr = primitive_attr());
 
-        /// Constructs a reorder primitive moving data between memory objects
-        /// @p src and @p dat with @p attr attributes.
+        /// Constructs a primitive descriptor for reorder primitive.
         ///
-        /// Note that the memory objects are used only to obtain information
-        /// about memory descriptors and engines.
+        /// @param src Source memory object. It is used to obtain the source
+        ///     memory descriptor and engine.
+        /// @param dst Destination memory object. It is used to obtain the
+        ///     destination memory descriptor and engine.
+        /// @param attr Primitive attributes to use (optional).
         primitive_desc(const memory &src, const memory &dst,
                 const primitive_attr &attr = primitive_attr());
 
-        /// @returns the engine on which the source memory is allocated.
+        /// Returns the engine on which the source memory is allocated.
+        /// @returns The engine on which the source memory is allocated.
         engine get_src_engine() const;
 
-        /// @returns the engine on which the destination memory is allocated.
+        /// Returns the engine on which the destination memory is allocated.
+        /// @returns The engine on which the destination memory is allocated.
         engine get_dst_engine() const;
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const;
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     reorder();
 
-    /// Constructs a reorder primitive from a primitive descriptor @p pd
-    /// of a corresponding type.
+    /// Constructs a reorder primitive.
+    /// @param pd Primitive descriptor for reorder primitive.
     reorder(const primitive_desc &pd);
 
     /// Constructs a reorder primitive that would reorder data between memory
-    /// objects having same memory descriptors as memory objects @p src and @p
-    /// dst.
+    /// objects having the same memory descriptors as memory objects @p src and
+    /// @p dst.
     ///
     /// @param src Source memory object.
     /// @param dst Destination memory object.
-    reorder(const memory &src, const memory &dst);
+    /// @param attr Primitive attributes to use (optional).
+    reorder(const memory &src, const memory &dst,
+            const primitive_attr &attr = primitive_attr());
 
     /// Executes the reorder primitive.
     ///
     /// @param stream Stream object. The stream must belong to the same engine
-    ///               as the primitive.
+    ///     as the primitive.
     /// @param src Source memory object.
     /// @param dst Destination memory object.
     void execute(stream stream, memory &src, memory &dst);
@@ -1068,21 +1812,38 @@ struct reorder : public primitive {
             const std::vector<cl::sycl::event> &deps = {});
 };
 
+/// @} dnnl_api_reorder
+
+/// @addtogroup dnnl_api_concat Concat
+///
+/// A primitive to concatenate data by arbitrary dimension.
+///
+/// @{
+
+
 /// Tensor concatenation (concat) primitive.
 struct concat : public primitive {
-    /// Primitive descriptor for concat primitive.
+    /// Primitive descriptor for a concat primitive.
     struct primitive_desc : public dnnl::primitive_desc_base {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for an out-of-place
-        /// concatenation primitive.
+        /// Constructs a primitive descriptor for an out-of-place concatenation
+        /// primitive.
         ///
-        /// @param dst Destination memory descriptor
+        /// Inputs:
+        ///  - `src[0]` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `src[1]` (#dnnl::primitive_desc_base::src_desc (`1`))
+        ///  - ...
+        ///  - `src[n - 1]` (#dnnl::primitive_desc_base::src_desc (`n - 1`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///
+        /// @param dst Destination memory descriptor.
         /// @param concat_dimension Source tensors will be concatenated over
-        ///                         dimension with this index. Note that order
-        ///                         of dimensions does not depend on memory
-        ///                         format.
+        ///     dimension with this index. Note that order of dimensions does
+        ///     not depend on memory format.
         /// @param srcs Vector of source memory descriptors.
         /// @param engine Engine to perform the operation on.
         /// @param attr Primitive attributes to use (optional).
@@ -1090,16 +1851,15 @@ struct concat : public primitive {
                 const std::vector<memory::desc> &srcs, const engine &engine,
                 const primitive_attr &attr = primitive_attr());
 
-        /// Constructs a primitive descriptor for an out-of-place
-        /// concatenation primitive.
+        /// Constructs a primitive descriptor for an out-of-place concatenation
+        /// primitive.
         ///
         /// This version derives the destination memory descriptor
         /// automatically.
         ///
         /// @param concat_dimension Source tensors will be concatenated over
-        ///                         dimension with this index. Note that order
-        ///                         of dimensions does not depend on memory
-        ///                         format.
+        ///     dimension with this index. Note that order of dimensions does
+        ///     not depend on memory format.
         /// @param srcs Vector of source memory descriptors.
         /// @param engine Engine to perform the operation on.
         /// @param attr Primitive attributes to use (optional).
@@ -1107,7 +1867,10 @@ struct concat : public primitive {
                 const std::vector<memory::desc> &srcs, const engine &engine,
                 const primitive_attr &attr = primitive_attr());
 
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc(int)const
+        memory::desc src_desc(int idx = 0) const;
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
     };
 
@@ -1119,19 +1882,35 @@ struct concat : public primitive {
     concat(const primitive_desc &pd);
 };
 
-/// Summation (sum) primitive.
+/// @} dnnl_api_concat
+
+/// @addtogroup dnnl_api_sum Sum
+///
+/// A primitive to sum multiple tensors.
+///
+/// @{
+
+/// Out-of-place summation (sum) primitive.
 struct sum : public primitive {
-    /// Primitive descriptor for sum primitive.
+    /// Primitive descriptor for a sum primitive.
     struct primitive_desc : public dnnl::primitive_desc_base {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs an out-of-place primitive descriptor for a sum
-        /// primitive.
+        /// Constructs a primitive descriptor for a sum primitive.
+        ///
+        /// Inputs:
+        ///  - `src[0]` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `src[1]` (#dnnl::primitive_desc_base::src_desc (`1`))
+        ///  - ...
+        ///  - `src[n - 1]` (#dnnl::primitive_desc_base::src_desc (`n - 1`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
         ///
         /// @param dst Destination memory descriptor.
         /// @param scales Vector of scales to multiply data in each source
-        ///               memory by.
+        ///     memory by.
         /// @param srcs Vector of source memory descriptors.
         /// @param engine Engine to perform the operation on.
         /// @param attr Primitive attributes to use (optional).
@@ -1140,54 +1919,93 @@ struct sum : public primitive {
                 const std::vector<memory::desc> &srcs, const engine &engine,
                 const primitive_attr &attr = primitive_attr());
 
-        /// Constructs an out-of-place primitive descriptor for a sum
-        /// primitive.
+        /// Constructs a primitive descriptor for a sum primitive.
         ///
         /// This version derives the destination memory descriptor
         /// automatically.
         ///
-        /// @param scales Vector of scales to multiply data in each source
-        ///               memory by.
+        /// @param scales Vector of scales by which to multiply data in each
+        ///     source memory object.
         /// @param srcs Vector of source memory descriptors.
-        /// @param engine Engine to perform the operation on.
+        /// @param engine Engine on which to perform the operation.
         /// @param attr Primitive attributes to use (optional).
         primitive_desc(const std::vector<float> &scales,
                 const std::vector<memory::desc> &srcs, const engine &engine,
                 const primitive_attr &attr = primitive_attr());
 
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc(int)const
+        memory::desc src_desc(int idx = 0) const;
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     sum();
 
-    /// Constructs a sum primitive from a primitive descriptor @p pd of a
-    /// corresponding type.
+    /// Constructs a sum primitive.
+    /// @param pd Primitive descriptor for sum primitive.
     sum(const primitive_desc &pd);
 };
 
-/// A base class for primitive descriptors of all primitives that have an
-/// operation descriptor and that support iteration over multiple
-/// implementations.
+/// @} dnnl_api_sum
+
+/// @addtogroup dnnl_api_primitives_common
+/// @{
+
+/// A base class for descriptors of all primitives that have an operation
+/// descriptor and that support iteration over multiple implementations.
 struct primitive_desc : public dnnl::primitive_desc_base {
     /// Default constructor. Produces an empty object.
     primitive_desc();
 };
 
+/// @} dnnl_api_primitives_common
+
+/// @addtogroup dnnl_api_convolution Convolution
+///
+/// A primitive to perform 1D, 2D or 3D convolution. Supported variants are
+/// forward propagation, backward propagation, and weights gradient with or
+/// without bias.
+///
+/// @{
+
 /// Convolution forward propagation primitive.
 struct convolution_forward : public primitive {
-    /// Descriptor for convolution forward propagation primitive.
+    /// Descriptor for a convolution forward propagation primitive.
     struct desc {
         /// Constructs a descriptor for a convolution forward propagation
-        /// primitive without bias using @p prop_kind (acceptable values are
-        /// #dnnl::prop_kind::forward_training and #dnnl::prop_kind::forward_inference), @p
-        /// algorithm, memory descriptors, @p strides, @p padding_l, and @p
-        /// padding_r.
+        /// primitive with bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///  - `bias` (#dnnl::primitive_desc_base::weights_desc (`1`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param algorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param bias_desc Bias memory descriptor. Passing zero memory
+        ///     descriptor disables the bias term.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(prop_kind prop_kind, algorithm algorithm,
                 const memory::desc &src_desc, const memory::desc &weights_desc,
                 const memory::desc &bias_desc, const memory::desc &dst_desc,
@@ -1195,43 +2013,110 @@ struct convolution_forward : public primitive {
                 const memory::dims &padding_r);
 
         /// Constructs a descriptor for a convolution forward propagation
-        /// primitive with bias using @p prop_kind (acceptable values are
-        /// #dnnl::prop_kind::forward_training and #dnnl::prop_kind::forward_inference), @p
-        /// algorithm, memory descriptors, @p strides, @p padding_l, and @p
-        /// padding_r.
+        /// primitive without bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param algorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(prop_kind prop_kind, algorithm algorithm,
                 const memory::desc &src_desc, const memory::desc &weights_desc,
                 const memory::desc &dst_desc, const memory::dims &strides,
                 const memory::dims &padding_l, const memory::dims &padding_r);
 
-        /// Constructs a descriptor for dilated convolution forward
-        /// propagation primitive without bias using @p prop_kind (possible
-        /// values are #dnnl::prop_kind::forward_training and #dnnl::prop_kind::forward_inference),
-        /// @p algorithm, memory descriptors, @p strides, @p dilates, @p
-        /// padding_l, and @p padding_r.
+        /// Constructs a descriptor for a dilated convolution forward
+        /// propagation primitive with bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///  - `bias` (#dnnl::primitive_desc_base::weights_desc (`1`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param algorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param bias_desc Bias memory descriptor. Passing zero memory
+        ///     descriptor disables the bias term.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(prop_kind prop_kind, algorithm algorithm,
                 const memory::desc &src_desc, const memory::desc &weights_desc,
                 const memory::desc &bias_desc, const memory::desc &dst_desc,
                 const memory::dims &strides, const memory::dims &dilates,
                 const memory::dims &padding_l, const memory::dims &padding_r);
 
-        /// Constructs a descriptor for dilated convolution forward
-        /// propagation primitive with bias using @p prop_kind (possible
-        /// values are #dnnl::prop_kind::forward_training and #dnnl::prop_kind::forward_inference),
-        /// @p algorithm, memory descriptors, @p strides, @p dilates, @p
-        /// padding_l, and @p padding_r.
+        /// Constructs a descriptor for a dilated convolution forward
+        /// propagation primitive without bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param algorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(prop_kind prop_kind, algorithm algorithm,
                 const memory::desc &src_desc, const memory::desc &weights_desc,
                 const memory::desc &dst_desc, const memory::dims &strides,
@@ -1247,78 +2132,119 @@ struct convolution_forward : public primitive {
         /// Constructs a primitive descriptor for a convolution forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for convolution forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a convolution forward propagation
+        ///     primitive.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case
+        ///     an empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 bool allow_empty = false);
 
         /// Constructs a primitive descriptor for a convolution forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for convolution forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a convolution forward propagation
+        ///     primitive.
         /// @param engine Engine to use.
         /// @param attr Primitive attributes to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case
+        ///     an empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine, bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the weights memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
         memory::desc weights_desc() const;
 
-        /// Returns the bias memory descriptor.
-        ///
-        /// Returns a zero_md if no bias was specified at op_desc creation
-        /// time.
-        memory::desc bias_desc() const;
-
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
+
+        /// Returns the bias memory descriptor.
+        /// @returns The bias memory descriptor.
+        /// @returns A zero memory descriptor of the primitive does not have a
+        ///     bias parameter.
+        memory::desc bias_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     convolution_forward();
 
-    /// Constructs a convolution forward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs a convolution forward propagation primitive.
+    /// @param pd Primitive descriptor for a convolution forward propagation
+    ///     primitive.
     convolution_forward(const primitive_desc &pd);
 };
 
 /// Convolution backward propagation primitive.
 struct convolution_backward_data : public primitive {
 
-    /// Descriptor for convolution backward propagation primitive.
+    /// Descriptor for a convolution backward propagation primitive.
     struct desc {
         /// Constructs a descriptor for a convolution backward propagation
-        /// primitive using @p algorithm, memory descriptors, @p strides, @p
-        /// padding_l, and @p padding_r.
+        /// primitive.
+        ///
+        /// Inputs:
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param algorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(algorithm algorithm, const memory::desc &diff_src_desc,
                 const memory::desc &weights_desc,
                 const memory::desc &diff_dst_desc, const memory::dims &strides,
                 const memory::dims &padding_l, const memory::dims &padding_r);
 
         /// Constructs a descriptor for dilated convolution backward
-        /// propagation using @p algorithm, memory descriptors, @p strides, @p
-        /// padding_l, and @p padding_r.
+        /// propagation primitive.
+        ///
+        /// Inputs:
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param algorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(algorithm algorithm, const memory::desc &diff_src_desc,
                 const memory::desc &weights_desc,
                 const memory::desc &diff_dst_desc, const memory::dims &strides,
@@ -1334,16 +2260,16 @@ struct convolution_backward_data : public primitive {
         /// Constructs a primitive descriptor for a convolution backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for convolution backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a convolution backward propagation
+        ///     primitive.
         /// @param engine Engine to perform the operation on.
-        /// @param hint_fwd_pd Primitive descriptor for convolution forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a convolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case
+        ///     an empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const convolution_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
@@ -1351,76 +2277,142 @@ struct convolution_backward_data : public primitive {
         /// Constructs a primitive descriptor for a convolution backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for convolution backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a convolution backward propagation
+        ///     primitive.
         /// @param engine Engine to perform the operation on.
         /// @param attr Primitive attributes to use.
-        /// @param hint_fwd_pd Primitive descriptor for convolution forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a convolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case
+        ///     an empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const convolution_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the diff source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
         memory::desc diff_src_desc() const;
 
-        /// Returns the weights memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
         memory::desc weights_desc() const;
 
-        /// Returns the diff destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
         memory::desc diff_dst_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     convolution_backward_data();
 
-    /// Constructs a convolution backward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs a convolution backward propagation primitive.
+    /// @param pd Primitive descriptor for a convolution backward propagation
+    ///     primitive.
     convolution_backward_data(const primitive_desc &pd);
 };
 
-/// Convolution weights update primitive.
+/// Convolution weights gradient primitive.
 struct convolution_backward_weights : public primitive {
-    /// Descriptor for convolution weights update primitive.
+    /// Descriptor for a convolution weights gradient primitive.
     struct desc {
-        /// Constructs a descriptor for a convolution weights update primitive
-        /// with bias using @p algorithm, memory descriptors, @p strides, @p
-        /// padding_l, and @p padding_r.
+        /// Constructs a descriptor for a convolution weights gradient primitive
+        /// with bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_weights` (#dnnl::primitive_desc_base::diff_weights_desc (`0`))
+        ///  - `diff_bias` (#dnnl::primitive_desc_base::diff_weights_desc (`1`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param algorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_bias_desc Diff bias memory descriptor. Passing zero
+        ///     memory descriptor disables the bias term.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(algorithm algorithm, const memory::desc &src_desc,
                 const memory::desc &diff_weights_desc,
                 const memory::desc &diff_bias_desc,
                 const memory::desc &diff_dst_desc, const memory::dims &strides,
                 const memory::dims &padding_l, const memory::dims &padding_r);
 
-        /// Constructs a descriptor for a convolution weights update primitive
-        /// without bias using @p algorithm, memory descriptors, @p strides,
-        /// @p padding_l, and @p padding_r.
+        /// Constructs a descriptor for a convolution weights gradient primitive
+        /// without bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_weights` (#dnnl::primitive_desc_base::diff_weights_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param algorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(algorithm algorithm, const memory::desc &src_desc,
                 const memory::desc &diff_weights_desc,
                 const memory::desc &diff_dst_desc, const memory::dims &strides,
                 const memory::dims &padding_l, const memory::dims &padding_r);
 
-        /// Constructs a descriptor for dilated convolution weights update
-        /// primitive with bias using @p algorithm, memory descriptors, @p
-        /// strides, @p dilates @p padding_l, and @p padding_r.
+        /// Constructs a descriptor for a dilated convolution weights gradient
+        /// primitive with bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_weights` (#dnnl::primitive_desc_base::diff_weights_desc (`0`))
+        ///  - `diff_bias` (#dnnl::primitive_desc_base::diff_weights_desc (`1`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param algorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_bias_desc Diff bias memory descriptor. Passing zero
+        ///     memory descriptor disables the bias term.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(algorithm algorithm, const memory::desc &src_desc,
                 const memory::desc &diff_weights_desc,
                 const memory::desc &diff_bias_desc,
@@ -1428,13 +2420,34 @@ struct convolution_backward_weights : public primitive {
                 const memory::dims &dilates, const memory::dims &padding_l,
                 const memory::dims &padding_r);
 
-        /// Constructs a descriptor for dilated convolution weights update
-        /// primitive without bias using @p algorithm, memory descriptors, @p
-        /// strides, @p dilates @p padding_l, and @p padding_r.
+        /// Constructs a descriptor for a dilated convolution weights gradient
+        /// primitive without bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_weights` (#dnnl::primitive_desc_base::diff_weights_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param algorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(algorithm algorithm, const memory::desc &src_desc,
                 const memory::desc &diff_weights_desc,
                 const memory::desc &diff_dst_desc, const memory::dims &strides,
@@ -1442,79 +2455,114 @@ struct convolution_backward_weights : public primitive {
                 const memory::dims &padding_r);
     };
 
-    /// Primitive descriptor for a convolution weights update primitive.
+    /// Primitive descriptor for a convolution weights gradient primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for a convolution weights update
+        /// Constructs a primitive descriptor for a convolution weights gradient
         /// primitive.
         ///
-        /// @param desc Descriptor for convolution weights update primitive.
+        /// @param desc Descriptor for a convolution weights gradient primitive.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for convolution forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a convolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case
+        ///     an empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const convolution_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for a convolution weights update
+        /// Constructs a primitive descriptor for a convolution weights gradient
         /// primitive.
         ///
-        /// @param desc Descriptor for convolution weights update primitive.
+        /// @param desc Descriptor for a convolution weights gradient primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for convolution forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a convolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case
+        ///     an empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const convolution_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the diff weights memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
         memory::desc diff_weights_desc() const;
 
-        /// Returns the diff bias memory descriptor.
-        memory::desc diff_bias_desc() const;
-
-        /// Returns the diff destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
         memory::desc diff_dst_desc() const;
+
+        /// Returns the diff bias memory descriptor.
+        /// @returns The diff bias memory descriptor.
+        /// @returns A zero memory descriptor of the primitive does not have a
+        ///          diff bias parameter.
+        memory::desc diff_bias_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     convolution_backward_weights();
 
-    /// Constructs a convolution weights update primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs a convolution weights gradient primitive.
+    /// @param pd Primitive descriptor for a convolution weights gradient
+    ///     primitive.
     convolution_backward_weights(const primitive_desc &pd);
 };
 
+/// @} dnnl_api_convolution
+//
+/// @addtogroup dnnl_api_deconvolution Deconvolution
+///
+/// A primitive to perform 1D, 2D or 3D deconvolution. Supported variants are
+/// forward propagation, backward propagation, and weights gradient with or
+/// without bias.
+///
+/// @{
+
 /// Deconvolution forward propagation primitive.
 struct deconvolution_forward : public primitive {
-    /// Descriptor for convolution forward propagation primitive.
+    /// Descriptor for a deconvolution forward propagation primitive.
     struct desc {
         /// Constructs a descriptor for a deconvolution forward propagation
-        /// primitive with bias using @p prop_kind (acceptable values are
-        /// #dnnl::prop_kind::forward_training and #dnnl::prop_kind::forward_inference), @p
-        /// algorithm, memory descriptors, @p strides, @p padding_l, and @p
-        /// padding_r.
+        /// primitive with bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///  - `bias` (#dnnl::primitive_desc_base::weights_desc (`1`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and #dnnl::prop_kind::forward_inference.
+        /// @param algorithm Deconvolution algorithm:
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param bias_desc Bias memory descriptor. Passing zero memory
+        ///     descriptor disables the bias term.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Vector of strides for spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(prop_kind prop_kind, algorithm algorithm,
                 const memory::desc &src_desc, const memory::desc &weights_desc,
                 const memory::desc &bias_desc, const memory::desc &dst_desc,
@@ -1522,43 +2570,104 @@ struct deconvolution_forward : public primitive {
                 const memory::dims &padding_r);
 
         /// Constructs a descriptor for a deconvolution forward propagation
-        /// primitive without bias using @p prop_kind (acceptable values are
-        /// #dnnl::prop_kind::forward_training and #dnnl::prop_kind::forward_inference), @p
-        /// algorithm, memory descriptors, @p strides, @p padding_l, and @p
-        /// padding_r.
+        /// primitive without bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and #dnnl::prop_kind::forward_inference.
+        /// @param algorithm Deconvolution algorithm:
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Vector of strides for spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(prop_kind prop_kind, algorithm algorithm,
                 const memory::desc &src_desc, const memory::desc &weights_desc,
                 const memory::desc &dst_desc, const memory::dims &strides,
                 const memory::dims &padding_l, const memory::dims &padding_r);
 
-        /// Constructs a descriptor for dilated deconvolution forward
-        /// propagation primitive with bias using @p prop_kind (possible
-        /// values are #dnnl::prop_kind::forward_training and #dnnl::prop_kind::forward_inference),
-        /// @p algorithm memory descriptors, @p strides, @p dilates, @p
-        /// padding_l, and @p padding_r.
+        /// Constructs a descriptor for a dilated deconvolution forward
+        /// propagation primitive with bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///  - `bias` (#dnnl::primitive_desc_base::weights_desc (`1`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and #dnnl::prop_kind::forward_inference.
+        /// @param algorithm Deconvolution algorithm:
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param bias_desc Bias memory descriptor. Passing zero memory
+        ///     descriptor disables the bias term.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Vector of strides for spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(prop_kind prop_kind, algorithm algorithm,
                 const memory::desc &src_desc, const memory::desc &weights_desc,
                 const memory::desc &bias_desc, const memory::desc &dst_desc,
                 const memory::dims &strides, const memory::dims &dilates,
                 const memory::dims &padding_l, const memory::dims &padding_r);
 
-        /// Constructs a descriptor for dilated deconvolution forward
-        /// propagation primitive without bias using @p prop_kind (possible
-        /// values are #dnnl::prop_kind::forward_training and #dnnl::prop_kind::forward_inference),
-        /// @p algorithm, memory descriptors, @p strides, @p dilates, @p
-        /// padding_l, and @p padding_r.
+        /// Constructs a descriptor for a dilated deconvolution forward
+        /// propagation primitive without bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and #dnnl::prop_kind::forward_inference.
+        /// @param algorithm Deconvolution algorithm:
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Vector of strides for spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(prop_kind prop_kind, algorithm algorithm,
                 const memory::desc &src_desc, const memory::desc &weights_desc,
                 const memory::desc &dst_desc, const memory::dims &strides,
@@ -1574,77 +2683,113 @@ struct deconvolution_forward : public primitive {
         /// Constructs a primitive descriptor for a deconvolution forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for deconvolution forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a deconvolution forward propagation
+        ///     primitive.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 bool allow_empty = false);
 
         /// Constructs a primitive descriptor for a deconvolution forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for deconvolution forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a deconvolution forward propagation
+        ///     primitive.
         /// @param engine Engine to use.
         /// @param attr Primitive attributes to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine, bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the weights memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
         memory::desc weights_desc() const;
 
-        /// Returns the bias memory descriptor.
-        ///
-        /// Returns a zero_md if no bias was specified at op_desc
-        /// creation time.
-        memory::desc bias_desc() const;
-
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
+
+        /// @copydoc dnnl::convolution_forward::primitive_desc::bias_desc()const
+        memory::desc bias_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     deconvolution_forward();
 
-    /// Constructs a deconvolution forward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs a deconvolution forward propagation primitive.
+    /// @param pd Primitive descriptor for a deconvolution forward propagation
+    ///     primitive.
     deconvolution_forward(const primitive_desc &pd);
 };
 
 /// Deconvolution backward propagation primitive.
 struct deconvolution_backward_data : public primitive {
-    /// Descriptor for deconvolution backward propagation primitive.
+    /// Descriptor for a deconvolution backward propagation primitive.
     struct desc {
         /// Constructs a descriptor for a deconvolution backward propagation
-        /// primitive using @p algorithm, memory descriptors, @p strides, @p
-        /// padding_l, and @p padding_r.
+        /// primitive.
+        ///
+        /// Inputs:
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param algorithm Deconvolution algorithm
+        ///     (#dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd).
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(algorithm algorithm, const memory::desc &diff_src_desc,
                 const memory::desc &weights_desc,
                 const memory::desc &diff_dst_desc, const memory::dims &strides,
                 const memory::dims &padding_l, const memory::dims &padding_r);
 
-        /// Constructs descriptor for dilated deconvolution backward
-        /// propagation primitive using @p algorithm, memory descriptors, @p
-        /// strides, @p padding_l, and @p padding_r.
+        /// Constructs a descriptor for a dilated deconvolution backward
+        /// propagation primitive.
+        ///
+        /// Inputs:
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param algorithm Deconvolution algorithm
+        ///     (#dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd).
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(algorithm algorithm, const memory::desc &diff_src_desc,
                 const memory::desc &weights_desc,
                 const memory::desc &diff_dst_desc, const memory::dims &strides,
@@ -1660,16 +2805,16 @@ struct deconvolution_backward_data : public primitive {
         /// Constructs a primitive descriptor for a deconvolution backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for deconvolution backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a deconvolution backward propagation
+        ///     primitive.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for deconvolution forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a deconvolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const deconvolution_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
@@ -1677,76 +2822,139 @@ struct deconvolution_backward_data : public primitive {
         /// Constructs a primitive descriptor for a deconvolution backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for deconvolution backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a deconvolution backward propagation
+        ///     primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for deconvolution forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a deconvolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const deconvolution_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the diff source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
         memory::desc diff_src_desc() const;
 
-        /// Returns the weights memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
         memory::desc weights_desc() const;
 
-        /// Returns the diff destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
         memory::desc diff_dst_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     deconvolution_backward_data();
 
-    /// Constructs a deconvolution backward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs a deconvolution backward propagation primitive.
+    /// @param pd Primitive descriptor for a deconvolution backward propagation
+    ///     primitive.
     deconvolution_backward_data(const primitive_desc &pd);
 };
 
-/// Deconvolution weights update primitive.
+/// Deconvolution weights gradient primitive.
 struct deconvolution_backward_weights : public primitive {
-    /// Descriptor for deconvolution weights update primitive.
+    /// Descriptor for a deconvolution weights gradient primitive.
     struct desc {
-        /// Constructs a descriptor for a deconvolution weights primitive update
-        /// with bias using @p algorithm, memory descriptors, @p strides, @p
-        /// padding_l, and @p padding_r.
+        /// Constructs a descriptor for a deconvolution weights gradient primitive
+        /// with bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_weights` (#dnnl::primitive_desc_base::diff_weights_desc (`0`))
+        ///  - `diff_bias` (#dnnl::primitive_desc_base::diff_weights_desc (`1`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param algorithm Deconvolution algorithm. Possible values are
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_bias_desc Diff bias memory descriptor. Passing zero
+        ///     memory descriptor disables the bias term.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(algorithm algorithm, const memory::desc &src_desc,
                 const memory::desc &diff_weights_desc,
                 const memory::desc &diff_bias_desc,
                 const memory::desc &diff_dst_desc, const memory::dims &strides,
                 const memory::dims &padding_l, const memory::dims &padding_r);
 
-        /// Constructs a descriptor for a deconvolution weights update primitive
-        /// without bias using @p algorithm, memory descriptors, @p strides,
-        /// @p padding_l, and @p padding_r.
+        /// Constructs a descriptor for a deconvolution weights gradient primitive
+        /// without bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_weights` (#dnnl::primitive_desc_base::diff_weights_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param algorithm Deconvolution algorithm. Possible values are
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(algorithm algorithm, const memory::desc &src_desc,
                 const memory::desc &diff_weights_desc,
                 const memory::desc &diff_dst_desc, const memory::dims &strides,
                 const memory::dims &padding_l, const memory::dims &padding_r);
 
-        /// Constructs a descriptor for dilated deconvolution weights update
-        /// primitive with bias using @p algorithm, memory descriptors, @p
-        /// strides, @p dilates @p padding_l, and @p padding_r.
+        /// Constructs a descriptor for a dilated deconvolution weights gradient
+        /// primitive with bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_weights` (#dnnl::primitive_desc_base::diff_weights_desc (`0`))
+        ///  - `diff_bias` (#dnnl::primitive_desc_base::diff_weights_desc (`1`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param algorithm Deconvolution algorithm. Possible values are
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_bias_desc Diff bias memory descriptor. Passing zero
+        ///     memory descriptor disables the bias term.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(algorithm algorithm, const memory::desc &src_desc,
                 const memory::desc &diff_weights_desc,
                 const memory::desc &diff_bias_desc,
@@ -1754,13 +2962,33 @@ struct deconvolution_backward_weights : public primitive {
                 const memory::dims &dilates, const memory::dims &padding_l,
                 const memory::dims &padding_r);
 
-        /// Constructs a descriptor for dilated deconvolution weights update
-        /// primitive without bias using @p algorithm, memory descriptors, @p
-        /// strides, @p dilates @p padding_l, and @p padding_r.
+        /// Constructs a descriptor for a dilated deconvolution weights gradient
+        /// primitive without bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_weights` (#dnnl::primitive_desc_base::diff_weights_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param algorithm Deconvolution algorithm. Possible values are
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(algorithm algorithm, const memory::desc &src_desc,
                 const memory::desc &diff_weights_desc,
                 const memory::desc &diff_dst_desc, const memory::dims &strides,
@@ -1768,7 +2996,7 @@ struct deconvolution_backward_weights : public primitive {
                 const memory::dims &padding_r);
     };
 
-    /// Primitive descriptor for a deconvolution weights update primitive.
+    /// Primitive descriptor for a deconvolution weights gradient primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
@@ -1776,15 +3004,15 @@ struct deconvolution_backward_weights : public primitive {
         /// Constructs a primitive descriptor for a deconvolution weights
         /// update primitive.
         ///
-        /// @param desc Descriptor for deconvolution weights update primitive.
+        /// @param desc Descriptor for a deconvolution weights gradient primitive.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for deconvolution forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a deconvolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception.  In this case
+        ///     an empty object will be produced.  This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const deconvolution_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
@@ -1792,194 +3020,271 @@ struct deconvolution_backward_weights : public primitive {
         /// Constructs a primitive descriptor for a deconvolution weights
         /// update primitive.
         ///
-        /// @param desc Descriptor for deconvolution weights update primitive.
+        /// @param desc Descriptor for a deconvolution weights gradient primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for deconvolution forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a deconvolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const deconvolution_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the diff weights memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
         memory::desc diff_weights_desc() const;
 
-        /// Returns the diff bias memory descriptor.
-        memory::desc diff_bias_desc() const;
-
-        /// Returns the diff destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
         memory::desc diff_dst_desc() const;
+
+        /// @copydoc dnnl::convolution_backward_weights::primitive_desc::diff_bias_desc()const
+        memory::desc diff_bias_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     deconvolution_backward_weights();
 
-    /// Constructs a deconvolution weights update primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs a deconvolution weights gradient primitive.
+    /// @param pd Primitive descriptor for a deconvolution weights gradient
+    ///     primitive.
     deconvolution_backward_weights(const primitive_desc &pd);
 };
 
+/// @} dnnl_api_deconvolution
+
+/// @addtogroup dnnl_api_lrn LRN
+///
+/// A primitive to perform local response normalization (LRN) across or within
+/// channels.
+///
+/// @{
+
 /// Local response normalization (LRN) forward propagation primitive.
 struct lrn_forward : public primitive {
-    /// Descriptor for LRN forward propagation primitive.
+    /// Descriptor for an LRN forward propagation primitive.
     struct desc {
-        /// Constructs a descriptor for LRN forward propagation primitive
-        /// using @p prop_kind (acceptable values are #dnnl::prop_kind::forward_training
-        /// and #dnnl::prop_kind::forward_inference), @p algorithm, memory descriptor @p
-        /// data_desc, and regularization parameters @p local_size, @p alpha,
-        /// @p beta, and @p k.
+        /// Constructs a descriptor for a LRN forward propagation primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `workspace` (#dnnl::primitive_desc_base::workspace_desc (`0`)),
+        ///     if @p alg_kind = #dnnl::algorithm::pooling_max and @p
+        ///     prop_kind = #dnnl::prop_kind::forward_training; must be
+        ///     queried for using @ref dnnl::primitive_desc_base::query_md()
+        ///     after a corresponding primitive descriptor is created
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param algorithm LRN algorithm kind: either
+        ///     #dnnl::algorithm::lrn_across_channels, or
+        ///     #dnnl::algorithm::lrn_within_channel.
+        /// @param data_desc Source and destination memory descriptors.
+        /// @param local_size Regularization local size.
+        /// @param alpha The alpha regularization parameter.
+        /// @param beta The beta regularization parameter.
+        /// @param k The k regularization parameter.
         desc(prop_kind prop_kind, algorithm algorithm,
-                const memory::desc &src_desc, memory::dim local_size,
+                const memory::desc &data_desc, memory::dim local_size,
                 float alpha, float beta, float k = 1.f);
     };
 
-    /// Primitive descriptor for LRN forward propagation primitive.
+    /// Primitive descriptor for an LRN forward propagation primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for LRN forward propagation
+        /// Constructs a primitive descriptor for an LRN forward propagation
         /// primitive.
         ///
-        /// @param desc Descriptor for LRN forward propagation primitive.
+        /// @param desc Descriptor for an LRN forward propagation primitive.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for LRN forward propagation
+        /// Constructs a primitive descriptor for an LRN forward propagation
         /// primitive.
         ///
-        /// @param desc Descriptor for LRN forward propagation primitive.
+        /// @param desc Descriptor for an LRN forward propagation primitive.
         /// @param engine Engine to use.
         /// @param attr Primitive attributes to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine, bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
 
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
         memory::desc workspace_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     lrn_forward();
 
-    /// Constructs an LRN forward propagation primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs an LRN forward propagation primitive.
+    /// @param pd Primitive descriptor for an LRN forward propagation
+    ///     primitive.
     lrn_forward(const primitive_desc &pd);
 };
 
 /// Local response normalization (LRN) backward propagation primitive.
 struct lrn_backward : public primitive {
-    /// Descriptor for LRN backward propagation primitive.
+    /// Descriptor for an LRN backward propagation primitive.
     struct desc {
-        /// Constructs a descriptor for LRN backward propagation primitive
-        /// using @p algorithm, memory descriptors @p data_desc and @p
-        /// diff_data_desc, and regularization parameters @p local_size, @p
-        /// alpha, @p beta, and @p k.
+        /// Constructs a descriptor for an LRN backward propagation primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///  - `workspace` (#dnnl::primitive_desc_base::workspace_desc (`0`)),
+        ///     if the underlying implementation requires it; must be queried
+        ///     for using @ref dnnl::primitive_desc_base::query_md() after a
+        ///     corresponding primitive descriptor is created
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///
+        /// @param algorithm LRN algorithm kind: either
+        ///     #dnnl::algorithm::lrn_across_channels, or
+        ///     #dnnl::algorithm::lrn_within_channel.
+        /// @param diff_data_desc Diff source and diff destination memory descriptor.
+        /// @param data_desc Source memory descriptor.
+        /// @param local_size Regularization local size.
+        /// @param alpha The alpha regularization parameter.
+        /// @param beta The beta regularization parameter.
+        /// @param k The k regularization parameter.
         desc(algorithm algorithm, const memory::desc &data_desc,
                 const memory::desc &diff_data_desc, memory::dim local_size,
                 float alpha, float beta, float k = 1.f);
     };
 
-    /// Primitive descriptor for LRN backward propagation primitive.
+    /// Primitive descriptor for an LRN backward propagation primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for LRN backward propagation
+        /// Constructs a primitive descriptor for an LRN backward propagation
         /// primitive.
         ///
-        /// @param desc Descriptor for LRN backward propagation primitive.
+        /// @param desc Descriptor for an LRN backward propagation primitive.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for LRN forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for an LRN forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const lrn_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for LRN backward propagation
+        /// Constructs a primitive descriptor for an LRN backward propagation
         /// primitive.
         ///
-        /// @param desc Descriptor for LRN backward propagation primitive.
+        /// @param desc Descriptor for an LRN backward propagation primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for LRN forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for an LRN forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const lrn_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the diff source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc diff_src_desc() const;
 
-        /// Returns the diff destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
         memory::desc diff_dst_desc() const;
 
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
         memory::desc workspace_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     lrn_backward();
 
-    /// Constructs an LRN backward propagation primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs an LRN backward propagation primitive.
+    /// @param pd Primitive descriptor for an LRN backward propagation
+    ///     primitive.
     lrn_backward(const primitive_desc &pd);
 };
 
+/// @} dnnl_api_lrn
+
+/// @addtogroup dnnl_api_pooling Pooling
+///
+/// A primitive to perform max or average pooling.
+///
+/// @{
+
 /// Pooling forward propagation primitive.
 struct pooling_forward : public primitive {
-    /// Descriptor for pooling forward propagation primitive.
+    /// Descriptor for a pooling forward propagation primitive.
     struct desc {
-        /// Constructs a descriptor for pooling forward propagation primitive
-        /// using @p prop_kind (acceptable values are #dnnl::prop_kind::forward_training
-        /// and #dnnl::prop_kind::forward_inference), @p algorithm, memory descriptors,
-        /// and pooling parameters in the spatial domain: @p strides, @p
-        /// kernel sizes, @p padding_l, and @p padding_r.
+        /// Constructs a descriptor for pooling forward propagation primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `workspace` (#dnnl::primitive_desc_base::workspace_desc (`0`)),
+        ///     if @p alg_kind = #dnnl::algorithm::pooling_max and @p
+        ///     prop_kind = #dnnl::prop_kind::forward_training; must be
+        ///     queried for using @ref dnnl::primitive_desc_base::query_md()
+        ///     after a corresponding primitive descriptor is created
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param algorithm Pooling algorithm kind: either
+        ///     #dnnl::algorithm::pooling_max,
+        ///     #dnnl::algorithm::pooling_avg_include_padding, or
+        ///     #dnnl::algorithm::pooling_avg (same as
+        ///     #dnnl::algorithm::pooling_avg_exclude_padding).
+        /// @param src_desc Source memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Vector of strides for spatial dimension.
+        /// @param kernel Vector of kernel spatial dimensions.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(prop_kind prop_kind, algorithm algorithm,
                 const memory::desc &src_desc, const memory::desc &dst_desc,
                 const memory::dims &strides, const memory::dims &kernel,
                 const memory::dims &padding_l, const memory::dims &padding_r);
     };
 
-    /// Primitive descriptor for pooling forward propagation primitive.
+    /// Primitive descriptor for a pooling forward propagation primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
@@ -1987,187 +3292,234 @@ struct pooling_forward : public primitive {
         /// Constructs a primitive descriptor for a pooling forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for pooling forward propagation primitive.
+        /// @param desc Descriptor for a pooling forward propagation primitive.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 bool allow_empty = false);
 
         /// Constructs a primitive descriptor for a pooling forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for pooling forward propagation primitive.
+        /// @param desc Descriptor for a pooling forward propagation primitive.
         /// @param engine Engine to use.
         /// @param attr Primitive attributes to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine, bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
 
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
         memory::desc workspace_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     pooling_forward();
 
-    /// Constructs an pooling forward propagation primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs a pooling forward propagation primitive.
+    /// @param pd Primitive descriptor for a pooling forward propagation
+    ///     primitive.
     pooling_forward(const primitive_desc &pd);
 };
 
 /// Pooling backward propagation primitive.
 struct pooling_backward : public primitive {
-    /// Descriptor for pooling backward propagation primitive.
+    /// Descriptor for a pooling backward propagation primitive.
     struct desc {
-        /// Constructs a pooling descriptor for pooling backward propagation
-        /// primitive using @p algorithm, memory descriptors, and pooling
-        /// parameters in the spatial domain: @p strides, @p kernel sizes, @p
-        /// padding_l, and @p padding_r.
+        /// Constructs a descriptor for pooling backward propagation primitive.
+        ///
+        /// Inputs:
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///  - `workspace` (#dnnl::primitive_desc_base::workspace_desc (`0`)),
+        ///     if @p alg_kind = #dnnl::algorithm::pooling_max; must be
+        ///     queried for using @ref dnnl::primitive_desc_base::query_md()
+        ///     after a corresponding primitive descriptor is created
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///
+        /// @param algorithm Pooling algorithm kind: either
+        ///     #dnnl::algorithm::pooling_max,
+        ///     #dnnl::algorithm::pooling_avg_include_padding, or
+        ///     #dnnl::algorithm::pooling_avg (same as
+        ///     #dnnl::algorithm::pooling_avg_exclude_padding).
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Vector of strides for spatial dimension.
+        /// @param kernel Vector of kernel spatial dimensions.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension (front, top, left).
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension (back, bottom, right).
         desc(algorithm algorithm, const memory::desc &diff_src_desc,
                 const memory::desc &diff_dst_desc, const memory::dims &strides,
                 const memory::dims &kernel, const memory::dims &padding_l,
                 const memory::dims &padding_r);
     };
 
-    /// Primitive descriptor for pooling backward propagation primitive.
+    /// Primitive descriptor for a pooling backward propagation primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for a pooling forward
+        /// Constructs a primitive descriptor for a pooling backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for pooling forward propagation primitive.
+        /// @param desc Descriptor for a pooling backward propagation primitive.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for pooling forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a pooling forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const pooling_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for a pooling forward
+        /// Constructs a primitive descriptor for a pooling backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for pooling forward propagation primitive.
+        /// @param desc Descriptor for a pooling backward propagation primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for pooling forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a pooling forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const pooling_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the diff source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc diff_src_desc() const;
 
-        /// Returns the diff destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
         memory::desc diff_dst_desc() const;
 
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
         memory::desc workspace_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     pooling_backward();
 
-    /// Constructs an pooling backward propagation primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs a pooling backward propagation primitive.
+    /// @param pd Primitive descriptor for a pooling backward propagation
+    ///     primitive.
     pooling_backward(const primitive_desc &pd);
 };
 
-/// Elementwise unary operation forward propagation primitive.
+/// @} dnnl_api_pooling
+
+/// @addtogroup dnnl_api_eltwise Eltwise
 ///
-/// This primitive computes unary elementwise operations such as rectified
-/// linear unit (ReLU), Sigmoid, tanh or others for each element of the
-/// source.
+/// A primitive to perform elementwise operations such as the
+/// rectifier linear unit (ReLU).
 ///
 /// Both forward and backward propagation primitives support in-place
-/// operation; that is, src and dst can point to the same memory for forward
-/// propagation, and diff_dst and diff_src can point to the same memory for
+/// operation; that is, src and dst can refer to the same memory for forward
+/// propagation, and diff_dst and diff_src can refer to the same memory for
 /// backward propagation.
+///
+/// @warning
+///     Because the original source data is required for backward propagation,
+///     in-place forward propagation is not generally supported in the
+///     training mode.  However, for namely ReLU with the alpha parameter set
+///     to 0, either dst or src can be used for the backward propagation,
+///     which makes it possible to get performance benefit even in the
+///     training mode.
+///
+/// @{
+
+/// Elementwise unary operation forward propagation primitive.
 struct eltwise_forward : public primitive {
-    /// Descriptor for elementwise forward propagation primitive.
+    /// Descriptor for an elementwise forward propagation primitive.
     struct desc {
-        /// Constructs a descriptor for elementwise forward propagation
-        /// primitive using @p prop_kind (acceptable values are
-        /// #dnnl::prop_kind::forward_training and #dnnl::prop_kind::forward_inference), @p
-        /// algorithm algorithm, memory descriptor @p data_desc, @p alpha, and
-        /// @p beta parameters.
+        /// Constructs a descriptor for an elementwise forward propagation
+        /// primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param algorithm Elementwise algorithm kind.
+        /// @param data_desc Source and destination memory descriptors.
+        /// @param alpha The alpha parameter for the elementwise operation.
+        ///     Specific meaning depends on the algorithm.
+        /// @param beta The beta parameter for the elementwise operation.
+        ///     Specific meaning depends on the algorithm.
         desc(prop_kind prop_kind, algorithm algorithm,
-                const memory::desc &src_desc, float alpha = 0, float beta = 0);
+                const memory::desc &data_desc, float alpha = 0,
+                float beta = 0);
     };
 
-    /// Primitive descriptor for elementwise forward propagation primitive.
+    /// Primitive descriptor for an elementwise forward propagation primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for elementwise forward
+        /// Constructs a primitive descriptor for an elementwise forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for elementwise forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for an elementwise forward propagation
+        ///     primitive.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for elementwise forward
+        /// Constructs a primitive descriptor for an elementwise forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for elementwise forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for an elementwise forward propagation
+        ///     primitive.
         /// @param engine Engine to use.
         /// @param attr Primitive attributes to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine, bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     eltwise_forward();
 
-    /// Constructs an elementwise forward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs an eltwise forward propagation primitive.
+    /// @param pd Primitive descriptor for an eltwise forward propagation
+    ///     primitive.
     eltwise_forward(const primitive_desc &pd);
 };
 
@@ -2175,808 +3527,1292 @@ struct eltwise_forward : public primitive {
 ///
 /// @sa eltwise_forward
 struct eltwise_backward : public primitive {
-    /// Descriptor for elementwise backward propagation primitive.
+    /// Descriptor for an elementwise backward propagation primitive.
     struct desc {
-        /// Constructs an eltwise descriptor for backward propagation using @p
-        /// algorithm algorithm memory descriptors @p diff_data_desc and @p
-        /// data_desc, and the @p alpha and @p beta parameters.
+        /// Constructs a descriptor for an elementwise backward propagation
+        /// primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///
+        /// @param algorithm Elementwise algorithm kind.
+        /// @param diff_data_desc Diff source and destination memory
+        ///     descriptors.
+        /// @param data_desc Source memory descriptor.
+        /// @param alpha The alpha parameter for the elementwise operation.
+        ///     Specific meaning depends on the algorithm.
+        /// @param beta The beta parameter for the elementwise operation.
+        ///     Specific meaning depends on the algorithm.
         desc(algorithm algorithm, const memory::desc &diff_data_desc,
-                const memory::desc &data_desc, float alpha = 0, float beta = 0);
+                const memory::desc &data_desc, float alpha = 0,
+                float beta = 0);
     };
 
-    /// Primitive descriptor for eltwise backward propagation primitive.
+    /// Primitive descriptor for eltwise backward propagation.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for elementwise backward
+        /// Constructs a primitive descriptor for an elementwise backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for elementwise backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for an elementwise backward propagation
+        ///     primitive.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for elementwise forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for an elementwise forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const eltwise_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for elementwise backward
+        /// Constructs a primitive descriptor for an elementwise backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for elementwise backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for an elementwise backward propagation
+        ///     primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for elementwise forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for an elementwise forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const eltwise_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the diff source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
         memory::desc diff_src_desc() const;
 
-        /// Returns the diff destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
         memory::desc diff_dst_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     eltwise_backward();
 
-    /// Constructs an elementwise backward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs an eltwise backward propagation primitive.
+    /// @param pd Primitive descriptor for an eltwise backward propagation
+    ///     primitive.
     eltwise_backward(const primitive_desc &pd);
 };
 
+/// @} dnnl_api_eltwise
+
+/// @addtogroup dnnl_api_softmax Softmax
+///
+/// A primitive to perform softmax.
+///
+/// @{
+
 /// Softmax forward propagation primitive.
 struct softmax_forward : public primitive {
-    /// Descriptor for softmax forward propagation primitive.
+    /// Descriptor for a softmax forward propagation primitive.
     struct desc {
-        /// Constructs a softmax descriptor for forward propagation using @p
-        /// prop_kind (acceptable values are #dnnl::prop_kind::forward_training and
-        /// #dnnl::prop_kind::forward_inference) and memory descriptor @p data_desc.
+        /// Default constructor. Produces an empty object.
+        desc();
+
+        /// Constructs a descriptor for a softmax forward propagation
+        /// primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param data_desc Source and destination memory descriptor.
+        /// @param softmax_axis Axis over which softmax is computed.
         desc(prop_kind prop_kind, const memory::desc &data_desc,
                 int softmax_axis);
     };
 
-    /// Primitive descriptor for softmax forward propagation primitive.
+    /// Primitive descriptor for a softmax forward propagation primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for softmax forward
+        /// Constructs a primitive descriptor for a softmax forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for softmax forward propagation
-        ///             primitive.
+        /// @param desc descriptor for a softmax forward propagation
+        ///     primitive.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for softmax forward
+        /// Constructs a primitive descriptor for a softmax forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for softmax forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a softmax forward propagation
+        ///     primitive.
         /// @param engine Engine to use.
         /// @param attr Primitive attributes to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine, bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     softmax_forward();
 
-    /// Constructs an softmax forward propagation primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs a softmax forward propagation primitive.
+    /// @param pd Primitive descriptor for a softmax forward propagation
+    ///     primitive.
     softmax_forward(const primitive_desc &pd);
 };
 
 /// Softmax backward propagation primitive.
 struct softmax_backward : public primitive {
-    /// Descriptor for softmax backward propagation primitive.
+    /// Descriptor for a softmax backward propagation primitive.
     struct desc {
-        /// Constructs a softmax descriptor for backward propagation using
-        /// memory descriptors @p diff_desc and @p data_desc.
-        desc(const memory::desc &diff_desc, const memory::desc &data_desc,
+        /// Default constructor. Produces an empty object.
+        desc();
+
+        /// Constructs a descriptor for a softmax backward propagation
+        /// primitive.
+        ///
+        /// Inputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///
+        /// @param diff_data_desc Diff source and diff destination memory descriptor.
+        /// @param data_desc Destination memory descriptor.
+        /// @param softmax_axis Axis over which softmax is computed.
+        desc(const memory::desc &diff_data_desc, const memory::desc &data_desc,
                 int softmax_axis);
     };
 
-    /// Primitive descriptor for softmax backward propagation primitive.
+    /// Primitive descriptor for a softmax backward propagation primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for softmax backward
+        /// Constructs a primitive descriptor for a softmax backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for softmax backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a softmax backward propagation
+        ///     primitive.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for softmax forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a softmax forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const softmax_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for softmax backward
+        /// Constructs a primitive descriptor for a softmax backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for softmax backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a softmax backward propagation
+        ///     primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for softmax forward
-        ///                    propagation primitive. It is used as a hint
-        ///                    when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a softmax forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const softmax_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
 
-        /// Returns the diff source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
         memory::desc diff_src_desc() const;
 
-        /// Returns the diff destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc diff_dst_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     softmax_backward();
 
-    /// Constructs an softmax backward propagation primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs a softmax backward propagation primitive.
+    /// @param pd Primitive descriptor for a softmax backward propagation
+    ///     primitive.
     softmax_backward(const primitive_desc &pd);
 };
 
+/// @} dnnl_api_softmax
+
+/// @addtogroup dnnl_api_logsoftmax LogSoftmax
+///
+/// A primitive to perform logsoftmax.
+///
+/// @{
+
+/// Logsoftmax forward propagation primitive.
+struct logsoftmax_forward : public primitive {
+    /// Descriptor for a logsoftmax forward propagation primitive.
+    struct desc {
+        /// Default constructor. Produces an empty object.
+        desc();
+
+        /// Constructs a descriptor for a logsoftmax forward propagation
+        /// primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param data_desc Source and destination memory descriptor.
+        /// @param logsoftmax_axis Axis over which softmax is computed.
+        desc(prop_kind prop_kind, const memory::desc &data_desc,
+                int logsoftmax_axis);
+    };
+
+    /// Primitive descriptor for a logsoftmax forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc();
+
+        /// Constructs a primitive descriptor for a logsoftmax forward
+        /// propagation primitive.
+        ///
+        /// @param desc descriptor for a logsoftmax forward propagation
+        ///     primitive.
+        /// @param engine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &desc, const engine &engine,
+                bool allow_empty = false);
+
+        /// Constructs a primitive descriptor for a logsoftmax forward
+        /// propagation primitive.
+        ///
+        /// @param desc Descriptor for a logsoftmax forward propagation
+        ///     primitive.
+        /// @param engine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &desc, const primitive_attr &attr,
+                const engine &engine, bool allow_empty = false);
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const;
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const;
+    };
+
+    /// Default constructor. Produces an empty object.
+    logsoftmax_forward();
+
+    /// Constructs a logsoftmax forward propagation primitive.
+    /// @param pd Primitive descriptor for a logsoftmax forward propagation
+    ///     primitive.
+    logsoftmax_forward(const primitive_desc &pd);
+};
+
+/// Logsoftmax backward propagation primitive.
+struct logsoftmax_backward : public primitive {
+    /// Descriptor for a logsoftmax backward propagation primitive.
+    struct desc {
+        /// Default constructor. Produces an empty object.
+        desc();
+
+        /// Constructs a descriptor for a logsoftmax backward propagation
+        /// primitive.
+        ///
+        /// Inputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///
+        /// @param diff_data_desc Diff source and diff destination memory
+        ///     descriptors.
+        /// @param data_desc Destination memory descriptor.
+        /// @param logsoftmax_axis Axis over which softmax is computed.
+        desc(const memory::desc &diff_data_desc, const memory::desc &data_desc,
+                int logsoftmax_axis);
+    };
+
+    /// Primitive descriptor for a logsoftmax backward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc();
+
+        /// Constructs a primitive descriptor for a logsoftmax backward
+        /// propagation primitive.
+        ///
+        /// @param desc Descriptor for a logsoftmax backward propagation
+        ///     primitive.
+        /// @param engine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a logsoftmax forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &desc, const engine &engine,
+                const logsoftmax_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false);
+
+        /// Constructs a primitive descriptor for a logsoftmax backward
+        /// propagation primitive.
+        ///
+        /// @param desc Descriptor for a logsoftmax backward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param engine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a logsoftmax forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &desc, const primitive_attr &attr,
+                const engine &engine,
+                const logsoftmax_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false);
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const;
+
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
+        memory::desc diff_src_desc() const;
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc diff_dst_desc() const;
+    };
+
+    /// Default constructor. Produces an empty object.
+    logsoftmax_backward();
+
+    /// Constructs a logsoftmax backward propagation primitive.
+    /// @param pd Primitive descriptor for a logsoftmax backward propagation
+    ///     primitive.
+    logsoftmax_backward(const primitive_desc &pd);
+};
+
+/// @} dnnl_api_logsoftmax
+
+/// @addtogroup dnnl_api_batch_normalization Batch Normalization
+///
+/// A primitive to perform batch normalization.
+///
+/// Both forward and backward propagation primitives support in-place
+/// operation; that is, src and dst can refer to the same memory for forward
+/// propagation, and diff_dst and diff_src can refer to the same memory for
+/// backward propagation.
+///
+/// The batch normalization primitives computations can be controlled by
+/// specifying different @ref dnnl::normalization_flags values. For example,
+/// batch normalization can compute the mean and variance on its own or take
+/// them as inputs.  It can either perform scaling and shifting using gamma
+/// and beta parameters or not. Optionally, it can also perform a fused ReLU,
+/// which in case of training would also require a workspace.
+///
+/// @{
+
 /// Batch normalization forward propagation primitive.
 struct batch_normalization_forward : public primitive {
-    /// Descriptor for batch normalization forward propagation primitive.
+    /// Descriptor for a batch normalization forward propagation primitive.
     struct desc {
         /// Constructs a batch normalization descriptor for forward
-        /// propagation using @p prop_kind (acceptable values are
-        /// #dnnl::prop_kind::forward_training and #dnnl::prop_kind::forward_inference), memory
-        /// descriptor @p data_desc, normalization parameter @p epsilon, and
-        /// flags set using bit @p flags.
-        desc(prop_kind prop_kind, const memory::desc &src_desc, float epsilon,
+        /// propagation.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `mean` (#dnnl::primitive_desc_base::src_desc (`1`)),
+        ///     if #dnnl::normalization_flags::use_global_stats bit-flag is
+        ///     set in @p flags
+        ///  - `variance` (#dnnl::primitive_desc_base::src_desc (`2`)),
+        ///     if #dnnl::normalization_flags::use_global_stats bit-flag is
+        ///     set in @p flags
+        ///  - `scale_and_shift` (#dnnl::primitive_desc_base::weights_desc (`0`)),
+        ///     if #dnnl::normalization_flags::use_scale_shift bit-flag is set
+        ///     in @p flags
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `mean` (#dnnl::primitive_desc_base::dst_desc (`1`)),
+        ///     if #dnnl::normalization_flags::use_global_stats bit-flag is
+        ///     not set in @p flags @p prop_kind =
+        ///     #dnnl::prop_kind::forward_training
+        ///  - `variance` (#dnnl::primitive_desc_base::dst_desc (`2`)),
+        ///     if #dnnl::normalization_flags::use_global_stats bit-flag is
+        ///     not set in @p flags and @p prop_kind =
+        ///     #dnnl::prop_kind::forward_training
+        ///  - `workspace` (#dnnl::primitive_desc_base::workspace_desc (`0`)),
+        ///     if #dnnl::normalization_flags::fuse_norm_relu bit-flag is set
+        ///     in @p flags and @p prop_kind =
+        ///     #dnnl::prop_kind::forward_training; must be queried
+        ///     for using @ref primitive_desc_base::query_md() after a
+        ///     corresponding primitive descriptor is created
+        ///
+        /// @note
+        ///     In-place operation is supported: the dst can refer to the same
+        ///     memory as the src.
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param data_desc Source and destination memory descriptors.
+        /// @param epsilon Batch normalization epsilon parameter.
+        /// @param flags Batch normalization flags (@ref
+        ///     dnnl::normalization_flags).
+        desc(prop_kind prop_kind, const memory::desc &data_desc, float epsilon,
                 normalization_flags flags);
     };
 
-    /// Primitive descriptor for batch normalization forward propagation
+    /// Primitive descriptor for a batch normalization forward propagation
     /// primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for batch normalization forward
+        /// Constructs a primitive descriptor for a batch normalization forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for batch normalization forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a batch normalization forward propagation
+        ///     primitive.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for batch normalization forward
+        /// Constructs a primitive descriptor for a batch normalization forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for batch normalization forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a batch normalization forward propagation
+        ///     primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine, bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the weights (scale and shift) memory descriptor.
-        memory::desc weights_desc() const;
-
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
 
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
+        memory::desc weights_desc() const;
+
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
         memory::desc workspace_desc() const;
 
-        /// Returns the mean memory descriptor.
+        /// Returns memory descriptor for mean.
+        /// @returns Memory descriptor for mean.
         memory::desc mean_desc() const;
 
-        /// Returns the variance memory descriptor.
+        /// Returns memory descriptor for variance.
+        /// @returns Memory descriptor for variance.
         memory::desc variance_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     batch_normalization_forward();
 
-    /// Constructs an batch normalization forward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs a batch normalization forward propagation primitive.
+    /// @param pd Primitive descriptor for a batch normalization forward
+    ///     propagation primitive.
     batch_normalization_forward(const primitive_desc &pd);
 };
 
 /// Batch normalization backward propagation primitive.
 struct batch_normalization_backward : public primitive {
-    /// Descriptor for batch normalization backward propagation primitive.
+    /// Descriptor for a batch normalization backward propagation primitive.
     struct desc {
         /// Constructs a batch normalization descriptor for backward
-        /// propagation with respect to data and scale-shift parameters using
-        /// memory descriptors @p data_desc and @p diff_data_desc,
-        /// normalization parameter @p epsilon, and flags set using bit @p
-        /// flags.
+        /// propagation.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `mean` (#dnnl::primitive_desc_base::src_desc (`1`))
+        ///  - `variance` (#dnnl::primitive_desc_base::src_desc (`2`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///  - `scale_and_shift` (#dnnl::primitive_desc_base::weights_desc (`0`)),
+        ///     if #dnnl::normalization_flags::use_scale_shift bit-flag is
+        ///     set in @p flags
+        ///  - `workspace` (#dnnl::primitive_desc_base::workspace_desc (`0`)),
+        ///     if #dnnl::normalization_flags::fuse_norm_relu bit-flag is set
+        ///     in @p flags
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///  - diff_scale_and_shift
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`0`)),
+        ///     if #dnnl::normalization_flags::use_scale_shift bitflags is
+        ///     set in @p flags and @p prop_kind = #dnnl::prop_kind::backward
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::backward_data and #dnnl::prop_kind::backward
+        ///     (diffs for all parameters are computed in this case).
+        /// @param diff_data_desc Diff source and diff destination memory
+        ///     descriptor.
+        /// @param data_desc Source memory descriptor.
+        /// @param epsilon Batch normalization epsilon parameter.
+        /// @param flags Batch normalization flags (@ref
+        ///     dnnl::normalization_flags).
         desc(prop_kind prop_kind, const memory::desc &diff_data_desc,
                 const memory::desc &data_desc, float epsilon,
                 normalization_flags flags);
     };
 
-    /// Primitive descriptor for batch normalization backward propagation
+    /// Primitive descriptor for a batch normalization backward propagation
     /// primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for batch normalization backward
+        /// Constructs a primitive descriptor for a batch normalization backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for batch normalization backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a batch normalization backward
+        ///     propagation primitive.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for batch normalization
-        ///                    forward propagation primitive. It is used as a
-        ///                    hint when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a batch normalization
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const batch_normalization_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for batch normalization backward
+        /// Constructs a primitive descriptor for a batch normalization backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for batch normalization backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a batch normalization backward
+        ///     propagation primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for batch normalization
-        ///                    forward propagation primitive. It is used as a
-        ///                    hint when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a batch normalization
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const batch_normalization_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the mean memory descriptor.
-        memory::desc mean_desc() const;
-
-        /// Returns the variance memory descriptor.
-        memory::desc variance_desc() const;
-
-        /// Returns the weights (scale and shift) memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
         memory::desc weights_desc() const;
 
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
 
-        /// Returns the diff destination memory descriptor.
-        memory::desc diff_dst_desc() const;
-
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
-        memory::desc workspace_desc() const;
-
-        /// Returns the diff source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
         memory::desc diff_src_desc() const;
 
-        /// Returns the diff weights (scale and shift) memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const;
+
+        /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
         memory::desc diff_weights_desc() const;
+
+        /// @copydoc dnnl::batch_normalization_forward::primitive_desc::mean_desc()const
+        memory::desc mean_desc() const;
+
+        /// @copydoc dnnl::batch_normalization_forward::primitive_desc::variance_desc()const
+        memory::desc variance_desc() const;
+
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     batch_normalization_backward();
 
-    /// Constructs an batch normalization backward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs a batch normalization backward propagation primitive.
+    /// @param pd Primitive descriptor for a batch normalization backward
+    ///     propagation primitive.
     batch_normalization_backward(const primitive_desc &pd);
 };
 
+/// @} dnnl_api_batch_normalization
+
+/// @addtogroup dnnl_api_layer_normalization Layer Normalization
+///
+/// A primitive to perform layer normalization. Normalization is performed
+/// within the last logical dimension of data tensor.
+///
+/// Both forward and backward propagation primitives support in-place
+/// operation; that is, src and dst can refer to the same memory for forward
+/// propagation, and diff_dst and diff_src can refer to the same memory for
+/// backward propagation.
+///
+/// The layer normalization primitives computations can be controlled by
+/// specifying different dnnl::normalization_flags values. For example,
+/// layer normalization forward propagation can be configured to either
+/// compute the mean and variance or take them as arguments. It can either
+/// perform scaling and shifting using gamma and beta parameters or not.
+/// Optionally, it can also perform a fused ReLU, which in case of training
+/// would also require a workspace.
+///
+/// @{
+
 /// Layer normalization forward propagation primitive.
 struct layer_normalization_forward : public primitive {
-    /// Descriptor for layer normalization forward propagation primitive.
+    /// Descriptor for a layer normalization forward propagation primitive.
     struct desc {
-        /// Constructs a layer normalization descriptor for forward
-        /// propagation using @p prop_kind (acceptable values are
-        /// #dnnl::prop_kind::forward_training and #dnnl::prop_kind::forward_inference), data memory
-        /// descriptor @p data_desc, statistics memory descriptor @p
-        /// stat_desc, normalization parameter @p epsilon, and flags set
-        /// using bit @p flags.
+        /// Constructs a descriptor for layer normalization forward
+        /// propagation primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `mean` (#dnnl::primitive_desc_base::src_desc (`1`)),
+        ///     if #dnnl::normalization_flags::use_global_stats bit-flag is
+        ///     set in @p flags
+        ///  - `variance` (#dnnl::primitive_desc_base::src_desc (`2`)),
+        ///     if #dnnl::normalization_flags::use_global_stats bit-flag is
+        ///     set in @p flags
+        ///  - `scale_and_shift` (#dnnl::primitive_desc_base::weights_desc (`0`)),
+        ///     if #dnnl::normalization_flags::use_scale_shift bit-flag is set
+        ///     in @p flags
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `mean` (#dnnl::primitive_desc_base::dst_desc (`1`)),
+        ///     if #dnnl::normalization_flags::use_global_stats bit-flag is
+        ///     not set in @p flags @p prop_kind =
+        ///     #dnnl::prop_kind::forward_training
+        ///  - `variance` (#dnnl::primitive_desc_base::dst_desc (`2`)),
+        ///     if #dnnl::normalization_flags::use_global_stats bit-flag is
+        ///     not set in @p flags and @p prop_kind =
+        ///     #dnnl::prop_kind::forward_training
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param data_desc Source and destination memory descriptor.
+        /// @param stat_desc Statistics memory descriptors.
+        /// @param epsilon Layer normalization epsilon parameter.
+        /// @param flags Layer normalization flags (@ref
+        ///     dnnl::normalization_flags).
         desc(prop_kind prop_kind, const memory::desc &data_desc,
                 const memory::desc &stat_desc, float epsilon,
                 normalization_flags flags);
 
-        /// Constructs a layer normalization descriptor for forward
-        /// propagation using @p prop_kind (acceptable values are
-        /// #dnnl::prop_kind::forward_training and #dnnl::prop_kind::forward_inference), data memory
-        /// descriptor @p data_desc, statistics memory descriptor @p
-        /// stat_desc, normalization parameter @p epsilon, and flags set
-        /// using bit @p flags.
-        desc(prop_kind prop_kind, const memory::desc &src_desc, float epsilon,
+        /// Constructs a descriptor for layer normalization forward
+        /// propagation primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `mean` (#dnnl::primitive_desc_base::src_desc (`1`)),
+        ///     if #dnnl::normalization_flags::use_global_stats bit-flag is
+        ///     set in @p flags
+        ///  - `variance` (#dnnl::primitive_desc_base::src_desc (`2`)),
+        ///     if #dnnl::normalization_flags::use_global_stats bit-flag is
+        ///     set in @p flags
+        ///  - `scale_and_shift` (#dnnl::primitive_desc_base::weights_desc (`0`)),
+        ///     if #dnnl::normalization_flags::use_scale_shift bit-flag is set
+        ///     in @p flags
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `mean` (#dnnl::primitive_desc_base::dst_desc (`1`)),
+        ///     if #dnnl::normalization_flags::use_global_stats bit-flag is
+        ///     not set in @p flags @p prop_kind =
+        ///     #dnnl::prop_kind::forward_training
+        ///  - `variance` (#dnnl::primitive_desc_base::dst_desc (`2`)),
+        ///     if #dnnl::normalization_flags::use_global_stats bit-flag is
+        ///     not set in @p flags and @p prop_kind =
+        ///     #dnnl::prop_kind::forward_training
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param data_desc Source and destination memory descriptor.
+        /// @param epsilon Layer normalization epsilon parameter.
+        /// @param flags Layer normalization flags (@ref
+        ///     dnnl::normalization_flags).
+        desc(prop_kind prop_kind, const memory::desc &data_desc, float epsilon,
                 normalization_flags flags);
     };
 
-    /// Primitive descriptor for layer normalization forward propagation
+    /// Primitive descriptor for a layer normalization forward propagation
     /// primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for layer normalization forward
+        /// Constructs a primitive descriptor for a layer normalization forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for layer normalization forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a layer normalization forward propagation
+        ///     primitive.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for layer normalization forward
+        /// Constructs a primitive descriptor for a layer normalization forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for layer normalization forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a layer normalization forward propagation
+        ///     primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine, bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the weights (scale and shift) memory descriptor.
-        memory::desc weights_desc() const;
-
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
 
-        /// Returns the mean memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
+        memory::desc weights_desc() const;
+
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const;
+
+        /// @copydoc dnnl::batch_normalization_forward::primitive_desc::mean_desc()const
         memory::desc mean_desc() const;
 
-        /// Returns the variance memory descriptor.
+        /// @copydoc dnnl::batch_normalization_forward::primitive_desc::variance_desc()const
         memory::desc variance_desc() const;
-
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
-        memory::desc workspace_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     layer_normalization_forward();
 
-    /// Constructs an layer normalization forward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs a layer normalization forward propagation primitive.
+    /// @param pd Primitive descriptor for a layer normalization forward
+    ///     propagation primitive.
     layer_normalization_forward(const primitive_desc &pd);
 };
 
 /// Layer normalization backward propagation primitive.
 struct layer_normalization_backward : public primitive {
-    /// Descriptor for layer normalization backward propagation primitive.
+    /// Descriptor for a layer normalization backward propagation primitive.
     struct desc {
-        /// Constructs a layer normalization descriptor for backward
-        /// propagation with respect to data and scale-shift parameters using
-        /// memory descriptors @p diff_data_desc, @p data_desc and @p
-        /// stat_desc, normalization parameter @p epsilon, and p flags set
-        /// using bit @p flags.
+        /// Constructs a descriptor for layer normalization backward
+        /// propagation primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `mean` (#dnnl::primitive_desc_base::src_desc (`1`))
+        ///  - `variance` (#dnnl::primitive_desc_base::src_desc (`2`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///  - `scale_and_shift` (#dnnl::primitive_desc_base::weights_desc (`0`)),
+        ///     if #dnnl::normalization_flags::use_scale_shift bit-flag is
+        ///     set in @p flags
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///  - diff_scale_and_shift
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`0`)), if
+        ///     #dnnl::normalization_flags::use_scale_shift bit-flag is set
+        ///     in @p flags and @p prop_kind = #dnnl::prop_kind::backward
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::backward_data and #dnnl::prop_kind::backward
+        ///     (diffs for all parameters are computed in this case).
+        /// @param diff_data_desc Diff source and diff destination memory
+        ///     descriptor.
+        /// @param data_desc Source memory descriptor.
+        /// @param stat_desc Statistics memory descriptors.
+        /// @param epsilon Layer normalization epsilon parameter.
+        /// @param flags Layer normalization flags (@ref
+        ///     dnnl::normalization_flags).
         desc(prop_kind prop_kind, const memory::desc &diff_data_desc,
                 const memory::desc &data_desc, const memory::desc &stat_desc,
                 float epsilon, normalization_flags flags);
 
-        /// Constructs a layer normalization descriptor for backward
-        /// propagation with respect to data and scale-shift parameters using
-        /// memory descriptors @p diff_data_desc and @p data_desc
-        /// normalization parameter @p epsilon, and flags set using bit
-        /// @p flags.
+        /// Constructs a descriptor for layer normalization backward
+        /// propagation primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `mean` (#dnnl::primitive_desc_base::src_desc (`1`))
+        ///  - `variance` (#dnnl::primitive_desc_base::src_desc (`2`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///  - `scale_and_shift` (#dnnl::primitive_desc_base::weights_desc (`0`)),
+        ///     if #dnnl::normalization_flags::use_scale_shift bit-flag is
+        ///     set in @p flags
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///  - diff_scale_and_shift
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`0`)), if
+        ///     #dnnl::normalization_flags::use_scale_shift bit-flag is set
+        ///     in @p flags and @p prop_kind = #dnnl::prop_kind::backward
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::backward_data and #dnnl::prop_kind::backward
+        ///     (diffs for all parameters are computed in this case).
+        /// @param diff_data_desc Diff source and diff destination memory
+        ///     descriptor.
+        /// @param data_desc Source memory descriptor.
+        /// @param epsilon Layer normalization epsilon parameter.
+        /// @param flags Layer normalization flags (@ref
+        ///     dnnl::normalization_flags).
         desc(prop_kind prop_kind, const memory::desc &diff_data_desc,
                 const memory::desc &data_desc, float epsilon,
                 normalization_flags flags);
     };
 
-    /// Primitive descriptor for layer normalization backward propagation
+    /// Primitive descriptor for a layer normalization backward propagation
     /// primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for layer normalization backward
+        /// Constructs a primitive descriptor for a layer normalization backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for layer normalization backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a layer normalization backward
+        ///     propagation primitive.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for layer normalization
-        ///                    forward propagation primitive. It is used as a
-        ///                    hint when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a layer normalization
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const layer_normalization_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for layer normalization backward
+        /// Constructs a primitive descriptor for a layer normalization backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for layer normalization backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a layer normalization backward
+        ///     propagation primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for layer normalization
-        ///                    forward propagation primitive. It is used as a
-        ///                    hint when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a layer normalization
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const layer_normalization_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the mean memory descriptor.
-        memory::desc mean_desc() const;
-
-        /// Returns the variance memory descriptor.
-        memory::desc variance_desc() const;
-
-        /// Returns the weights (scale and shift) memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
         memory::desc weights_desc() const;
 
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
 
-        /// Returns the diff destination memory descriptor.
-        memory::desc diff_dst_desc() const;
-
-        /// Returns the diff source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
         memory::desc diff_src_desc() const;
 
-        /// Returns the diff weights (scale and shift) memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const;
+
+        /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
         memory::desc diff_weights_desc() const;
 
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
+        /// @copydoc dnnl::batch_normalization_forward::primitive_desc::mean_desc()const
+        memory::desc mean_desc() const;
+
+        /// @copydoc dnnl::batch_normalization_forward::primitive_desc::variance_desc()const
+        memory::desc variance_desc() const;
+
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
         memory::desc workspace_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     layer_normalization_backward();
 
-    /// Constructs an layer normalization backward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs a layer normalization backward propagation primitive.
+    /// @param pd Primitive descriptor for a layer normalization backward
+    ///     propagation primitive.
     layer_normalization_backward(const primitive_desc &pd);
 };
 
+/// @} dnnl_api_layer_normalization
+
+/// @addtogroup dnnl_api_inner_product Inner Product
+///
+/// A primitive to compute an inner product.
+///
+/// @{
+
 /// Inner product forward propagation primitive.
 struct inner_product_forward : public primitive {
-    /// Descriptor for inner product forward propagation primitive.
+    /// Descriptor for an inner product forward propagation primitive.
     struct desc {
-        /// Constructs a descriptor for inner product forward propagation
-        /// primitive using @p prop_kind (acceptable values are
-        /// #dnnl::prop_kind::forward_training and
-        /// #dnnl::prop_kind::forward_inference) and memory descriptors. In
-        /// order to create an inner product without bias, the @p bias_desc
-        /// should be initialized with a zero memory descriptor.
+        /// Constructs a descriptor for an inner product forward propagation
+        /// primitive with bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///  - `bias` (#dnnl::primitive_desc_base::weights_desc (`1`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param src_desc Memory descriptor for src.
+        /// @param weights_desc Memory descriptor for diff weights.
+        /// @param bias_desc Memory descriptor for diff bias.
+        /// @param dst_desc Memory descriptor for diff dst.
         desc(prop_kind prop_kind, const memory::desc &src_desc,
                 const memory::desc &weights_desc, const memory::desc &bias_desc,
                 const memory::desc &dst_desc);
 
-        /// Constructs an descriptor for inner product forward propagation
-        /// primitive using @p prop_kind (acceptable values are
-        /// #dnnl::prop_kind::forward_training and
-        /// #dnnl::prop_kind::forward_inference) and memory descriptors.
+        /// Constructs a descriptor for an inner product forward propagation
+        /// primitive without bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param src_desc Memory descriptor for src.
+        /// @param weights_desc Memory descriptor for diff weights.
+        /// @param dst_desc Memory descriptor for dst.
         desc(prop_kind prop_kind, const memory::desc &src_desc,
-                const memory::desc &weights_desc, const memory::desc &dst_desc);
+                const memory::desc &weights_desc,
+                const memory::desc &dst_desc);
     };
 
-    /// Primitive descriptor for inner product forward propagation primitive.
+    /// Primitive descriptor for an inner product forward propagation primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for inner product forward
+        /// Constructs a primitive descriptor for an inner product forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for inner product forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for an inner product forward propagation
+        ///     primitive.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for inner product forward
+        /// Constructs a primitive descriptor for an inner product forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for inner product forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for an inner product forward propagation
+        ///     primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine, bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the weights memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
         memory::desc weights_desc() const;
 
-        /// Returns the bias memory descriptor.
-        ///
-        /// Returns a zero_md if no bias was specified at op_desc
-        /// creation time.
-        memory::desc bias_desc() const;
-
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
+
+        /// @copydoc dnnl::convolution_forward::primitive_desc::bias_desc()const
+        memory::desc bias_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     inner_product_forward();
 
-    /// Constructs an inner product forward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs an inner product forward propagation primitive.
+    /// @param pd Primitive descriptor for an inner product forward
+    ///     propagation primitive.
     inner_product_forward(const primitive_desc &pd);
 };
 
 /// Inner product backward propagation primitive.
 struct inner_product_backward_data : public primitive {
-    /// Descriptor for inner product backward propagation primitive.
+    /// Descriptor for an inner product backward propagation primitive.
     struct desc {
-        /// Constructs a descriptor for inner product backward propagation
+        /// Constructs a descriptor for an inner product backward propagation
         /// primitive.
         ///
-        /// @param diff_src_desc Memory descriptor for diff src.
-        /// @param weights_desc Memory descriptor for weights.
-        /// @param diff_dst_desc Memory descriptor for diff dst.
+        /// Inputs:
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param diff_src_desc Memory descriptor for diff src.
+        /// @param weights_desc Memory descriptor for weights.
+        /// @param diff_dst_desc Memory descriptor for diff dst.
         desc(const memory::desc &diff_src_desc,
                 const memory::desc &weights_desc,
                 const memory::desc &diff_dst_desc);
     };
 
-    /// Primitive descriptor for inner product backward propagation primitive.
+    /// Primitive descriptor for an inner product backward propagation
+    /// primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for inner product backward
+        /// Constructs a primitive descriptor for an inner product backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for inner product backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for an inner product backward propagation
+        ///     primitive.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for inner product
-        ///                    forward propagation primitive. It is used as a
-        ///                    hint when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for an inner product
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const inner_product_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for inner product backward
+        /// Constructs a primitive descriptor for an inner product backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for inner product backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for an inner product backward propagation
+        ///     primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for inner product
-        ///                    forward propagation primitive. It is used as a
-        ///                    hint when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for an inner product
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const inner_product_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the diff source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
         memory::desc diff_src_desc() const;
 
-        /// Returns the weights memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
         memory::desc weights_desc() const;
 
-        /// Returns the diff destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
         memory::desc diff_dst_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     inner_product_backward_data();
 
-    /// Constructs an inner product backward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs an inner product backward propagation primitive.
+    /// @param pd Primitive descriptor for an inner product backward
+    ///     propagation primitive.
     inner_product_backward_data(const primitive_desc &pd);
 };
 
-/// Inner product weights update primitive.
+/// Inner product weights gradient primitive.
 struct inner_product_backward_weights : public primitive {
-    /// Descriptor for inner product weights update primitive.
+    /// Descriptor for an inner product weights gradient primitive.
     struct desc {
-        /// Constructs a descriptor for inner product descriptor weights
-        /// update primitive.
+        /// Constructs a descriptor for an inner product descriptor weights
+        /// update primitive with bias.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_weights` (#dnnl::primitive_desc_base::diff_weights_desc (`0`))
+        ///  - `diff_bias` (#dnnl::primitive_desc_base::diff_weights_desc (`1`))
+        ///
+        /// @note
+        ///     Memory descriptors are allowed to be initialized with
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
         ///
         /// @param src_desc Memory descriptor for src.
         /// @param diff_weights_desc Memory descriptor for diff weights.
         /// @param diff_bias_desc Memory descriptor for diff bias.
         /// @param diff_dst_desc Memory descriptor for diff dst.
-        ///
-        /// @note
-        ///     Memory descriptors are allowed to be initialized with
-        ///     #dnnl::memory::format_tag::any value of @p format_tag.
         desc(const memory::desc &src_desc,
                 const memory::desc &diff_weights_desc,
                 const memory::desc &diff_bias_desc,
                 const memory::desc &diff_dst_desc);
 
-        /// Constructs a descriptor for inner product descriptor weights
-        /// update primitive.
+        /// Constructs a descriptor for an inner product descriptor weights
+        /// update primitive without bias.
         ///
-        /// @param src_desc Memory descriptor for src.
-        /// @param diff_weights_desc Memory descriptor for diff weights.
-        /// @param diff_dst_desc Memory descriptor for diff dst.
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_weights` (#dnnl::primitive_desc_base::diff_weights_desc (`0`))
         ///
         /// @note
         ///     Memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param src_desc Memory descriptor for src.
+        /// @param diff_weights_desc Memory descriptor for diff weights.
+        /// @param diff_dst_desc Memory descriptor for diff dst.
         desc(const memory::desc &src_desc,
                 const memory::desc &diff_weights_desc,
                 const memory::desc &diff_dst_desc);
     };
 
-    /// Primitive descriptor for inner product weights update primitive.
+    /// Primitive descriptor for an inner product weights gradient primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for inner product weights update
-        /// primitive.
+        /// Constructs a primitive descriptor for an inner product weights
+        /// update primitive.
         ///
-        /// @param desc Descriptor for inner product weights update primitive.
+        /// @param desc Descriptor for an inner product weights gradient
+        ///     primitive.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for inner product
-        ///                    forward propagation primitive. It is used as a
-        ///                    hint when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for an inner product
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const inner_product_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for inner product weights update
-        /// primitive.
+        /// Constructs a primitive descriptor for an inner product weights
+        /// update primitive.
         ///
-        /// @param desc Descriptor for inner product weights update primitive.
+        /// @param desc Descriptor for an inner product weights gradient
+        ///     primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for inner product
-        ///                    forward propagation primitive. It is used as a
-        ///                    hint when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for an inner product
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const inner_product_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the diff weights memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
         memory::desc diff_weights_desc() const;
 
-        /// Returns the diff bias memory descriptor.
-        memory::desc diff_bias_desc() const;
-
-        /// Returns the diff destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
         memory::desc diff_dst_desc() const;
+
+        /// @copydoc dnnl::convolution_backward_weights::primitive_desc::diff_bias_desc()const
+        memory::desc diff_bias_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
@@ -2987,36 +4823,160 @@ struct inner_product_backward_weights : public primitive {
     inner_product_backward_weights(const primitive_desc &pd);
 };
 
+/// @} dnnl_api_inner_product
+
+/// @addtogroup dnnl_api_rnn RNN
+///
+/// A primitive to compute recurrent neural network layers.
+///
+/// @{
+
 /// Base class for primitive descriptors for RNN primitives.
 struct rnn_primitive_desc_base : public primitive_desc {
     /// Default constructor. Produces an empty object.
     rnn_primitive_desc_base();
+
+    /// Returns source layer memory descriptor.
+    /// @returns Source layer memory descriptor.
+    memory::desc src_layer_desc() const;
+
+    /// Returns source iteration memory descriptor.
+    /// @returns Source iteration memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///          source iteration parameter.
+    memory::desc src_iter_desc() const;
+
+    /// Returns source recurrent cell state memory descriptor.
+    /// @returns Source recurrent cell state memory descriptor.
+    memory::desc src_iter_c_desc() const;
+
+    /// Returns weights layer memory descriptor.
+    /// @returns Weights layer memory descriptor.
+    memory::desc weights_layer_desc() const;
+
+    /// Returns weights iteration memory descriptor.
+    /// @returns Weights iteration memory descriptor.
+    memory::desc weights_iter_desc() const;
+
+    /// Returns bias memory descriptor.
+    /// @returns Bias memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///          bias parameter.
+    memory::desc bias_desc() const;
+
+    /// Returns destination layer memory descriptor.
+    /// @returns Destination layer memory descriptor.
+    memory::desc dst_layer_desc() const;
+
+    /// Returns destination iteration memory descriptor.
+    /// @returns Destination iteration memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///          destination iteration parameter.
+    memory::desc dst_iter_desc() const;
+
+    /// Returns destination recurrent cell state memory descriptor.
+    /// @returns Destination recurrent cell state memory descriptor.
+    memory::desc dst_iter_c_desc() const;
+
+    /// Returns diff source layer memory descriptor.
+    /// @returns Diff source layer memory descriptor.
+    memory::desc diff_src_layer_desc() const;
+
+    /// Returns diff source iteration memory descriptor.
+    /// @returns Diff source iteration memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///          diff source iteration parameter.
+    memory::desc diff_src_iter_desc() const;
+
+    /// Returns diff source recurrent cell state memory descriptor.
+    /// @returns Diff source recurrent cell state memory descriptor.
+    memory::desc diff_src_iter_c_desc() const;
+
+    /// Returns diff weights layer memory descriptor.
+    /// @returns Diff weights layer memory descriptor.
+    memory::desc diff_weights_layer_desc() const;
+
+    /// Returns diff weights iteration memory descriptor.
+    /// @returns Diff weights iteration memory descriptor.
+    memory::desc diff_weights_iter_desc() const;
+
+    /// Returns diff bias memory descriptor.
+    /// @returns Diff bias memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///          diff bias parameter.
+    memory::desc diff_bias_desc() const;
+
+    /// Returns diff destination layer memory descriptor.
+    /// @returns Diff destination layer memory descriptor.
+    memory::desc diff_dst_layer_desc() const;
+
+    /// Returns diff destination iteration memory descriptor.
+    /// @returns Diff destination iteration memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///          diff destination iteration parameter.
+    memory::desc diff_dst_iter_desc() const;
+
+    /// Returns diff destination recurrent cell state memory descriptor.
+    /// @returns Diff destination recurrent cell state memory descriptor.
+    memory::desc diff_dst_iter_c_desc() const;
 };
 
 /// Vanilla RNN forward propagation primitive.
 struct vanilla_rnn_forward : public primitive {
-    /// Descriptor for vanilla RNN forward propagation primitive.
+    /// Descriptor for a vanilla RNN forward propagation primitive.
     struct desc {
-        /// Constructs a descriptor for vanilla RNN forward propagation
-        /// primitive using @p prop_kind, @p activation, @p direction, and
-        /// memory descriptors.
+        /// Constructs a descriptor for a vanilla RNN forward propagation
+        /// primitive.
         ///
-        /// If @p activation is #algorithm::eltwise_relu, @p alpha represents the
-        /// negative slope. The @p beta and @p flags are currently ignored.
+        /// The @p src_iter_desc, @p bias_desc, and @p dst_iter_desc may point
+        /// to a zero memory descriptor. This would then indicate that the RNN
+        /// forward propagation primitive should not use them and should
+        /// default to zero values instead.
         ///
-        /// The @p src_iter_desc, @p bias_desc, and @p dst_iter_desc are
-        /// allowed to point to a zero memory descriptor, which would indicate
-        /// that the primitive should not use them.
+        /// Inputs:
+        ///  - `src_layer` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `src_iter` (#dnnl::primitive_desc_base::src_desc (`1`)), if used
+        ///  - `weights_layer` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///  - `weights_iter` (#dnnl::primitive_desc_base::weights_desc (`1`))
+        ///  - `bias` (#dnnl::primitive_desc_base::weights_desc (`2`)), if used
         ///
-        /// @note
-        ///     If @p prop_kind equals #dnnl::prop_kind::forward_training, you must
-        ///     query for workspace memory descriptor before creating the
-        ///     primitive.
+        /// Outputs:
+        ///  - `dst_layer` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `dst_iter` (#dnnl::primitive_desc_base::dst_desc (`1`)), if used
+        ///  - `workspace` (#dnnl::primitive_desc_base::workspace_desc (`0`)),
+        ///     if @p prop_kind equals #dnnl::prop_kind::forward_training; must be
+        ///     queried for using @ref dnnl::primitive_desc_base::query_md() after a
+        ///     corresponding primitive descriptor is created
         ///
         /// @note
         ///     All memory descriptors except @p src_iter_desc can be
         ///     initialized with an #dnnl::memory::format_tag::any value of @p
         ///     format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param activation Activation kind. Possible values are
+        ///     #dnnl::algorithm::eltwise_relu,
+        ///     #dnnl::algorithm::eltwise_tanh, or
+        ///     #dnnl::algorithm::eltwise_logistic.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param flags Unused.
+        /// @param alpha Negative slope if activation is
+        ///     #dnnl::algorithm::eltwise_relu.
+        /// @param beta Unused.
         desc(prop_kind prop_kind, algorithm activation, rnn_direction direction,
                 const memory::desc &src_layer_desc,
                 const memory::desc &src_iter_desc,
@@ -3029,79 +4989,69 @@ struct vanilla_rnn_forward : public primitive {
                 float beta = 0.0f);
     };
 
-    /// Primitive descriptor for vanilla RNN forward propagation primitive.
+    /// Primitive descriptor for a vanilla RNN forward propagation primitive.
     struct primitive_desc : public rnn_primitive_desc_base {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for vanilla RNN forward
+        /// Constructs a primitive descriptor for a vanilla RNN forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for vanilla RNN forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a vanilla RNN forward propagation
+        ///     primitive.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for vanilla RNN forward
+        /// Constructs a primitive descriptor for a vanilla RNN forward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for vanilla RNN forward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a vanilla RNN forward propagation
+        ///     primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine, bool allow_empty = false);
 
-        /// Returns the source layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const;
 
-        /// Returns the source iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no src_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
         memory::desc src_iter_desc() const;
 
-        /// Returns the weights layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
         memory::desc weights_layer_desc() const;
 
-        /// Returns the weights iteration memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
         memory::desc weights_iter_desc() const;
 
-        /// Returns the bias memory descriptor.
-        ///
-        /// Returns a zero_md if no bias was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
         memory::desc bias_desc() const;
 
-        /// Returns the destination layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
         memory::desc dst_layer_desc() const;
 
-        /// Returns the destination iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no dst_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
         memory::desc dst_iter_desc() const;
 
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
         memory::desc workspace_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     vanilla_rnn_forward();
 
-    /// Constructs a vanilla RNN forward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs a vanilla RNN forward propagation primitive.
+    /// @param pd Primitive descriptor for a vanilla RNN forward
+    ///     propagation primitive.
     vanilla_rnn_forward(const primitive_desc &pd);
 };
 
@@ -3109,23 +5059,81 @@ struct vanilla_rnn_forward : public primitive {
 struct vanilla_rnn_backward : public primitive {
     /// Vanilla RNN descriptor backward propagation primitive.
     struct desc {
-        /// Constructs a descriptor for vanilla RNN backward propagation
-        /// primitive using @p prop_kind, @p activation, @p direction, and
-        /// memory descriptors.
+        /// Constructs a descriptor for a vanilla RNN backward propagation
+        /// primitive.
         ///
-        /// If @p activation is #algorithm::eltwise_relu, @p alpha represents the
-        /// negative slope. The @p beta and @p flags are currently ignored.
+        /// The @p src_iter_desc together with @p diff_src_iter_desc, @p
+        /// bias_desc together with @p diff_bias_desc, and @p dst_iter_desc
+        /// together with @p diff_src_iter_desc, may point to a zero memory
+        /// descriptor. This would then indicate that the RNN backward
+        /// propagation primitive should not use the respective data and
+        /// should use zero values instead.
         ///
-        /// The @p src_iter_desc (simultaneously with @p diff_src_iter_desc),
-        /// @p bias_desc (simultaneously with @p diff_bias_desc), and @p
-        /// dst_iter_desc (simultaneously with @p diff_src_iter_desc) are
-        /// allowed point to a zero memory descriptor, which would indicate
-        /// that the primitive should not use them and consider them to be
-        /// zero values.
+        /// Inputs:
+        ///  - `src_layer` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `src_iter` (#dnnl::primitive_desc_base::src_desc (`1`)), if used
+        ///  - `weights_layer` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///  - `weights_iter` (#dnnl::primitive_desc_base::weights_desc (`1`))
+        ///  - `bias` (#dnnl::primitive_desc_base::weights_desc (`2`)), if used
+        ///  - `dst_layer` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `dst_iter` (#dnnl::primitive_desc_base::dst_desc (`1`)), if used
+        ///  - `diff_dst_layer` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///  - diff_dst_iter
+        ///     (#dnnl::primitive_desc_base::diff_dst_desc (`1`)), if used
+        ///  - `workspace` (#dnnl::primitive_desc_base::workspace_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - diff_src_layer
+        ///     (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///  - diff_src_iter
+        ///     (#dnnl::primitive_desc_base::diff_src_desc (`1`)), if used
+        ///  - diff_weights_layer
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`0`))
+        ///  - diff_weights_iter
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`1`))
+        ///  - diff_bias
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`2`)), if used
         ///
         /// @note
         ///     All memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Must be
+        ///     #dnnl::prop_kind::backward.
+        /// @param activation Activation kind. Possible values are
+        ///     #dnnl::algorithm::eltwise_relu,
+        ///     #dnnl::algorithm::eltwise_tanh, or
+        ///     #dnnl::algorithm::eltwise_logistic.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param diff_src_layer_desc Memory descriptor for the diff of input
+        ///     vector.
+        /// @param diff_src_iter_desc Memory descriptor for the diff of input
+        ///     recurrent hidden state vector.
+        /// @param diff_weights_layer_desc Memory descriptor for the diff of
+        ///     weights applied to the layer input.
+        /// @param diff_weights_iter_desc Memory descriptor for the diff of
+        ///     weights applied to the recurrent input.
+        /// @param diff_bias_desc Diff bias memory descriptor.
+        /// @param diff_dst_layer_desc Memory descriptor for the diff of
+        ///     output vector.
+        /// @param diff_dst_iter_desc Memory descriptor for the diff of output
+        ///     recurrent hidden state vector.
+        /// @param flags Unused.
+        /// @param alpha Negative slope if activation is
+        ///     #dnnl::algorithm::eltwise_relu.
+        /// @param beta Unused.
         desc(prop_kind prop_kind, algorithm activation, rnn_direction direction,
                 const memory::desc &src_layer_desc,
                 const memory::desc &src_iter_desc,
@@ -3145,141 +5153,157 @@ struct vanilla_rnn_backward : public primitive {
                 float beta = 0.0f);
     };
 
-    /// Primitive descriptor for RNN backward propagation primitive.
+    /// Primitive descriptor for a RNN backward propagation primitive.
     struct primitive_desc : public rnn_primitive_desc_base {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for vanilla RNN backward
+        /// Constructs a primitive descriptor for a vanilla RNN backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for vanilla RNN backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a vanilla RNN backward propagation
+        ///     primitive.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for vanilla RNN
-        ///                    forward propagation primitive. It is used as a
-        ///                    hint when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a vanilla RNN
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const vanilla_rnn_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for vanilla RNN backward
+        /// Constructs a primitive descriptor for a vanilla RNN backward
         /// propagation primitive.
         ///
-        /// @param desc Descriptor for vanilla RNN backward propagation
-        ///             primitive.
+        /// @param desc Descriptor for a vanilla RNN backward propagation
+        ///     primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for vanilla RNN
-        ///                    forward propagation primitive. It is used as a
-        ///                    hint when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a vanilla RNN
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const vanilla_rnn_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the source layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const;
 
-        /// Returns the source iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no src_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
         memory::desc src_iter_desc() const;
 
-        /// Returns the weights layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
         memory::desc weights_layer_desc() const;
 
-        /// Returns the weights iteration memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
         memory::desc weights_iter_desc() const;
 
-        /// Returns the bias memory descriptor.
-        ///
-        /// Returns a zero_md if no bias was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
         memory::desc bias_desc() const;
 
-        /// Returns the destination layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
         memory::desc dst_layer_desc() const;
 
-        /// Returns the destination iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no dst_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
         memory::desc dst_iter_desc() const;
 
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
         memory::desc workspace_desc() const;
 
-        /// Returns the diff source layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
         memory::desc diff_src_layer_desc() const;
 
-        /// Returns the diff source iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no diff_src_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
         memory::desc diff_src_iter_desc() const;
 
-        /// Returns the diff weights layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
         memory::desc diff_weights_layer_desc() const;
 
-        /// Returns the diff weights iteration memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
         memory::desc diff_weights_iter_desc() const;
 
-        /// Returns the diff bias memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
         memory::desc diff_bias_desc() const;
 
-        /// Returns the diff destination layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
         memory::desc diff_dst_layer_desc() const;
 
-        /// Returns the diff destination iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no diff_dst_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
         memory::desc diff_dst_iter_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     vanilla_rnn_backward();
 
-    /// Constructs a vanilla RNN backward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs a vanilla RNN backward propagation primitive.
+    /// @param pd Primitive descriptor for a vanilla RNN backward
+    ///     propagation primitive.
     vanilla_rnn_backward(const primitive_desc &pd);
 };
 
 /// LSTM forward propagation primitive.
 struct lstm_forward : public primitive {
-    /// Descriptor for LSTM forward propagation primitive.
+    /// Descriptor for an LSTM forward propagation primitive.
     struct desc {
-        /// Constructs a descriptor for LSTM forward propagation primitive
-        /// using @p prop_kind, @p direction, and memory descriptors.
-        ///
-        /// The @p flags parameter is currently ignored.
+        /// Constructs a descriptor for an LSTM forward propagation primitive.
         ///
         /// The @p src_iter_desc, @p src_iter_c_desc, @p bias_desc, @p
-        /// dst_iter_desc and @p dst_iter_c_desc are allowed to point
-        /// to a zero memory descriptor, which would indicate that the
-        /// LSTM forward propagation primitive should not use them.
+        /// dst_iter_desc, and @p dst_iter_c_desc may point to a zero memory
+        /// descriptor. This would then indicate that the LSTM forward
+        /// propagation primitive should not use them and should default to
+        /// zero values instead.
+        ///
+        /// Inputs:
+        ///  - `src_layer` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `src_iter` (#dnnl::primitive_desc_base::src_desc (`1`)), if used
+        ///  - `src_iter_c` (#dnnl::primitive_desc_base::src_desc (`2`)), if used
+        ///  - `weights_layer` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///  - `weights_iter` (#dnnl::primitive_desc_base::weights_desc (`1`))
+        ///  - `bias` (#dnnl::primitive_desc_base::weights_desc (`2`)), if used
+        ///
+        /// Outputs:
+        ///  - `dst_layer` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `dst_iter` (#dnnl::primitive_desc_base::dst_desc (`1`)), if used
+        ///  - `dst_iter_c` (#dnnl::primitive_desc_base::dst_desc (`2`)), if used
+        ///  - `workspace` (#dnnl::primitive_desc_base::workspace_desc (`0`)),
+        ///     if @p prop_kind equals #dnnl::prop_kind::forward_training; must be
+        ///     queried for using @ref dnnl::primitive_desc_base::query_md() after a
+        ///     corresponding primitive descriptor is created
         ///
         /// @note
         ///     All memory descriptors except @p src_iter_desc can be
         ///     initialized with an #dnnl::memory::format_tag::any value of @p
         ///     format_tag.
         ///
-        /// @note
-        ///     If @p prop_kind equals #dnnl::prop_kind::forward_training, you must query
-        ///     for workspace memory descriptor before creating the primitive.
-        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param src_iter_c_desc Memory descriptor for the input recurrent
+        ///     cell state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param dst_iter_c_desc Memory descriptor for the output recurrent
+        ///     cell state vector.
+        /// @param flags Unused.
         desc(prop_kind prop_kind, rnn_direction direction,
                 const memory::desc &src_layer_desc,
                 const memory::desc &src_iter_desc,
@@ -3293,108 +5317,162 @@ struct lstm_forward : public primitive {
                 rnn_flags flags = rnn_flags::undef);
     };
 
-    /// Primitive descriptor for LSTM forward propagation primitive.
+    /// Primitive descriptor for an LSTM forward propagation primitive.
     struct primitive_desc : public rnn_primitive_desc_base {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for LSTM forward propagation
+        /// Constructs a primitive descriptor for an LSTM forward propagation
         /// primitive.
         ///
-        /// @param desc Descriptor for LSTM forward propagation primitive.
+        /// @param desc Descriptor for an LSTM forward propagation primitive.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for LSTM forward propagation
+        /// Constructs a primitive descriptor for an LSTM forward propagation
         /// primitive.
         ///
-        /// @param desc Descriptor for LSTM forward propagation primitive.
+        /// @param desc Descriptor for an LSTM forward propagation primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine, bool allow_empty = false);
 
-        /// Returns the source layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const;
 
-        /// Returns the source recurrent hidden state memory descriptor.
-        ///
-        /// Returns a zero_md if no src_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
         memory::desc src_iter_desc() const;
 
-        /// Returns the source recurrent cell state memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
         memory::desc src_iter_c_desc() const;
 
-        /// Returns the weights layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
         memory::desc weights_layer_desc() const;
 
-        /// Returns the weights iteration memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
         memory::desc weights_iter_desc() const;
 
-        /// Returns the bias memory descriptor.
-        ///
-        /// Returns a zero_md if no bias was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
         memory::desc bias_desc() const;
 
-        /// Returns the destination layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
         memory::desc dst_layer_desc() const;
 
-        /// Returns the destination recurrent hidden state memory descriptor.
-        ///
-        /// Returns a zero_md if no dst_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
         memory::desc dst_iter_desc() const;
 
-        /// Returns the destination recurrent cell state memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
         memory::desc dst_iter_c_desc() const;
 
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
         memory::desc workspace_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     lstm_forward();
 
-    /// Constructs an LSTM forward propagation primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs an LSTM forward propagation primitive.
+    /// @param pd Primitive descriptor for an LSTM forward propagation
+    ///     primitive.
     lstm_forward(const primitive_desc &pd);
 };
 
 /// LSTM backward propagation primitive.
 struct lstm_backward : public primitive {
-    /// Descriptor for LSTM backward propagation primitive.
+    /// Descriptor for an LSTM backward propagation primitive.
     struct desc {
         /// Constructs an LSTM descriptor for backward propagation using @p
         /// prop_kind, @p direction, and memory descriptors.
         ///
-        /// The @p flags parameter is currently ignored.
+        /// The @p src_iter_desc together with @p diff_iter_desc, @p
+        /// src_iter_c_desc together with @p src_iter_c_desc, @p bias_desc
+        /// together with @p diff_bias_desc, @p dst_iter_desc together with @p
+        /// diff_dst_iter_desc, and @p dst_iter_c_desc together with @p
+        /// diff_dst_iter_c_desc, may point to a zero memory descriptor. This
+        /// would then indicate that the LSTM backward propagation primitive
+        /// should not use them and should default to zero values instead.
         ///
-        /// The @p src_iter_desc (simultaneously with @p diff_src_iter_desc),
-        /// @p src_iter_c_desc (simultaneously with @p diff_src_iter_c_desc),
-        /// @p bias_desc (simultaneously with @p diff_bias_desc), @p
-        /// dst_iter_desc (simultaneously with @p diff_src_iter_desc) and @p
-        /// dst_iter_c_desc (simultaneously with @p diff_src_iter_c_desc) are
-        /// allowed point to a zero memory descriptor, which would indicate
-        /// that the LSTM primitive should not use them and consider them to
-        /// be zero values.
+        /// Inputs:
+        ///  - `src_layer` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `src_iter` (#dnnl::primitive_desc_base::src_desc (`1`)), if used
+        ///  - `src_iter_c` (#dnnl::primitive_desc_base::src_desc (`2`)), if used
+        ///  - `weights_layer` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///  - `weights_iter` (#dnnl::primitive_desc_base::weights_desc (`1`))
+        ///  - `bias` (#dnnl::primitive_desc_base::weights_desc (`2`)), if used
+        ///  - `dst_layer` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `dst_iter` (#dnnl::primitive_desc_base::dst_desc (`1`)), if used
+        ///  - `dst_iter_c` (#dnnl::primitive_desc_base::dst_desc (`2`)), if used
+        ///  - `diff_dst_layer` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///  - diff_dst_iter
+        ///     (#dnnl::primitive_desc_base::diff_dst_desc (`1`)), if used
+        ///  - diff_dst_iter_c
+        ///     (#dnnl::primitive_desc_base::diff_dst_desc (`2`)), if used
+        ///  - `workspace` (#dnnl::primitive_desc_base::workspace_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_src_layer` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///  - diff_src_iter
+        ///     (#dnnl::primitive_desc_base::diff_src_desc (`1`)), if used
+        ///  - diff_src_iter_c
+        ///     (#dnnl::primitive_desc_base::diff_src_desc (`2`)), if used
+        ///  - diff_weights_layer
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`0`))
+        ///  - diff_weights_iter
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`1`))
+        ///  - diff_bias
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`2`)), if used
         ///
         /// @note
         ///     All memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
         ///
+        /// @param prop_kind Propagation kind. Must be
+        ///     #dnnl::prop_kind::backward.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param src_iter_c_desc Memory descriptor for the input recurrent
+        ///     cell state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param dst_iter_c_desc Memory descriptor for the output recurrent
+        ///     cell state vector.
+        /// @param diff_src_layer_desc Memory descriptor for the diff of input
+        ///     vector.
+        /// @param diff_src_iter_desc Memory descriptor for the diff of input
+        ///     recurrent hidden state vector.
+        /// @param diff_src_iter_c_desc Memory descriptor for the diff of
+        ///     input recurrent cell state vector.
+        /// @param diff_weights_layer_desc Memory descriptor for the diff of
+        ///     weights applied to the layer input.
+        /// @param diff_weights_iter_desc Memory descriptor for the diff of
+        ///     weights applied to the recurrent input.
+        /// @param diff_bias_desc Diff bias memory descriptor.
+        /// @param diff_dst_layer_desc Memory descriptor for the diff of
+        ///     output vector.
+        /// @param diff_dst_iter_desc Memory descriptor for the diff of output
+        ///     recurrent hidden state vector.
+        /// @param diff_dst_iter_c_desc Memory descriptor for the diff of
+        ///     output recurrent cell state vector.
+        /// @param flags Unused.
         desc(prop_kind prop_kind, rnn_direction direction,
                 const memory::desc &src_layer_desc,
                 const memory::desc &src_iter_desc,
@@ -3417,151 +5495,160 @@ struct lstm_backward : public primitive {
                 rnn_flags flags = rnn_flags::undef);
     };
 
-    /// Primitive descriptor for LSTM backward propagation primitive.
+    /// Primitive descriptor for LSTM backward propagation.
     struct primitive_desc : public rnn_primitive_desc_base {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for LSTM forward propagation
+        /// Constructs a primitive descriptor for an LSTM backward propagation
         /// primitive.
         ///
-        /// @param desc Descriptor for LSTM forward propagation primitive.
+        /// @param desc Descriptor for LSTM backward propagation primitive.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for LSTM
-        ///                    forward propagation primitive. It is used as a
-        ///                    hint when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for an LSTM
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const lstm_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for LSTM forward propagation
+        /// Constructs a primitive descriptor for an LSTM backward propagation
         /// primitive.
         ///
-        /// @param desc Descriptor for LSTM forward propagation primitive.
+        /// @param desc Descriptor for an LSTM backward propagation primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for LSTM
-        ///                    forward propagation primitive. It is used as a
-        ///                    hint when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for an LSTM
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const lstm_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the source layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const;
 
-        /// Returns the source recurrent hidden state memory descriptor.
-        ///
-        /// Returns a zero_md if no src_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
         memory::desc src_iter_desc() const;
 
-        /// Returns the source recurrent cell state memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
         memory::desc src_iter_c_desc() const;
 
-        /// Returns the weights layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
         memory::desc weights_layer_desc() const;
 
-        /// Returns the weights iteration memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
         memory::desc weights_iter_desc() const;
 
-        /// Returns the bias memory descriptor.
-        ///
-        /// Returns a zero_md if no bias was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
         memory::desc bias_desc() const;
 
-        /// Returns the destination layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
         memory::desc dst_layer_desc() const;
 
-        /// Returns the destination recurrent hidden state memory descriptor.
-        ///
-        /// Returns a zero_md if no dst_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
         memory::desc dst_iter_desc() const;
 
-        /// Returns the destination recurrent cell state memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
         memory::desc dst_iter_c_desc() const;
 
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
         memory::desc workspace_desc() const;
 
-        /// Returns the diff source layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
         memory::desc diff_src_layer_desc() const;
 
-        /// Returns the diff source recurrent hidden state memory descriptor.
-        ///
-        /// Returns a zero_md if no diff_src_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
         memory::desc diff_src_iter_desc() const;
 
-        /// Returns the diff source recurrent cell state memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_c_desc()const
         memory::desc diff_src_iter_c_desc() const;
 
-        /// Returns the diff weights layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
         memory::desc diff_weights_layer_desc() const;
 
-        /// Returns the diff weights iteration memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
         memory::desc diff_weights_iter_desc() const;
 
-        /// Returns the diff bias memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
         memory::desc diff_bias_desc() const;
 
-        /// Returns the diff destination layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
         memory::desc diff_dst_layer_desc() const;
 
-        /// Returns the diff destination recurrent hidden state memory descriptor.
-        ///
-        /// Returns a zero_md if no diff_dst_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
         memory::desc diff_dst_iter_desc() const;
 
-        /// Returns the diff destination recurrent cell state memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_c_desc()const
         memory::desc diff_dst_iter_c_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     lstm_backward();
 
-    /// Constructs a vanilla RNN backward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs an LSTM backward propagation primitive.
+    /// @param pd Primitive descriptor for an LSTM backward propagation
+    ///     primitive.
     lstm_backward(const primitive_desc &pd);
 };
 
 /// GRU forward propagation primitive.
 struct gru_forward : public primitive {
-    /// Descriptor for GRU forward propagation primitive.
+    /// Descriptor for a GRU forward propagation primitive.
     struct desc {
-        /// Constructs a descriptor for GRU forward propagation primitive
-        /// using @p prop_kind, @p direction, and memory descriptors.
+        /// Constructs a descriptor for a GRU forward propagation primitive.
         ///
-        /// The @p flags parameter is currently ignored.
+        /// The @p src_iter_desc, @p bias_desc, and @p dst_iter, may point to
+        /// a zero memory descriptor. This would then indicate that the GRU
+        /// forward propagation primitive should not use them and should
+        /// default to zero values instead.
         ///
-        /// The @p src_iter_desc, @p bias_desc, and @p dst_iter_desc are allowed
-        /// to point to a zero memory descriptor, which would indicate that
-        /// the GRU primitive should not use them and will default to zero
-        /// values.
+        /// Inputs:
+        ///  - `src_layer` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `src_iter` (#dnnl::primitive_desc_base::src_desc (`1`)), if used
+        ///  - `weights_layer` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///  - `weights_iter` (#dnnl::primitive_desc_base::weights_desc (`1`))
+        ///  - `bias` (#dnnl::primitive_desc_base::weights_desc (`2`)), if used
+        ///
+        /// Outputs:
+        ///  - `dst_layer` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `dst_iter` (#dnnl::primitive_desc_base::dst_desc (`1`)), if used
+        ///  - `workspace` (#dnnl::primitive_desc_base::workspace_desc (`0`)),
+        ///     if @p prop_kind equals #dnnl::prop_kind::forward_training; must be
+        ///     queried for using @ref dnnl::primitive_desc_base::query_md() after a
+        ///     corresponding primitive descriptor is created
         ///
         /// @note
         ///     All memory descriptors except @p src_iter_desc can be
         ///     initialized with an #dnnl::memory::format_tag::any value of @p
         ///     format_tag.
         ///
-        /// @note
-        ///     If @p prop_kind equals #dnnl::prop_kind::forward_training, you must query
-        ///     a workspace memory descriptor before creating the primitive.
-        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param flags Unused.
         desc(prop_kind prop_kind, rnn_direction direction,
                 const memory::desc &src_layer_desc,
                 const memory::desc &src_iter_desc,
@@ -3578,94 +5665,135 @@ struct gru_forward : public primitive {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for GRU forward propagation
+        /// Constructs a primitive descriptor for a GRU forward propagation
         /// primitive.
         ///
-        /// @param desc Descriptor for GRU forward propagation primitive.
+        /// @param desc Descriptor for a GRU forward propagation primitive.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for GRU forward propagation
+        /// Constructs a primitive descriptor for a GRU forward propagation
         /// primitive.
         ///
-        /// @param desc Descriptor for GRU forward propagation primitive.
+        /// @param desc Descriptor for a GRU forward propagation primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine, bool allow_empty = false);
 
-        /// Returns the source layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const;
 
-        /// Returns the source iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no src_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
         memory::desc src_iter_desc() const;
 
-        /// Returns the weights layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
         memory::desc weights_layer_desc() const;
 
-        /// Returns the weights iteration memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
         memory::desc weights_iter_desc() const;
 
-        /// Returns the bias memory descriptor.
-        ///
-        /// Returns a zero_md if no bias was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
         memory::desc bias_desc() const;
 
-        /// Returns the destination layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
         memory::desc dst_layer_desc() const;
 
-        /// Returns the destination iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no dst_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
         memory::desc dst_iter_desc() const;
 
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
         memory::desc workspace_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     gru_forward();
 
-    /// Constructs a GRU forward propagation primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs a GRU forward propagation primitive.
+    /// @param pd Primitive descriptor for a GRU forward propagation
+    ///     primitive.
     gru_forward(const primitive_desc &pd);
 };
 
 /// GRU backward propagation primitive.
 struct gru_backward : public primitive {
-    /// Descriptor for GRU backward propagation primitive.
+    /// Descriptor for a GRU backward propagation primitive.
     struct desc {
-        /// Constructs a descriptor for GRU backward propagation primitive
-        /// using @p prop_kind, @p direction, and memory descriptors.
+        /// Constructs a descriptor for a GRU backward propagation primitive.
         ///
-        /// The @p flags parameter is ignored.
+        /// The @p src_iter_desc together with @p diff_src_iter_desc, @p
+        /// bias_desc together with @p diff_bias_desc, and @p dst_iter
+        /// together with @p diff_dst_iter, may point to a zero memory
+        /// descriptor.  This would then indicate that the GRU backward
+        /// propagation primitive should not use them and should default to
+        /// zero values instead.
         ///
-        /// The @p src_iter_desc (simultaneously with @p diff_src_iter_desc),
-        /// @p bias_desc (simultaneously with @p diff_bias_desc), and @p
-        /// dst_iter_desc (simultaneously with @p diff_src_iter_desc) are
-        /// allowed point to a zero memory descriptor, which would indicate
-        /// that the GRU primitive should not use them and consider them to be
-        /// zero values.
+        /// Inputs:
+        ///  - `src_layer` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `src_iter` (#dnnl::primitive_desc_base::src_desc (`1`)), if used
+        ///  - `weights_layer` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///  - `weights_iter` (#dnnl::primitive_desc_base::weights_desc (`1`))
+        ///  - `bias` (#dnnl::primitive_desc_base::weights_desc (`2`)), if used
+        ///  - `dst_layer` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `dst_iter` (#dnnl::primitive_desc_base::dst_desc (`1`)), if used
+        ///  - `diff_dst_layer` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///  - diff_dst_iter
+        ///     (#dnnl::primitive_desc_base::diff_dst_desc (`1`)), if used
+        ///  - `workspace` (#dnnl::primitive_desc_base::workspace_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_src_layer` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///  - diff_src_iter
+        ///     (#dnnl::primitive_desc_base::diff_src_desc (`1`)), if used
+        ///  - diff_weights_layer
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`0`))
+        ///  - diff_weights_iter
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`1`))
+        ///  - diff_bias
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`2`)), if used
         ///
         /// @note
         ///     All memory descriptors are allowed to be initialized with
         ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Must be
+        ///     #dnnl::prop_kind::backward.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param diff_src_layer_desc Memory descriptor for the diff of input
+        ///     vector.
+        /// @param diff_src_iter_desc Memory descriptor for the diff of input
+        ///     recurrent hidden state vector.
+        /// @param diff_weights_layer_desc Memory descriptor for the diff of
+        ///     weights applied to the layer input.
+        /// @param diff_weights_iter_desc Memory descriptor for the diff of
+        ///     weights applied to the recurrent input.
+        /// @param diff_bias_desc Diff bias memory descriptor.
+        /// @param diff_dst_layer_desc Memory descriptor for the diff of
+        ///     output vector.
+        /// @param diff_dst_iter_desc Memory descriptor for the diff of output
+        ///     recurrent hidden state vector.
+        /// @param flags Unused.
         desc(prop_kind prop_kind, rnn_direction direction,
                 const memory::desc &src_layer_desc,
                 const memory::desc &src_iter_desc,
@@ -3684,139 +5812,149 @@ struct gru_backward : public primitive {
                 rnn_flags flags = rnn_flags::undef);
     };
 
-    /// Primitive descriptor for GRU backward propagation primitive.
+    /// Primitive descriptor for a GRU backward propagation primitive.
     struct primitive_desc : public rnn_primitive_desc_base {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for GRU forward propagation
+        /// Constructs a primitive descriptor for a GRU backward propagation
         /// primitive.
         ///
-        /// @param desc Descriptor for GRU forward propagation primitive.
+        /// @param desc Descriptor for a GRU backward propagation primitive.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for GRU
-        ///                    forward propagation primitive. It is used as a
-        ///                    hint when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a GRU
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const gru_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for GRU forward propagation
+        /// Constructs a primitive descriptor for a GRU backward propagation
         /// primitive.
         ///
-        /// @param desc Descriptor for GRU forward propagation primitive.
+        /// @param desc Descriptor for a GRU backward propagation primitive.
         /// @param attr Primitive attributes to use.
         /// @param engine Engine to use.
-        /// @param hint_fwd_pd Primitive descriptor for GRU
-        ///                    forward propagation primitive. It is used as a
-        ///                    hint when deciding which memory format to use.
+        /// @param hint_fwd_pd Primitive descriptor for a GRU
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const gru_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the source layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const;
 
-        /// Returns the source iter memory descriptor.
-        ///
-        /// Returns a zero_md if no src_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
         memory::desc src_iter_desc() const;
 
-        /// Returns the weights layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
         memory::desc weights_layer_desc() const;
 
-        /// Returns the weights iteration memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
         memory::desc weights_iter_desc() const;
 
-        /// Returns the bias memory descriptor.
-        ///
-        /// Returns a zero_md if no bias was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
         memory::desc bias_desc() const;
 
-        /// Returns the destination layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
         memory::desc dst_layer_desc() const;
 
-        /// Returns the destination iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no dst_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
         memory::desc dst_iter_desc() const;
 
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
         memory::desc workspace_desc() const;
 
-        /// Returns the diff source layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
         memory::desc diff_src_layer_desc() const;
 
-        /// Returns the diff source iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no diff_src_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
         memory::desc diff_src_iter_desc() const;
 
-        /// Returns the diff weights layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
         memory::desc diff_weights_layer_desc() const;
 
-        /// Returns the diff weights iteration memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
         memory::desc diff_weights_iter_desc() const;
 
-        /// Returns the diff bias memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
         memory::desc diff_bias_desc() const;
 
-        /// Returns the diff destination layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
         memory::desc diff_dst_layer_desc() const;
 
-        /// Returns the diff destination iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no diff_dst_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
         memory::desc diff_dst_iter_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     gru_backward();
 
-    /// Constructs a vanilla RNN backward propagation primitive from a
-    /// primitive descriptor @p pd of a corresponding type.
+    /// Constructs a GRU backward propagation primitive.
+    /// @param pd Primitive descriptor for a GRU backward propagation
+    ///     primitive.
     gru_backward(const primitive_desc &pd);
 };
 
 /// LBR GRU forward propagation primitive.
 struct lbr_gru_forward : public primitive {
-    /// Descriptor for LBR GRU forward propagation primitive.
+    /// Descriptor for an LBR GRU forward propagation primitive.
     struct desc {
-        /// Constructs an LBR GRU descriptor for forward propagation using @p
-        /// prop_kind, @p direction, and memory descriptors.
+        /// Constructs a descriptor for LBR GRU forward propagation primitive.
         ///
-        /// The @p flags parameter is currently ignored.
+        /// The @p src_iter_desc, @p bias_desc, and @p dst_iter, may point to
+        /// a zero memory descriptor. This would then indicate that the LBR
+        /// GRU forward propagation primitive should not use them and should
+        /// default to zero values instead.
         ///
-        /// The @p src_iter_desc, @p bias_desc, and @p dst_iter_desc are allowed
-        /// to point to a zero memory descriptor, which would indicate that
-        /// the LBR GRU primitive should not use them and will default to zero
-        /// values.
+        /// Inputs:
+        ///  - `src_layer` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `src_iter` (#dnnl::primitive_desc_base::src_desc (`1`)), if used
+        ///  - `weights_layer` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///  - `weights_iter` (#dnnl::primitive_desc_base::weights_desc (`1`))
+        ///  - `bias` (#dnnl::primitive_desc_base::weights_desc (`2`)), if used
+        ///
+        /// Outputs:
+        ///  - `dst_layer` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `dst_iter` (#dnnl::primitive_desc_base::dst_desc (`1`)), if used
+        ///  - `workspace` (#dnnl::primitive_desc_base::workspace_desc (`0`)),
+        ///     if @p prop_kind equals #dnnl::prop_kind::forward_training;
+        ///     must be queried for using @ref
+        ///     dnnl::primitive_desc_base::query_md() after a corresponding
+        ///     primitive descriptor is created
         ///
         /// @note
         ///     All memory descriptors except @p src_iter_desc can be
         ///     initialized with an #dnnl::memory::format_tag::any value of @p
         ///     format_tag.
         ///
-        /// @note
-        ///     If @p prop_kind equals #dnnl::prop_kind::forward_training, you must query
-        ///     a workspace memory descriptor before creating the primitive.
-        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param flags Unused.
         desc(prop_kind prop_kind, rnn_direction direction,
                 const memory::desc &src_layer_desc,
                 const memory::desc &src_iter_desc,
@@ -3828,90 +5966,144 @@ struct lbr_gru_forward : public primitive {
                 rnn_flags flags = rnn_flags::undef);
     };
 
-    /// Primitive descriptor for LBR GRU forward propagation primitive.
+    /// Primitive descriptor for an LBR GRU forward propagation primitive.
     struct primitive_desc : public rnn_primitive_desc_base {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for LBR GRU forward propagation
-        /// primitive from a corresponding operation descriptor @p desc using
-        /// engine @p engine. The @p allow_empty flag signifies whether
-        /// construction is allowed to fail, in which case an empty primitive
-        /// would be produced.
+        /// Constructs a primitive descriptor for a LBR GRU forward
+        /// propagation primitive.
+        ///
+        /// @param desc Descriptor for a LBR GRU forward propagation
+        ///     primitive.
+        /// @param engine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for LBR GRU forward propagation
-        /// primitive from a corresponding operation descriptor @p desc using
-        /// engine @p engine, and primitive attributes @p attr. The @p
-        /// allow_empty flag signifies whether construction is allowed to
-        /// fail, in which case an empty primitive would be produced.
+        /// Constructs a primitive descriptor for a LBR GRU forward
+        /// propagation primitive.
+        ///
+        /// @param desc Descriptor for a LBR GRU forward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param engine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine, bool allow_empty = false);
 
-        /// Returns the source layer memory descriptor.
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const;
 
-        /// Returns the source iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no src_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
         memory::desc src_iter_desc() const;
 
-        /// Returns the weights layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
         memory::desc weights_layer_desc() const;
 
-        /// Returns the weights iteration memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
         memory::desc weights_iter_desc() const;
 
-        /// Returns the bias memory descriptor.
-        ///
-        /// Returns a zero_md if no bias was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
         memory::desc bias_desc() const;
 
-        /// Returns the destination layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
         memory::desc dst_layer_desc() const;
 
-        /// Returns the destination iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no dst_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
         memory::desc dst_iter_desc() const;
 
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
         memory::desc workspace_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     lbr_gru_forward();
 
-    /// Constructs a LBR GRU forward propagation primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs an LBR GRU forward propagation primitive.
+    /// @param pd Primitive descriptor for an LBR GRU forward propagation
+    ///     primitive.
     lbr_gru_forward(const primitive_desc &pd);
 };
 
 /// LBR GRU backward propagation primitive.
 struct lbr_gru_backward : public primitive {
-    /// LBR_GRU descriptor for backward propagation primitive.
+    /// Descriptor for a LBR GRU backward propagation primitive.
     struct desc {
-        /// Constructs a descriptor LBR_GRU backward propagation primitive
-        /// using @p prop_kind, @p direction, and memory descriptors.
+        /// Constructs a descriptor for LBR GRU backward propagation
+        /// primitive.
         ///
-        /// The @p flags parameter is currently ignored.
+        /// The @p src_iter_desc together with @p diff_src_iter_desc, @p
+        /// bias_desc together with @p diff_bias_desc, and @p dst_iter
+        /// together with @p diff_dst_iter, may point to a zero memory
+        /// descriptor.  This would then indicate that the LBR GRU backward
+        /// propagation primitive should not use them and should default to
+        /// zero values instead.
         ///
-        /// The @p src_iter_desc (simultaneously with @p diff_src_iter_desc),
-        /// @p bias_desc (simultaneously with @p diff_bias_desc), and @p
-        /// dst_iter_desc (simultaneously with @p diff_src_iter_desc) are
-        /// allowed point to a zero memory descriptor, which would indicate
-        /// that the LBR GRU primitive should not use them and consider them
-        /// to be zero values.
+        /// Inputs:
+        ///  - `src_layer` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `src_iter` (#dnnl::primitive_desc_base::src_desc (`1`)), if used
+        ///  - `weights_layer` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///  - `weights_iter` (#dnnl::primitive_desc_base::weights_desc (`1`))
+        ///  - `bias` (#dnnl::primitive_desc_base::weights_desc (`2`)), if used
+        ///  - `dst_layer` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///  - `dst_iter` (#dnnl::primitive_desc_base::dst_desc (`1`)), if used
+        ///  - `diff_dst_layer` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///  - diff_dst_iter
+        ///     (#dnnl::primitive_desc_base::diff_dst_desc (`1`)), if used
+        ///  - `workspace` (#dnnl::primitive_desc_base::workspace_desc (`0`))
         ///
-        /// @note All memory descriptors are allowed to be initialized with
-        ///       #dnnl::memory::format_tag::any value of @p format_tag.
+        /// Outputs:
+        ///  - `diff_src_layer` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///  - diff_src_iter
+        ///     (#dnnl::primitive_desc_base::diff_src_desc (`1`)), if used
+        ///  - diff_weights_layer
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`0`))
+        ///  - diff_weights_iter
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`1`))
+        ///  - diff_bias
+        ///     (#dnnl::primitive_desc_base::diff_weights_desc (`2`)), if used
         ///
+        /// @note
+        ///     All memory descriptors are allowed to be initialized with
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Must be
+        ///     #dnnl::prop_kind::backward.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param diff_src_layer_desc Memory descriptor for the diff of input
+        ///     vector.
+        /// @param diff_src_iter_desc Memory descriptor for the diff of input
+        ///     recurrent hidden state vector.
+        /// @param diff_weights_layer_desc Memory descriptor for the diff of
+        ///     weights applied to the layer input.
+        /// @param diff_weights_iter_desc Memory descriptor for the diff of
+        ///     weights applied to the recurrent input.
+        /// @param diff_bias_desc Diff bias memory descriptor.
+        /// @param diff_dst_layer_desc Memory descriptor for the diff of
+        ///     output vector.
+        /// @param diff_dst_iter_desc Memory descriptor for the diff of output
+        ///     recurrent hidden state vector.
+        /// @param flags Unused.
         desc(prop_kind prop_kind, rnn_direction direction,
                 const memory::desc &src_layer_desc,
                 const memory::desc &src_iter_desc,
@@ -3930,190 +6122,251 @@ struct lbr_gru_backward : public primitive {
                 rnn_flags flags = rnn_flags::undef);
     };
 
-    /// Primitive descriptor for LBR GRU backward propagation primitive.
+    /// Primitive descriptor for an LBR GRU backward propagation primitive.
     struct primitive_desc : public rnn_primitive_desc_base {
         /// Default constructor. Produces an empty object.
-        primitive_desc();
+        primitive_desc() = default;
 
-        /// Constructs a primitive descriptor for LBR GRU backward propagation
-        /// primitive from a corresponding operation descriptor @p desc using
-        /// engine @p engine, and LBR GRU forward propagation primitive
-        /// descriptor hint @p hint_fwd_pd. The @p allow_empty flag signifies
-        /// whether construction is allowed to fail, in which case an empty
-        /// primitive would be produced..
+        /// Constructs a primitive descriptor for an LBR GRU backward
+        /// propagation primitive.
+        ///
+        /// @param desc Descriptor for an LBR GRU backward propagation
+        ///     primitive.
+        /// @param engine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an LBR GRU
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const lbr_gru_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for LBR GRU backward propagation
-        /// primitive from a corresponding operation descriptor @p desc using
-        /// engine @p engine, LBR GRU forward propagation primitive descriptor
-        /// hint @p hint_fwd_pd, and primitive attributes @p attr. The @p
-        /// allow_empty flag signifies whether construction is allowed to
-        /// fail, in which case an empty primitive would be produced.
+        /// Constructs a primitive descriptor for an LBR GRU backward
+        /// propagation primitive.
+        ///
+        /// @param desc Descriptor for an LBR GRU backward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param engine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an LBR GRU
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine,
                 const lbr_gru_forward::primitive_desc &hint_fwd_pd,
                 bool allow_empty = false);
 
-        /// Returns the source layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const;
 
-        /// Returns the source iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no src_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
         memory::desc src_iter_desc() const;
 
-        /// Returns the weights layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
         memory::desc weights_layer_desc() const;
 
-        /// Returns the weights iteration memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
         memory::desc weights_iter_desc() const;
 
-        /// Returns the bias memory descriptor.
-        ///
-        /// Returns a zero_md if no bias was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
         memory::desc bias_desc() const;
 
-        /// Returns the destination layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
         memory::desc dst_layer_desc() const;
 
-        /// Returns the destination iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no dst_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
         memory::desc dst_iter_desc() const;
 
-        /// Returns the workspace memory descriptor.
-        ///
-        /// Returns a zero_md if no workspace is required.
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
         memory::desc workspace_desc() const;
 
-        /// Returns the diff source layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
         memory::desc diff_src_layer_desc() const;
 
-        /// Returns the diff source iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no diff_src_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
         memory::desc diff_src_iter_desc() const;
 
-        /// Returns the diff weights layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
         memory::desc diff_weights_layer_desc() const;
 
-        /// Returns the diff weights iteration memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
         memory::desc diff_weights_iter_desc() const;
 
-        /// Returns the diff bias memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
         memory::desc diff_bias_desc() const;
 
-        /// Returns the diff destination layer memory descriptor.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
         memory::desc diff_dst_layer_desc() const;
 
-        /// Returns the diff destination iteration memory descriptor.
-        ///
-        /// Returns a zero_md if no diff_dst_iter was specified at op_desc
-        /// creation time.
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
         memory::desc diff_dst_iter_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     lbr_gru_backward();
 
-    /// Constructs a LBR GRU backward propagation primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs an LBR GRU backward propagation primitive.
+    /// @param pd Primitive descriptor for an LBR GRU backward propagation
+    ///     primitive.
     lbr_gru_backward(const primitive_desc &pd);
 };
 
+/// @} dnnl_api_rnn
+
+/// @addtogroup dnnl_api_shuffle Shuffle
+///
+/// A primitive to shuffle tensor data along an axis.
+///
+/// @{
+
 /// Shuffle forward propagation primitive.
 struct shuffle_forward : public primitive {
-    /// Descriptor for shuffle forward propagation primitive.
+    /// Descriptor for a shuffle forward propagation primitive.
     struct desc {
-        /// Constructs a descriptor shuffle forward propagation primitive
-        /// using @p prop_kind, memory descriptor @p data_desc, @p axis, and
-        /// @p group_size.
+        /// Constructs a descriptor for a shuffle forward propagation
+        /// primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param data_desc Source and destination memory descriptor.
+        /// @param axis The axis along which the data is shuffled.
+        /// @param group_size Shuffle group size.
         desc(prop_kind prop_kind, const memory::desc &data_desc, int axis,
                 int group_size);
     };
 
-    /// Primitive descriptor for shuffle forward propagation primitive.
+    /// Primitive descriptor for a shuffle forward propagation primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for shuffle forward propagation
-        /// primitive from a corresponding operation descriptor @p desc using
-        /// engine @p engine, and primitive attributes @p attr. The @p
-        /// allow_empty flag signifies whether construction is allowed to
-        /// fail, in which case an empty primitive would be produced.
+        /// Constructs a primitive descriptor for a shuffle forward
+        /// propagation primitive.
+        ///
+        /// @param desc Descriptor for a shuffle forward propagation
+        ///     primitive.
+        /// @param engine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const primitive_attr &attr = primitive_attr(),
                 bool allow_empty = false);
 
-        /// Returns the source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const;
 
-        /// Returns the destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     shuffle_forward();
 
-    /// Constructs a shuffle forward propagation primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs a shuffle forward propagation primitive.
+    /// @param pd Primitive descriptor for a shuffle forward propagation
+    ///     primitive.
     shuffle_forward(const primitive_desc &pd);
 };
 
 /// Shuffle backward propagation primitive.
 struct shuffle_backward : public primitive {
-    /// Descriptor for shuffle primitive backward propagation
+    /// Descriptor for a shuffle primitive backward propagation
     /// primitive.
     struct desc {
-        /// Constructs a primitive descriptor for a shuffle backward
-        /// propagation primitive using a memory descriptor @p diff_data_desc,
-        /// @p axis, and @p group_size.
+        /// Constructs a descriptor for a shuffle backward propagation
+        /// primitive.
+        ///
+        /// Inputs:
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///
+        /// @param diff_data_desc Diff source and diff destination memory
+        ///     descriptor.
+        /// @param axis The axis along which the data is shuffled.
+        /// @param group_size Shuffle group size.
         desc(const memory::desc &diff_data_desc, int axis, int group_size);
     };
 
-    /// Primitive descriptor for shuffle backward propagation primitive.
+    /// Primitive descriptor for a shuffle backward propagation primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for shuffle backward propagation
-        /// primitive from a corresponding operation descriptor @p desc using
-        /// engine @p engine, shuffle forward propagation primitive descriptor
-        /// hint @p hint_fwd_pd, and primitive attributes @p attr. The @p
-        /// allow_empty flag signifies whether construction is allowed to
-        /// fail, in which case an empty primitive would be produced.
+        /// Constructs a primitive descriptor for a shuffle backward
+        /// propagation primitive.
+        ///
+        /// @param desc Descriptor for a shuffle backward propagation
+        ///     primitive.
+        /// @param engine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param hint_fwd_pd Primitive descriptor for a shuffle
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 const shuffle_forward::primitive_desc &hint_fwd_pd,
                 const primitive_attr &attr = primitive_attr(),
                 bool allow_empty = false);
 
-        /// Returns the diff source memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
         memory::desc diff_src_desc() const;
 
-        /// Returns the diff destination memory descriptor.
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
         memory::desc diff_dst_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     shuffle_backward();
 
-    /// Constructs a shuffle backward propagation primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs a shuffle backward propagation primitive.
+    /// @param pd Primitive descriptor for a shuffle backward propagation
+    ///     primitive.
     shuffle_backward(const primitive_desc &pd);
 };
 
+/// @} dnnl_api_shuffle
+
+/// @addtogroup dnnl_api_binary Binary
+///
+/// A primitive to perform tensor operations over two tensors.
+///
+/// @{
+
 /// Elementwise binary operator primitive.
 struct binary : public primitive {
-    /// Descriptor for a elementwise binary operator primitive.
+    /// Descriptor for an elementwise binary operator primitive.
     struct desc {
-        /// Constructs a descriptor for elementwise binary operator primitive.
+        /// Constructs a descriptor for an elementwise binary operator
+        /// primitive.
+        ///
+        /// Inputs:
+        ///  - `src0` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `src1` (#dnnl::primitive_desc_base::src_desc (`1`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
         ///
         /// @param algorithm Elementwise algorithm.
         /// @param src0 Memory descriptor for source tensor #0.
@@ -4123,35 +6376,38 @@ struct binary : public primitive {
                 const memory::desc &src1, const memory::desc &dst);
     };
 
-    /// Primitive descriptor for elementwise binary operator primitive.
+    /// Primitive descriptor for an elementwise binary operator primitive.
     struct primitive_desc : public dnnl::primitive_desc {
         /// Default constructor. Produces an empty object.
         primitive_desc();
 
-        /// Constructs a primitive descriptor for elementwise binary operator
+        /// Constructs a primitive descriptor for an elementwise binary operator
         /// primitive.
         ///
-        /// @param desc Descriptor for elementwise binary operator primitive.
+        /// @param desc Descriptor for an elementwise binary operator primitive.
         /// @param engine Engine to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const engine &engine,
                 bool allow_empty = false);
 
-        /// Constructs a primitive descriptor for elementwise binary operator
+        /// Constructs a primitive descriptor for an elementwise binary operator
         /// primitive.
         ///
-        /// @param desc Descriptor for elementwise binary operator primitive.
+        /// @param desc Descriptor for an elementwise binary operator primitive.
         /// @param engine Engine to use.
         /// @param attr Primitive attributes to use.
         /// @param allow_empty A flag signifying whether construction is
-        ///                    allowed to fail without throwing an exception.
-        ///                    In this case an empty object will be produced.
-        ///                    This flag is optional and defaults to false.
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
         primitive_desc(const desc &desc, const primitive_attr &attr,
                 const engine &engine, bool allow_empty = false);
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc(int)const
+        memory::desc src_desc(int idx = 0) const;
 
         /// Returns the memory descriptor for source #0.
         memory::desc src0_desc() const;
@@ -4159,20 +6415,346 @@ struct binary : public primitive {
         /// Returns the memory descriptor for source #1.
         memory::desc src1_desc() const;
 
-        /// Returns the memory descriptor for destination.
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const;
     };
 
     /// Default constructor. Produces an empty object.
     binary();
 
-    /// Constructs a elementwise binary operator primitive from a primitive
-    /// descriptor @p pd of a corresponding type.
+    /// Constructs an elementwise binary operation primitive.
+    /// @param pd Primitive descriptor for an elementwise binary operation
+    ///     primitive.
     binary(const primitive_desc &pd);
 };
 
+/// @} dnnl_api_binary
+
+/// @addtogroup dnnl_api_matmul Matrix Multiplication
+///
+/// A primitive to perform matrix-matrix multiplication. The batched mode
+/// is supported with 3D tensors.
+///
+/// @{
+
+/// Matrix multiplication (matmul) primitive.
+struct matmul : public primitive {
+    /// Descriptor for a matmul primitive.
+    struct desc {
+        /// Constructs a descriptor for a matmul primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///
+        /// @param src_desc Memory descriptor for source (matrix A).
+        /// @param weights_desc Memory descriptor for weights (matrix B).
+        /// @param dst_desc Memory descriptor for destination (matrix C).
+        desc(const memory::desc &src_desc, const memory::desc &weights_desc,
+                const memory::desc &dst_desc);
+
+        /// Constructs a descriptor for a matmul primitive.
+        ///
+        /// Inputs:
+        ///  - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///  - `weights` (#dnnl::primitive_desc_base::weights_desc (`0`))
+        ///  - `bias` (#dnnl::primitive_desc_base::weights_desc (`1`))
+        ///
+        /// Outputs:
+        ///  - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///
+        /// @param src_desc Memory descriptor for source (matrix A).
+        /// @param weights_desc Memory descriptor for weights (matrix B).
+        /// @param dst_desc Memory descriptor for destination (matrix C).
+        /// @param bias_desc Memory descriptor for bias.
+        desc(const memory::desc &src_desc, const memory::desc &weights_desc,
+                const memory::desc &bias_desc, const memory::desc &dst_desc);
+    };
+
+    /// Primitive descriptor for a matmul primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc();
+
+        /// Constructs a primitive descriptor for a matmul primitive.
+        ///
+        /// @param desc Descriptor for a matmul primitive.
+        /// @param engine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &desc, const engine &engine,
+                bool allow_empty = false);
+
+        /// Constructs a primitive descriptor for a matmul primitive.
+        ///
+        /// @param desc Descriptor for a matmul primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param engine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &desc, const primitive_attr &attr,
+                const engine &engine, bool allow_empty = false);
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const;
+
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
+        memory::desc weights_desc() const;
+
+        /// @copydoc dnnl::convolution_forward::primitive_desc::bias_desc()const
+        memory::desc bias_desc() const;
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const;
+    };
+
+    /// Default constructor. Produces an empty object.
+    matmul();
+
+    /// Constructs a matmul primitive.
+    /// @param pd Primitive descriptor for a matmul primitive.
+    matmul(const primitive_desc &pd);
+};
+
+/// @} dnnl_api_matmul
+
+/// @addtogroup dnnl_api_resampling Resampling
+///
+/// A primitive to compute resampling operation on 1D, 2D or 3D data tensor
+/// using Nearest Neighbor, or Linear (Bilinear, Trilinear) interpolation
+/// method.
+///
+/// @{
+
+/// Resampling forward propagation.
+struct resampling_forward : public primitive {
+    /// Descriptor for resampling forward propagation.
+    struct desc {
+        /// Constructs a descriptor for a resampling forward propagation
+        /// primitive using source and destination memory descriptors.
+        ///
+        /// Inputs:
+        /// - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///
+        /// Outputs:
+        /// - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///
+        /// @note
+        ///     The destination memory descriptor is allowed to be initialized
+        ///     with #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param algorithm resampling algorithm kind: either
+        ///     #dnnl::algorithm::resampling_nearest, or
+        ///     #dnnl::algorithm::resampling_linear
+        /// @param src_desc Source memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        desc(prop_kind prop_kind, algorithm algorithm,
+                const memory::desc &src_desc, const memory::desc &dst_desc);
+
+        /// Constructs a descriptor for a resampling forward propagation
+        /// primitive using source memory descriptor and factors.
+        ///
+        /// Inputs:
+        /// - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param algorithm resampling algorithm kind: either
+        ///     #dnnl::algorithm::resampling_nearest, or
+        ///     #dnnl::algorithm::resampling_linear
+        /// @param factors Vector of scaling factors for spatial dimension.
+        /// @param src_desc Source memory descriptor.
+        desc(prop_kind prop_kind, algorithm algorithm,
+                const std::vector<float> &factors,
+                const memory::desc &src_desc);
+
+        /// Constructs a descriptor for a resampling forward propagation
+        /// primitive.
+        ///
+        /// Inputs:
+        /// - `src` (#dnnl::primitive_desc_base::src_desc (`0`))
+        ///
+        /// Outputs:
+        /// - `dst` (#dnnl::primitive_desc_base::dst_desc (`0`))
+        ///
+        /// @note
+        ///     The destination memory descriptor is allowed to be initialized
+        ///     with #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param prop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param algorithm resampling algorithm kind: either
+        ///     #dnnl::algorithm::resampling_nearest, or
+        ///     #dnnl::algorithm::resampling_linear
+        /// @param factors Vector of scaling factors for spatial dimension.
+        /// @param src_desc Source memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        desc(prop_kind prop_kind, algorithm algorithm,
+                const std::vector<float> &factors, const memory::desc &src_desc,
+                const memory::desc &dst_desc);
+    };
+
+    /// Primitive descriptor for a resampling forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc();
+
+        /// Constructs a primitive descriptor for a resampling forward
+        /// propagation primitive.
+        ///
+        /// @param desc Descriptor for a resampling forward propagation
+        /// primitive.
+        /// @param engine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &desc, const engine &engine,
+                bool allow_empty = false);
+
+        /// Constructs a primitive descriptor for a resampling forward
+        /// propagation primitive.
+        ///
+        /// @param desc Descriptor for a resampling forward propagation primitive.
+        /// @param engine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &desc, const primitive_attr &attr,
+                const engine &engine, bool allow_empty = false);
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const;
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const;
+    };
+
+    /// Default constructor. Produces an empty object.
+    resampling_forward();
+
+    /// Constructs a resampling forward propagation primitive.
+    /// @param pd Primitive descriptor for a resampling forward propagation
+    ///     primitive.
+    resampling_forward(const primitive_desc &pd);
+};
+
+/// Resampling backward propagation primitive.
+struct resampling_backward : public primitive {
+    /// Descriptor for a resampling backward propagation primitive.
+    struct desc {
+        /// Constructs a descriptor for a resampling backward propagation
+        /// primitive using source and destination memory descriptors.
+        ///
+        /// Inputs:
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///
+        /// @param algorithm resampling algorithm kind: either
+        ///     #dnnl::algorithm::resampling_nearest, or
+        ///     #dnnl::algorithm::resampling_linear
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        desc(algorithm algorithm, const memory::desc &diff_src_desc,
+                const memory::desc &diff_dst_desc);
+
+        /// Constructs a descriptor for resampling backward propagation
+        /// primitive.
+        ///
+        /// Inputs:
+        ///  - `diff_dst` (#dnnl::primitive_desc_base::diff_dst_desc (`0`))
+        ///
+        /// Outputs:
+        ///  - `diff_src` (#dnnl::primitive_desc_base::diff_src_desc (`0`))
+        ///
+        /// @param algorithm resampling algorithm kind: either
+        ///     #dnnl::algorithm::resampling_nearest, or
+        ///     #dnnl::algorithm::resampling_linear
+        /// @param factors Vector of scaling factors for spatial dimension.
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        desc(algorithm algorithm, std::vector<float> factors,
+                const memory::desc &diff_src_desc,
+                const memory::desc &diff_dst_desc);
+    };
+
+    /// Primitive descriptor for resampling backward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc();
+
+        /// Constructs a primitive descriptor for a resampling backward
+        /// propagation primitive.
+        ///
+        /// @param desc Descriptor for a resampling backward propagation primitive.
+        /// @param engine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a resampling forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &desc, const engine &engine,
+                const resampling_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false);
+
+        /// Constructs a primitive descriptor for a resampling backward
+        /// propagation primitive.
+        ///
+        /// @param desc Descriptor for a resampling backward propagation primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param engine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a resampling forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &desc, const primitive_attr &attr,
+                const engine &engine,
+                const resampling_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false);
+
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
+        memory::desc diff_src_desc() const;
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const;
+    };
+
+    /// Default constructor. Produces an empty object.
+    resampling_backward();
+
+    /// Constructs a resampling backward propagation primitive.
+    /// @param pd Primitive descriptor for a resampling backward propagation
+    ///     primitive.
+    resampling_backward(const primitive_desc &pd);
+};
+
+/// @} dnnl_api_resampling
+
+/// @} dnnl_api_primitives
+
 } // namespace dnnl
 
-/// @}
+/// @} dnnl_api
 
 #endif

--- a/source/elements/oneDNN/source/api/engine.rst
+++ b/source/elements/oneDNN/source/api/engine.rst
@@ -1,0 +1,13 @@
+Engine
+------
+
+*Engine* is abstraction of a computational device: a CPU, a specific GPU card in
+the system, etc. Most primitives are created to execute computations on one
+specific engine. The only exceptions are reorder primitives that transfer data
+between two different engines.
+
+.. doxygenstruct:: dnnl::engine
+   :project: oneDNN
+   :members:
+
+

--- a/source/elements/oneDNN/source/api/memory.rst
+++ b/source/elements/oneDNN/source/api/memory.rst
@@ -1,0 +1,69 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Memory
+------
+
+Memory object is container that describes and stores data. Memory objects can
+contain data of various data types and formats. There are two levels of
+abstraction:
+
+1. *Memory descriptor* -- engine-agnostic logical description of data (number
+   of dimensions, dimension sizes, and data type), and, optionally, the
+   information about the physical format of data in memory. If this
+   information is not known yet, a memory descriptor can be created with
+   :enum:`dnnl::memory::format_tag::any`. This allows compute-intensive
+   primitives to chose the most appropriate format for the computations.  The
+   user is then responsible for reordering their data into the new format if
+   the formats do not match.
+
+   A memory descriptor can be initialized either by specifying dimensions, and
+   memory format tag or strides for each of them.
+
+   User can query amount of memory required by a memory descriptor using the
+   :func:`dnnl::memory::desc::get_size` function. The size of data in
+   general cannot be computed as the product of dimensions multiplied by the
+   size of the data type. So users are required to use this function for
+   better code portability.
+
+   Two memory descriptors can be compared using the equality and inequality
+   operators.  The comparison is especially useful when checking whether it is
+   necessary to reorder data from the user's data format to a primitive's
+   format.
+
+2. *Memory object* -- an engine-specific object that handles the data and its
+   description (a memory descriptor). With USM, the data handle is simply a
+   pointer to ``void``. The data handle can be queried using
+   :func:`dnnl::memory::get_data_handle` and set using
+   :func:`dnnl::memory::set_data_handle`. The underlying SYCL buffer, when
+   used, can be queried using :func:`dnnl::memory::get_sycl_buffer` and
+   and set using :func:`dnnl::memory::set_sycl_buffer`. A memory object
+   can also be queried for the underlying memory descriptor and for its engine
+   using :func:`dnnl::memory::get_desc` and
+   :func:`dnnl::memory::get_engine`.
+
+Along with ordinary memory descriptors with all dimensions being positive, the
+library supports *zero-volume* memory descriptors with one or more dimensions
+set to zero. This is used to support the NumPy\* convention. If a zero-volume
+memory is passed to a primitive, the primitive typically does not perform any
+computations with this memory. For example:
+
+* A concatenation primitive would ignore all memory object with zeroes in the
+  concat dimension / axis.
+
+* A forward convolution with a source memory object with zero in the minibatch
+  dimension would always produce a detination memory object with a zero in the
+  minibatch dimension and perform no computations.
+
+* However, a forward convolution with a zero in one of the weights dimensions
+  is ill-defined and is considered to be an error by the library because there
+  is no clear definition on what the output values should be.
+
+Data handle of a zero-volume memory is never accessed.
+
+.. doxygenstruct:: dnnl::memory
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives.rst
+++ b/source/elements/oneDNN/source/api/primitives.rst
@@ -1,0 +1,70 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Primitives
+----------
+
+The library has multiple levels of abstractions for primitives and memory
+objects in order to expose maximum flexibility to its users.
+
+On the logical level, the library provides the following abstractions:
+
+* *Operation descriptors* (one for each supported primitive) describe an
+  operation's most basic properties without specifying, for example, which
+  engine will be used to compute them. For example, convolution descriptor
+  describes shapes of source, destination, and weights tensors, propagation
+  kind (forward, backward with respect to data or weights), and other
+  implementation-independent parameters.
+
+* *Primitive descriptors* (one for each supported primitive) are at an
+  abstraction level in between operation descriptors and primitives and can be
+  used to inspect details of a specific primitive implementation like expected
+  memory formats via queries to implement memory format propagation (see
+  Memory format propagation) without having to fully instantiate a primitive.
+
+* *Primitives* are functor objects that encapsulates a particular computation
+  such as forward convolution, backward LSTM computations, or a data
+  transformation operation. A single primitive can sometimes represent more
+  complex fused computations such as a forward convolution followed by a ReLU.
+
+  The most important difference between a primitive and a pure function is
+  that a primitive can store state.
+
+  One part of the primitive’s state is immutable. For example, convolution
+  primitives store parameters like tensor shapes and can pre-compute other
+  dependent parameters like cache blocking. This approach allows DNNL primitives
+  to pre-generate code specifically tailored for the operation to be performed.
+  The DNNL programming model assumes that the time it takes to perform the
+  pre-computations is amortized by reusing the same primitive to perform
+  computations multiple times.
+
+  The mutable part of the primitive’s state is referred to as a scratchpad. It
+  is a memory buffer that a primitive may use for temporary storage only
+  during computations. The scratchpad can either be owned by a primitive
+  object (which makes that object non-thread safe) or be an execution-time
+  parameter.
+
+.. toctree::
+   :maxdepth: 1
+
+   primitives/common.rst
+   primitives/attributes.rst
+   primitives/convolution.rst
+   primitives/deconvolution.rst
+   primitives/inner_product.rst
+   primitives/rnn.rst
+   primitives/batch_normalization.rst
+   primitives/binary.rst
+   primitives/concat.rst
+   primitives/eltwise.rst
+   primitives/layer_normalization.rst
+   primitives/lrn.rst
+   primitives/logsoftmax.rst
+   primitives/pooling.rst
+   primitives/resampling.rst
+   primitives/softmax.rst
+   primitives/shuffle.rst
+   primitives/sum.rst
+   primitives/reorder.rst

--- a/source/elements/oneDNN/source/api/primitives/attributes.rst
+++ b/source/elements/oneDNN/source/api/primitives/attributes.rst
@@ -1,0 +1,33 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Attributes
+~~~~~~~~~~
+
+Attributes are parameters that extend a primitive's behavior.
+
+Attributes can also contain *post-ops*, which are computations executed after
+the primitive.
+
+API
++++
+
+.. doxygenenum:: dnnl::scratchpad_mode
+   :project: oneDNN
+
+.. doxygenenum:: dnnl::prop_kind
+   :project: oneDNN
+
+.. doxygenenum:: dnnl::algorithm
+   :project: oneDNN
+
+.. doxygenstruct:: dnnl::post_ops
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::primitive_attr
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/batch_normalization.rst
+++ b/source/elements/oneDNN/source/api/primitives/batch_normalization.rst
@@ -1,0 +1,29 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Batch Normalization
+~~~~~~~~~~~~~~~~~~~
+
+Both forward and backward propagation primitives support in-place operation;
+that is, ``src`` and ``dst`` can refer to the same memory for forward
+propagation, and ``diff_dst`` and ``diff_src`` can refer to the same memory for
+backward propagation. You can control the batch normalization primitives'
+computations by specifying different ``dnnl::normalization_flags`` values.
+For example, batch normalization can compute the mean and variance on its own
+or take them as inputs. It can either perform scaling and shifting using gamma
+and beta parameters or not. Optionally, it can also perform a fused ReLU, which
+in case of training would also require a workspace.
+
+API
++++
+
+.. doxygenstruct:: dnnl::batch_normalization_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::batch_normalization_backward
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/binary.rst
+++ b/source/elements/oneDNN/source/api/primitives/binary.rst
@@ -1,0 +1,17 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Binary
+~~~~~~
+
+A primitive to perform tensor operations over two tensors.
+
+API
++++
+
+.. doxygenstruct:: dnnl::binary
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/common.rst
+++ b/source/elements/oneDNN/source/api/primitives/common.rst
@@ -1,0 +1,192 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Common
+~~~~~~
+
+Base class for primitives
++++++++++++++++++++++++++
+
+.. doxygenstruct:: dnnl::primitive
+   :project: oneDNN
+   :members:
+
+Normalization primitives flags
+++++++++++++++++++++++++++++++
+
+.. doxygenenum:: dnnl::normalization_flags
+   :project: oneDNN
+
+Execution argument indices
+++++++++++++++++++++++++++
+
+.. doxygendefine:: DNNL_ARG_SRC_0
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_SRC
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_SRC_LAYER
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_FROM
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_SRC_1
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_SRC_ITER
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_SRC_2
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_SRC_ITER_C
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DST_0
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DST
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_TO
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DST_LAYER
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DST_1
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DST_ITER
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DST_2
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DST_ITER_C
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_WEIGHTS_0
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_WEIGHTS
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_SCALE_SHIFT
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_WEIGHTS_LAYER
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_WEIGHTS_1
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_WEIGHTS_ITER
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_BIAS
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_MEAN
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_VARIANCE
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_WORKSPACE
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_SCRATCHPAD
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_SRC_0
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_SRC
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_SRC_LAYER
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_SRC_1
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_SRC_ITER
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_SRC_2
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_SRC_ITER_C
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_DST_0
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_DST
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_DST_LAYER
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_DST_1
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_DST_ITER
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_DST_2
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_DST_ITER_C
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_WEIGHTS_0
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_WEIGHTS
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_SCALE_SHIFT
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_WEIGHTS_LAYER
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_WEIGHTS_1
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_WEIGHTS_ITER
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_DIFF_BIAS
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_ATTR_OUTPUT_SCALES
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_MULTIPLE_SRC
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_MULTIPLE_DST
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_ARG_ATTR_ZERO_POINTS
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_RUNTIME_DIM_VAL
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_RUNTIME_SIZE_VAL
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_RUNTIME_F32_VAL
+   :project: oneDNN
+
+.. doxygendefine:: DNNL_RUNTIME_S32_VAL
+   :project: oneDNN
+

--- a/source/elements/oneDNN/source/api/primitives/concat.rst
+++ b/source/elements/oneDNN/source/api/primitives/concat.rst
@@ -1,0 +1,17 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Concat
+~~~~~~
+
+A primitive to concatenate data by arbitrary dimension.
+
+API
++++
+
+.. doxygenstruct:: dnnl::concat
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/convolution.rst
+++ b/source/elements/oneDNN/source/api/primitives/convolution.rst
@@ -1,0 +1,27 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Convolution
+~~~~~~~~~~~
+
+A convolution primitive performs 1D, 2D or 3D convolution. Supported variants
+are forward propagation, backward propagation, and weights gradient with or
+without bias.
+
+API
++++
+
+.. doxygenstruct:: dnnl::convolution_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::convolution_backward_data
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::convolution_backward_weights
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/deconvolution.rst
+++ b/source/elements/oneDNN/source/api/primitives/deconvolution.rst
@@ -1,0 +1,27 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Deconvolution
+~~~~~~~~~~~~~
+
+A deconvolution primitive performs 1D, 2D, or 3D deconvolution. Supported
+variants are forward propagation, backward propagation, and weights gradient
+with or without bias.
+
+API
++++
+
+.. doxygenstruct:: dnnl::deconvolution_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::deconvolution_backward_data
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::deconvolution_backward_weights
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/eltwise.rst
+++ b/source/elements/oneDNN/source/api/primitives/eltwise.rst
@@ -1,0 +1,35 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Element-wise
+~~~~~~~~~~~~
+
+A primitive to perform element-wise operations such as the rectifier linear unit
+(ReLU).
+
+Both forward and backward propagation primitives support in-place operation;
+that is, ``src`` and ``dst`` can refer to the same memory for forward
+propagation, and ``diff_dst`` and ``diff_src`` can refer to the same memory for
+backward propagation.
+
+.. warning::
+
+   Because the original source data is required for backward propagation,
+   in-place forward propagation is not generally supported in the training mode.
+   However, for ReLU with the alpha parameter set to 0, either ``dst`` or
+   ``src`` can be used for the backward propagation, which makes possible a
+   performance benefit even in the training mode.
+
+API
++++
+
+.. doxygenstruct:: dnnl::eltwise_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::eltwise_backward
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/inner_product.rst
+++ b/source/elements/oneDNN/source/api/primitives/inner_product.rst
@@ -1,0 +1,25 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Inner Product
+~~~~~~~~~~~~~
+
+A primitive to compute an inner product.
+
+API
++++
+
+.. doxygenstruct:: dnnl::inner_product_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::inner_product_backward_data
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::inner_product_backward_weights
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/layer_normalization.rst
+++ b/source/elements/oneDNN/source/api/primitives/layer_normalization.rst
@@ -1,0 +1,31 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Layer Normalization
+~~~~~~~~~~~~~~~~~~~
+
+A primitive to perform layer normalization. Normalization is performed within
+the last logical dimension of data tensor. Both forward and backward propagation
+primitives support in-place operation; that is, ``src`` and ``dst`` can refer to
+the same memory for forward propagation, and ``diff_dst`` and ``diff_src`` can
+refer to the same memory for backward propagation. You can control the layer
+normalization primitives' computations by specifying different
+``dnnl::normalization_flags`` values. For example, you can configure layer
+normalization forward propagation to either compute the mean and variance or
+take them as arguments. Layer normalization can either perform scaling and
+shifting using gamma and beta parameters or not. Optionally, it can also perform
+a fused ReLU, which in case of training would also require a workspace.
+
+API
++++
+
+.. doxygenstruct:: dnnl::layer_normalization_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::layer_normalization_backward
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/logsoftmax.rst
+++ b/source/elements/oneDNN/source/api/primitives/logsoftmax.rst
@@ -1,0 +1,21 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+LogSoftmax
+~~~~~~~~~~
+
+A primitive to perform logsoftmax.
+
+API
++++
+
+.. doxygenstruct:: dnnl::logsoftmax_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::logsoftmax_backward
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/lrn.rst
+++ b/source/elements/oneDNN/source/api/primitives/lrn.rst
@@ -1,0 +1,22 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Local Response Normalization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A primitive to perform local response normalization (LRN) across or within
+channels.
+
+API
++++
+
+.. doxygenstruct:: dnnl::lrn_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::lrn_backward
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/pooling.rst
+++ b/source/elements/oneDNN/source/api/primitives/pooling.rst
@@ -1,0 +1,21 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Pooling
+~~~~~~~
+
+A primitive to perform max or average pooling.
+
+API
++++
+
+.. doxygenstruct:: dnnl::pooling_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::pooling_backward
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/reorder.rst
+++ b/source/elements/oneDNN/source/api/primitives/reorder.rst
@@ -1,0 +1,18 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Reorder
+~~~~~~~
+
+A primitive to copy data between two memory objects. This primitive is typically
+used to change the way that the data is laid out in memory.
+
+API
++++
+
+.. doxygenstruct:: dnnl::reorder
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/resampling.rst
+++ b/source/elements/oneDNN/source/api/primitives/resampling.rst
@@ -1,0 +1,22 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Resampling
+~~~~~~~~~~
+
+A primitive to compute resampling operation on 1D, 2D, or 3D data tensor using
+the Nearest Neighbor, or Linear (Bilinear, Trilinear), interpolation method.
+
+API
++++
+
+.. doxygenstruct:: dnnl::resampling_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::resampling_backward
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/rnn.rst
+++ b/source/elements/oneDNN/source/api/primitives/rnn.rst
@@ -1,0 +1,51 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+RNN
+~~~
+
+A primitive to compute recurrent neural network layers.
+
+API
++++
+
+.. doxygenenum:: dnnl::rnn_flags
+   :project: oneDNN
+
+.. doxygenenum:: dnnl::rnn_direction
+   :project: oneDNN
+
+.. doxygenstruct:: dnnl::vanilla_rnn_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::vanilla_rnn_backward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::lstm_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::lstm_backward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::gru_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::gru_backward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::lbr_gru_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::lbr_gru_backward
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/shuffle.rst
+++ b/source/elements/oneDNN/source/api/primitives/shuffle.rst
@@ -1,0 +1,21 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Shuffle
+~~~~~~~
+
+A primitive to shuffle tensor data along an axis.
+
+API
++++
+
+.. doxygenstruct:: dnnl::shuffle_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::shuffle_backward
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/softmax.rst
+++ b/source/elements/oneDNN/source/api/primitives/softmax.rst
@@ -1,0 +1,21 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Softmax
+~~~~~~~
+
+A primitive to perform softmax.
+
+API
++++
+
+.. doxygenstruct:: dnnl::softmax_forward
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::softmax_backward
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/primitives/sum.rst
+++ b/source/elements/oneDNN/source/api/primitives/sum.rst
@@ -1,0 +1,17 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Sum
+~~~
+
+A primitive to sum multiple tensors.
+
+API
++++
+
+.. doxygenstruct:: dnnl::sum
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/stream.rst
+++ b/source/elements/oneDNN/source/api/stream.rst
@@ -1,0 +1,15 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Stream
+------
+
+A *stream* is an encapsulation of execution context tied to a particular
+engine.
+
+.. doxygenstruct:: dnnl::stream
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/api/utilities.rst
+++ b/source/elements/oneDNN/source/api/utilities.rst
@@ -1,0 +1,20 @@
+..
+  Copyright 2019 Intel Corporation
+
+.. default-domain:: cpp
+
+Utility Types and Definitions
+-----------------------------
+
+.. doxygenstruct:: dnnl::error
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::primitive_desc_base
+   :project: oneDNN
+   :members:
+
+.. doxygenstruct:: dnnl::rnn_primitive_desc_base
+   :project: oneDNN
+   :members:
+

--- a/source/elements/oneDNN/source/index.rst
+++ b/source/elements/oneDNN/source/index.rst
@@ -1,6 +1,8 @@
 ..
   Copyright 2019 Intel Corporation
 
+.. default-domain:: cpp
+
 .. _oneDNN-section:
 
 ========================
@@ -83,6 +85,19 @@ Open Source Implementation
 Intel has published an `open source implementation`_ with the Apache
 license.
 
+---
+API
+---
+
+.. toctree::
+   :maxdepth: 2
+
+   api/engine.rst
+   api/stream.rst
+   api/memory.rst
+   api/primitives.rst
+   api/utilities.rst
+
 -------
 Testing
 -------
@@ -93,13 +108,7 @@ can be used to test library functionality.
 The `open source implementation`_ includes a comprehensive test suite.
 Consult the `README`_ for directions.
 
----
-API
----
-
-.. doxygenindex::
-   :project: oneDNN
-
 .. _`open source implementation`: https://github.com/intel/mkl-dnn
 .. _`README`: https://github.com/intel/mkl-dnn/blob/master/README.md
 
+.. vim: ts=3 sw=3 et


### PR DESCRIPTION
Get rid of `doxygenindex` and split documentation into groups manually.

Co-authored-by: Ben Fitch <benjamin.fitch@intel.com>