### PR TITLE
[DAL] Fix term warnings

### DIFF
--- a/source/elements/oneDAL/Makefile
+++ b/source/elements/oneDAL/Makefile
@@ -1,6 +1,6 @@
 GH_PAGES = build/gh-pages
 
-.PHONY: build doxygen parse-doxygen clean gh-pages
+.PHONY: html pdf doxygen parse-doxygen clean gh-pages
 
 html:
 	sphinx-build -M html source build -q
@@ -18,8 +18,9 @@ parse-doxygen: doxygen
 clean:
 	rm -rf build/doctrees
 	rm -rf build/html
+	rm -rf build/latex
 
-gh-pages: build
+gh-pages: html
 	cp -r build/html/* $(GH_PAGES)
 	cd $(GH_PAGES) && \
 		git checkout gh-pages && \

--- a/source/elements/oneDAL/Makefile
+++ b/source/elements/oneDAL/Makefile
@@ -16,6 +16,7 @@ parse-doxygen: doxygen
 	python -m dalapi.doxypy.cli doxygen/xml --compact > build/tree.yaml
 
 clean:
+	rm -rf build/doctrees
 	rm -rf build/html
 
 gh-pages: build

--- a/source/elements/oneDAL/dalapi/extension.py
+++ b/source/elements/oneDAL/dalapi/extension.py
@@ -4,6 +4,7 @@ import time
 from typing import (Dict, Tuple, Text)
 from collections import OrderedDict, namedtuple
 from . import directives
+from . import roles
 from . import doxypy
 from . import utils
 
@@ -277,6 +278,8 @@ class EventHandler(object):
 
 def setup(app):
     ctx = Context(app)
+
+    app.add_role('capterm', roles.capterm_role)
 
     app.add_directive('onedal_class', directives.ClassDirective(ctx))
     app.add_directive('onedal_func', directives.FunctionDirective(ctx))

--- a/source/elements/oneDAL/dalapi/roles.py
+++ b/source/elements/oneDAL/dalapi/roles.py
@@ -4,7 +4,6 @@ from sphinx import roles
 
 _term_ref_re = re.compile(r'(.+)<(.+)>', flags=re.DOTALL)
 def capterm_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
-    global _term_ref_re
     xref_role = roles.XRefRole(innernodeclass=nodes.inline,
                                warn_dangling=True)
     term_match = _term_ref_re.match(text)

--- a/source/elements/oneDAL/dalapi/roles.py
+++ b/source/elements/oneDAL/dalapi/roles.py
@@ -1,0 +1,16 @@
+import re
+from docutils import nodes
+from sphinx import roles
+
+_term_ref_re = re.compile(r'(.+)<(.+)>', flags=re.DOTALL)
+def capterm_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    global _term_ref_re
+    xref_role = roles.XRefRole(innernodeclass=nodes.inline,
+                               warn_dangling=True)
+    term_match = _term_ref_re.match(text)
+    if term_match:
+        txt, ref = term_match.group(1), term_match.group(2)
+    else:
+        txt, ref = text, text
+    fixed_term = f'{txt.strip()} <{ref.strip().capitalize()}>'
+    return xref_role('std:term', rawtext, fixed_term, lineno, inliner, options, content)

--- a/source/elements/oneDAL/source/data_management/index.rst
+++ b/source/elements/oneDAL/source/data_management/index.rst
@@ -19,7 +19,7 @@ contains three main steps of data acquisition, preparation, and computation (see
 
 2. Data preparation
 
-  - Support different in-memory :term:`data formats <Data format>`.
+  - Support different in-memory :capterm:`data formats <Data format>`.
   - Compress and decompress the data.
   - Convert the data into numeric representation.
   - Recover missing values.
@@ -56,9 +56,9 @@ Dataset
 --------
 
 The main data-related concept that |dal_short_name| works with is a
-:term:`dataset`. It is an in-memory or out-of-memory tabular view of data, where
-table rows represent the :term:`observations <Observation>` and columns
-represent the :term:`features <Feature>`.
+:capterm:`dataset`. It is an in-memory or out-of-memory tabular view of data,
+where table rows represent the :capterm:`observations <observation>` and columns
+represent the :capterm:`features <feature>`.
 
 .. image:: _static/dataset.png
   :width: 400
@@ -82,8 +82,9 @@ example:
 Data source
 -----------
 
-Data source is a concept of an out-of-memory storage for a :term:`dataset`. It is
-used at the data acquisition and data preparation stages for the following:
+Data source is a concept of an out-of-memory storage for a :capterm:`dataset`.
+It is used at the data acquisition and data preparation stages for the
+following:
 
 - To extract datasets from external sources such as databases, files, remote
   storages.
@@ -92,18 +93,18 @@ used at the data acquisition and data preparation stages for the following:
   the local memory, especially when processing with accelerators. A data source
   provides the ability to load data by batches and extracts it directly into the
   device's local memory. Therefore, a data source enables complex data analytics
-  scenarios, such as :term:`online computations <Online mode>`.
+  scenarios, such as :capterm:`online computations <Online mode>`.
 
-- To filter and normalize :term:`feature` values that are being extracted.
+- To filter and normalize :capterm:`feature` values that are being extracted.
 
-- To recover missing :term:`feature` values.
+- To recover missing :capterm:`feature` values.
 
-- To detect :term:`outliers <Outlier>` and recover the abnormal data.
+- To detect :capterm:`outliers <outlier>` and recover the abnormal data.
 
 - To transform datasets into numerical representation. Data source shall
-  automatically transform non-numeric :term:`categorical <Categorical feature>`
-  and :term:`continuous <Continuous feature>` data values into one of the
-  numeric :term:`data formats <Data format>`.
+  automatically transform non-numeric :capterm:`categorical <categorical
+  feature>` and :capterm:`continuous <continuous feature>` data values into one
+  of the numeric :capterm:`data formats <data format>`.
 
 For details, see :ref:`data-sources` section.
 
@@ -112,11 +113,11 @@ For details, see :ref:`data-sources` section.
 Table
 -----
 
-Table is a concept of a :term:`dataset` with in-memory numerical data. It is
+Table is a concept of a :capterm:`dataset` with in-memory numerical data. It is
 used at the data preparation and data processing stages for the following:
 
 - To store heterogeneous in-memory data in various
-  :term:`data formats <Data format>`, such as dense, sparse, chunked,
+  :capterm:`data formats <data format>`, such as dense, sparse, chunked,
   contiguous.
 
 - To avoid unnecessary data copies during conversion from external data
@@ -130,26 +131,27 @@ used at the data preparation and data processing stages for the following:
 
 - To support streaming of the data to the algorithm.
 
-- To access the underlying data on a device in a required :term:`data format`,
-  e.g. by blocks with the defined :term:`data layout`.
+- To access the underlying data on a device in a required :capterm:`data
+  format`, e.g. by blocks with the defined :capterm:`data layout`.
 
 For thread-safety reasons and better integration with external entities, a table
 provides a read-only access to the data within it, thus, table concept
-implementations shall be :term:`immutable <Immutability>`.
+implementations shall be :capterm:`immutable <immutability>`.
 
-This concept has different logical organization and physical
-:term:`format of the data <data format>`:
+This concept has different logical organization and physical :capterm:`format of
+the data <data format>`:
 
 - Logically, a table is a :ref:`dataset` with :math:`n` rows and
-  :math:`p` columns. Each row represents an :term:`observation` and each column
-  is a :term:`feature` of a dataset. Physical amount of bytes needed to store
-  the data differ from the number of elements :math:`n \times p` within
+  :math:`p` columns. Each row represents an :capterm:`observation` and each
+  column is a :capterm:`feature` of a dataset. Physical amount of bytes needed
+  to store the data differ from the number of elements :math:`n \times p` within
   a table.
 
-- Physically, a table can be organized in different ways: as a :term:`homogeneous
-  <Homogeneous data>`, :term:`contiguous <Contiguous data>` array of bytes, as a
-  :term:`heterogeneous <Heterogeneous data>` list of arrays of different
-  :term:`data types <Data type>`, in a compressed-sparse-row format.
+- Physically, a table can be organized in different ways: as a
+  :capterm:`homogeneous <homogeneous data>`, :capterm:`contiguous <contiguous
+  data>` array of bytes, as a :capterm:`heterogeneous <heterogeneous data>` list
+  of arrays of different :capterm:`data types <data type>`, in a
+  compressed-sparse-row format.
 
 For details, see :ref:`tables` section.
 
@@ -169,24 +171,25 @@ For each dataset, its metadata shall contain:
 
 - The number of rows :math:`n` and columns :math:`p` in a dataset.
 
-- The type of each :term:`feature` (e.g. :term:`nominal <Nominal feature>`,
-  :term:`interval <Interval feature>`).
+- The type of each :capterm:`feature` (e.g. :capterm:`nominal <nominal
+  feature>`, :capterm:`interval <interval feature>`).
 
-- The :term:`data type` of each feature (e.g. :code:`float` or :code:`double`).
+- The :capterm:`data type` of each feature (e.g. :code:`float` or
+  :code:`double`).
 
 .. note::
   Metadata can contain both compile-time and run-time information. For example,
   basic compile-time metadata is the type of a dataset - whether it is a
   particular :ref:`data-source` or a :ref:`table`. Run-time information can
-  contain the :term:`feature` types and :term:`data types <Data type>` of a
-  dataset.
+  contain the :capterm:`feature` types and :capterm:`data types <data type>` of
+  a dataset.
 
 .. _table-builder:
 
 Table builder
 -------------
 
-A table :term:`builder` is a concept that is associated with a particular
+A table :capterm:`builder` is a concept that is associated with a particular
 :ref:`table` type and is used at the data preparation and data processing stages
 for:
 
@@ -197,7 +200,7 @@ for:
   data, such as arrays, pointers to the memory, external entities.
 
 - Changing dataset values. Since :ref:`table` is an
-  :term:`immutable <Immutability>` dataset, a builder provides the ability to
+  :capterm:`immutable <immutability>` dataset, a builder provides the ability to
   change the values in a dataset under construction.
 
 - Encapsulating construction process of a :ref:`table`. This is used to hide the
@@ -223,21 +226,21 @@ in-memory numerical :ref:`dataset`. It allows:
   such as :ref:`tables <Table>` or :ref:`table builders <table-builder>`,
   without exposing their implementation details.
 
-- To convert a variety of numeric :term:`data formats <Data format>` into a
+- To convert a variety of numeric :capterm:`data formats <data format>` into a
   smaller set of formats.
 
-- To provide a :term:`flat <flat data>` view on the data blocks of a
+- To provide a :capterm:`flat <flat data>` view on the data blocks of a
   :ref:`dataset` for better a data locality. For example, some accessor
-  implementation returns :term:`feature` values as a contiguous array, while the
-  original dataset stored row-by-row (there are strides between values of a
+  implementation returns :capterm:`feature` values as a contiguous array, while
+  the original dataset stored row-by-row (there are strides between values of a
   single feature).
 
-- To acquire data in a desired :term:`data format` for which
+- To acquire data in a desired :capterm:`data format` for which
   a specific set of operations is defined.
 
 - To have read-only, read-write and write-only access to the data. Accessor
   implementations are not required to have read-write and write-only access
-  modes for :term:`immutable <Immutability>` entities like :ref:`tables
+  modes for :capterm:`immutable <immutability>` entities like :ref:`tables
   <Table>`.
 
 For details, see :ref:`accessors` section.
@@ -282,7 +285,7 @@ within some table, a builder object can be constructed for this. Data inside a
 table builder can be retrieved by read-only, write-only or read-write accessors.
 
 Accessors shown on the diagram allow to get data from tables and table builders
-as :term:`flat <flat data>` blocks of rows.
+as :capterm:`flat <flat data>` blocks of rows.
 
 Details
 =======

--- a/source/elements/oneDAL/source/glossary.rst
+++ b/source/elements/oneDAL/source/glossary.rst
@@ -11,42 +11,42 @@ Machine learning terms
     :sorted:
 
     Categorical feature
-        A :term:`feature` with a discrete domain. Can be :term:`nominal <Nominal
-        feature>` or :term:`ordinal <Ordinal feature>`.
+        A :capterm:`feature` with a discrete domain. Can be :capterm:`nominal
+        <nominal feature>` or :capterm:`ordinal <ordinal feature>`.
 
         **Synonyms:** discrete feature, qualitative feature
 
     Nominal feature
-        A :term:`categorical feature` without ordering between values. Only
+        A :capterm:`categorical feature` without ordering between values. Only
         equality operation is defined for nominal features.
 
         **Examples:** a person's gender, color of a car
 
     Classification
-        A :term:`supervised machine learning problem <Supervised learning>` of
-        assigning :term:`labels <Label>` to :term:`feature vectors <Feature
-        vector>`.
+        A :capterm:`supervised machine learning problem <supervised learning>`
+        of assigning :capterm:`labels <label>` to :capterm:`feature vectors
+        <feature vector>`.
 
         **Examples:** predict what type of object is on the picture (a dog or a cat?),
         predict whether or not an email is spam
 
     Clustering
-        An :term:`unsupervised machine learning problem <Unsupervised learning>`
-        of grouping :term:`feature vectors <Feature vector>` into bunches, which
-        are usually encoded as :term:`nominal <Nominal feature>` values.
+        An :capterm:`unsupervised machine learning problem <unsupervised learning>`
+        of grouping :capterm:`feature vectors <feature vector>` into bunches, which
+        are usually encoded as :capterm:`nominal <nominal feature>` values.
 
         **Example:** find big star clusters in the space images
 
     Continuous feature
-        A :term:`feature` with values in a domain of real numbers. Can be
-        :term:`interval <Interval feature>` or :term:`ratio <Ratio feature>`
+        A :capterm:`feature` with values in a domain of real numbers. Can be
+        :capterm:`interval <interval feature>` or :capterm:`ratio <ratio feature>`
 
         **Synonyms:** quantitative feature, numerical feature
 
         **Examples:** a person's height, the price of the house
 
     Dataset
-        A collection of :term:`observations <Observation>`.
+        A collection of :capterm:`observations <observation>`.
 
     Feature
         A particular property or quality of a real object or an event. Has a
@@ -57,102 +57,102 @@ Machine learning terms
 
     Feature vector
         A vector that encodes information about real object, an event or a group
-        of objects or events. Contains at least one :term:`feature`.
+        of objects or events. Contains at least one :capterm:`feature`.
 
         **Example:** A rectangle can be described by two features: its width and
         height
 
     Inference
-        A process of applying a :term:`trained <Training>` :term:`model` to the
-        :term:`dataset` in order to predict :term:`response`
-        values based on input :term:`feature vectors <Feature vector>`.
+        A process of applying a :capterm:`trained <Training>` :capterm:`model`
+        to the :capterm:`dataset` in order to predict :capterm:`response` values
+        based on input :capterm:`feature vectors <Feature vector>`.
 
         **Synonym:** prediction
 
     Inference set
-        A :term:`dataset` used at the :term:`inference` stage.
-        Usually without :term:`responses <Response>`.
+        A :capterm:`dataset` used at the :capterm:`inference` stage.
+        Usually without :capterm:`responses <Response>`.
 
     Interval feature
-        A :term:`continuous feature` with values that can be compared, added or
+        A :capterm:`continuous feature` with values that can be compared, added or
         subtracted, but cannot be multiplied or divided.
 
         **Examples:** a timeframe scale, a temperature in Celcius or Fahrenheit
 
     Label
-        A :term:`response` with :term:`categorical <Categorical feature>` or
-        :term:`ordinal <Ordinal feature>` values. This is an output in
-        :term:`classification` and :term:`clustering` problems.
+        A :capterm:`response` with :capterm:`categorical <Categorical feature>` or
+        :capterm:`ordinal <Ordinal feature>` values. This is an output in
+        :capterm:`classification` and :capterm:`clustering` problems.
 
         **Example:** the spam-detection problem has a binary label indicating
         whether the email is spam or not
 
     Model
-        An entity that stores information necessary to run :term:`inference`
-        on a new :term:`dataset`. Typically a result of a :term:`training`
+        An entity that stores information necessary to run :capterm:`inference`
+        on a new :capterm:`dataset`. Typically a result of a :capterm:`training`
         process.
 
         **Example:** in linear regression algorithm, the model contains weight
         values for each input feature and a single bias value
 
     Observation
-        A :term:`feature vector` and zero or more :term:`responses<Response>`.
+        A :capterm:`feature vector` and zero or more :capterm:`responses<Response>`.
 
         **Synonyms:** instance, sample
 
     Ordinal feature
-        A :term:`categorical feature` with defined operations of equality and
+        A :capterm:`categorical feature` with defined operations of equality and
         ordering between values.
 
         **Example:** student's grade
 
     Outlier
-        :term:`Observation` which is significantly different from the other
+        :capterm:`Observation` which is significantly different from the other
         observations.
 
     Ratio feature
-        A :term:`continuous feature` with defined operations of equality,
+        A :capterm:`continuous feature` with defined operations of equality,
         comparison, addition, subtraction, multiplication, and division.
         Zero value element means the absence of any value.
 
         **Example:** the height of a tower
 
     Regression
-        A :term:`supervised machine learning problem <Supervised learning>` of
-        assigning :term:`continuous <Continuous feature>`
-        :term:`responses<Response>` for :term:`feature vectors <Feature vector>`.
+        A :capterm:`supervised machine learning problem <Supervised learning>` of
+        assigning :capterm:`continuous <Continuous feature>`
+        :capterm:`responses<Response>` for :capterm:`feature vectors <Feature vector>`.
 
         **Example:** predict temperature based on weather conditions
 
     Response
         A property of some real object or event which dependency from
-        :term:`feature vector` need to be defined in :term:`supervised learning`
-        problem. While a :term:`feature` is an input in the machine learning
+        :capterm:`feature vector` need to be defined in :capterm:`supervised learning`
+        problem. While a :capterm:`feature` is an input in the machine learning
         problem, the response is one of the outputs can be made by the
-        :term:`model` on the :term:`inference` stage.
+        :capterm:`model` on the :capterm:`inference` stage.
 
         **Synonym:** dependent variable
 
     Supervised learning
-        :term:`Training` process that uses a :term:`dataset` with information
-        about dependencies between :term:`features <Feature>` and
-        :term:`responses <Response>`. The goal is to get a :term:`model` of
-        dependencies between input :term:`feature vector` and
-        :term:`responses <Response>`.
+        :capterm:`Training` process that uses a :capterm:`dataset` with information
+        about dependencies between :capterm:`features <Feature>` and
+        :capterm:`responses <Response>`. The goal is to get a :capterm:`model` of
+        dependencies between input :capterm:`feature vector` and
+        :capterm:`responses <Response>`.
 
     Training
-        A process of creating a :term:`model` based on information extracted
-        from a :term:`training set`. Resulting :term:`model` is selected in
+        A process of creating a :capterm:`model` based on information extracted
+        from a :capterm:`training set`. Resulting :capterm:`model` is selected in
         accordance with some quality criteria.
 
     Training set
-        A :term:`dataset` used at the :term:`training` stage to create a
-        :term:`model`.
+        A :capterm:`dataset` used at the :capterm:`training` stage to create a
+        :capterm:`model`.
 
     Unsupervised learning
-        :term:`Training` process that uses a :term:`training set` with no
-        :term:`responses <Response>`. The goal is to find hidden patters inside
-        :term:`feature vectors <Feature vector>` and dependencies between them.
+        :capterm:`Training` process that uses a :capterm:`training set` with no
+        :capterm:`responses <Response>`. The goal is to find hidden patters inside
+        :capterm:`feature vectors <Feature vector>` and dependencies between them.
 
 |dal_short_name| terms
 ======================
@@ -162,11 +162,11 @@ Machine learning terms
 
     Accessor
         A |dal_short_name| concept for an object that provides access to the
-        data of another object in the special :term:`data format`. It abstracts
+        data of another object in the special :capterm:`data format`. It abstracts
         data access from interface of an object and provides uniform access to
         the data stored in objects of different types.
 
-    Batch Mode
+    Batch mode
         The computation mode for an algorithm in |dal_short_name|, where all the
         data needed for computation is available at the start and fits the
         memory of the device on which the computations are performed.
@@ -177,7 +177,7 @@ Machine learning terms
 
     Contiguous data
         Data that are stored as one contiguous memory block. One of the
-        characteristics of a :term:`data format`.
+        characteristics of a :capterm:`data format`.
 
     Data format
         Representation of the internal structure of the data.
@@ -186,8 +186,8 @@ Machine learning terms
         compressed-sparse-row format
 
     Data layout
-        A characteristic of :term:`data format` which describes the
-        order of elements in a :term:`contiguous data` block.
+        A characteristic of :capterm:`data format` which describes the
+        order of elements in a :capterm:`contiguous data` block.
 
         **Example:** row-major format, where elements are stored row by row
 
@@ -199,7 +199,7 @@ Machine learning terms
         **Examples:** ``int32_t``, ``float``, ``double``
 
     Flat data
-        A block of :term:`contiguous <contiguous data>` :term:`homogeneous
+        A block of :capterm:`contiguous <contiguous data>` :capterm:`homogeneous
         <homogeneous data>` data.
 
     Getter
@@ -213,22 +213,22 @@ Machine learning terms
 
 
     Heterogeneous data
-        Data which contain values either of different :term:`data types <Data
+        Data which contain values either of different :capterm:`data types <Data
         type>` or different sets of operations defined on them. One of the
-        characteristics of a :term:`data format`.
+        characteristics of a :capterm:`data format`.
 
-        **Example:** A :term:`dataset` with 100
-        :term:`observations <Observation>` of three :term:`interval features <Interval
-        feature>`. The first two features are of float32 :term:`data type`, while the
+        **Example:** A :capterm:`dataset` with 100
+        :capterm:`observations <Observation>` of three :capterm:`interval features <Interval
+        feature>`. The first two features are of float32 :capterm:`data type`, while the
         third one is of float64 data type.
 
     Homogeneous data
-        Data with values of single :term:`data type` and the same set of
+        Data with values of single :capterm:`data type` and the same set of
         available operations defined on them. One of the characteristics of a
-        :term:`data format`.
+        :capterm:`data format`.
 
-        **Example:** A :term:`dataset` with 100
-        :term:`observations <Observation>` of three  :term:`interval features <Interval
+        **Example:** A :capterm:`dataset` with 100
+        :capterm:`observations <Observation>` of three  :capterm:`interval features <Interval
         feature>`, each of type float32
 
     Immutability
@@ -241,12 +241,12 @@ Machine learning terms
         possible objects of a given type. Metadata do not expose information
         that is not a part of a type definition, e.g. implementation details.
 
-        **Example:** :term:`table` object can contain three :term:`nominal features
-        <Nominal feature>` with 100 :term:`observations <Observation>` (logical
+        **Example:** :capterm:`table` object can contain three :capterm:`nominal features
+        <Nominal feature>` with 100 :capterm:`observations <Observation>` (logical
         part of metadata). This object can store data as sparse csr array and
         provides direct access to them (physical part)
 
-    Online Mode
+    Online mode
         The computation mode for an algorithm in |dal_short_name|, where the
         data needed for computation becomes available in parts over time.
 
@@ -270,14 +270,14 @@ Machine learning terms
 
 
     Table
-        A |dal_short_name| concept for a :term:`dataset` that contains only
-        numerical data, :term:`categorical <Categorical feature>` or
-        :term:`continuous <Continuous feature>`. Serves as a transfer of data
+        A |dal_short_name| concept for a :capterm:`dataset` that contains only
+        numerical data, :capterm:`categorical <Categorical feature>` or
+        :capterm:`continuous <Continuous feature>`. Serves as a transfer of data
         between user's application and computations inside |dal_short_name|.
-        Hides details of :term:`data format` and generalizes access to the data.
+        Hides details of :capterm:`data format` and generalizes access to the data.
 
     Workload
-        A problem of applying a |dal_short_name| algorithm to a :term:`dataset`.
+        A problem of applying a |dal_short_name| algorithm to a :capterm:`dataset`.
 
 Common oneAPI terms
 ===================
@@ -291,7 +291,7 @@ Common oneAPI terms
     DPC++
         Data Parallel C++ (DPC++) is a high-level language designed for data
         parallel programming productivity. DPC++ is based on :term:`SYCL*
-        <sycl>` from the Khronos* Group to support data parallelism and
+        <SYCL>` from the Khronos* Group to support data parallelism and
         heterogeneous programming.
 
     Host/Device


### PR DESCRIPTION
Fix #147 with the help of [custom Sphinx role](https://protips.readthedocs.io/link-roles.html):
```py
_term_ref_re = re.compile(r'(.+)<(.+)>', flags=re.DOTALL)
def capterm_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
    xref_role = roles.XRefRole(innernodeclass=nodes.inline,
                               warn_dangling=True)
    term_match = _term_ref_re.match(text)
    if term_match:
        txt, ref = term_match.group(1), term_match.group(2)
    else:
        txt, ref = text, text
    fixed_term = f'{txt.strip()} <{ref.strip().capitalize()}>'
    return xref_role('std:term', rawtext, fixed_term, lineno, inliner, options, content)
```

Results:
- The [produced output](https://rlnx.github.io/oneapi-spec/glossary.html) does not contain capitalized references.
- Sphinx does not generate warnings during the build.
- Less code: ``:term:`feature <Feature>` `` -> ``:capterm:`feature` ``