### PR TITLE
[DAL] Lowercase references in the text

### DIFF
--- a/source/elements/oneDAL/dalapi/extension.py
+++ b/source/elements/oneDAL/dalapi/extension.py
@@ -280,6 +280,7 @@ def setup(app):
     ctx = Context(app)
 
     app.add_role('capterm', roles.capterm_role)
+    app.add_role('txtref', roles.txtref_role)
 
     app.add_directive('onedal_class', directives.ClassDirective(ctx))
     app.add_directive('onedal_func', directives.FunctionDirective(ctx))

--- a/source/elements/oneDAL/dalapi/roles.py
+++ b/source/elements/oneDAL/dalapi/roles.py
@@ -13,3 +13,33 @@ def capterm_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
         txt, ref = text, text
     fixed_term = f'{txt.strip()} <{ref.strip().capitalize()}>'
     return xref_role('std:term', rawtext, fixed_term, lineno, inliner, options, content)
+
+
+_term_txt_ref_re = re.compile(r'(.*)<(.+)>(.*)', flags=re.DOTALL)
+def txtref_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    xref_role = roles.XRefRole(lowercase=True,
+                               innernodeclass=nodes.inline,
+                               warn_dangling=True)
+    def extract_ref_words(ref):
+        return [item for sub in ref.split('-') for item in sub.split('_')]
+
+    def make_term_text(words, ref, suffix=''):
+        txt = ' '.join(words).strip()
+        txt = txt[0].lower() + txt[1:]
+        return f"{txt}{suffix} <{ref.strip()}>"
+
+    term_match = _term_txt_ref_re.match(text)
+    if term_match:
+        alias, ref, suffix = term_match.group(1), term_match.group(2), term_match.group(3)
+        if len(alias) > 0 and len(suffix) == 0:
+            fixed_term = text
+        elif len(alias) == 0 and len(suffix) > 0:
+            words = extract_ref_words(ref)
+            fixed_term = make_term_text(words, ref, suffix)
+        else:
+            raise RuntimeError('Unexpected role syntax: ' + rawtext)
+    else:
+        ref, words = text, extract_ref_words(text)
+        fixed_term = make_term_text(words, ref)
+
+    return xref_role('std:ref', rawtext, fixed_term, lineno, inliner, options, content)

--- a/source/elements/oneDAL/source/algorithms/nearest_neighbors/knn_classification.rst
+++ b/source/elements/oneDAL/source/algorithms/nearest_neighbors/knn_classification.rst
@@ -62,7 +62,7 @@ from the initial training set :math:`X`.
 Training method: *k-d tree*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The training operation builds a :math:`k`-:math:`d` tree that partitions the
-training set :math:`X` (for more details, see :ref:`kd_tree`).
+training set :math:`X` (for more details, see :txtref:`k-d Tree <kd_tree>`).
 
 
 .. _i_math:

--- a/source/elements/oneDAL/source/data_management/accessors.rst
+++ b/source/elements/oneDAL/source/data_management/accessors.rst
@@ -4,9 +4,9 @@
 Accessors
 =========
 
-This section defines `requirements <accessor_reqs_>`_ to an :ref:`accessor
-<accessor>` implementation and introduces several `accessor types
-<accessor_types_>`_.
+This section defines :txtref:`requirements <accessor_reqs>` to an
+:txtref:`accessor` implementation and introduces several
+:txtref:`accessor_types`.
 
 .. _accessor_reqs:
 
@@ -20,15 +20,14 @@ Each accessor implementation shall:
    accessor. Every single accessor type shall return and use only one data
    format.
 
-2. Provide an access to at least one in-memory :ref:`dataset` implementation
-   (such as :code:`table`, its sub-types, or :ref:`table builders
-   <table-builder>`).
+2. Provide an access to at least one in-memory :txtref:`dataset` implementation
+   (such as :code:`table`, its sub-types, or :txtref:`<table-builder>s`).
 
 3. Provide read-only, write-only, or read-write access to the data. If an
-   accessor supports several :ref:`dataset` implementations to be passed in, it
-   is not necessary for an accessor to support all access modes for every input
-   object. For example, tables shall support a single read-only mode according
-   to their :ref:`concept <table>` definition.
+   accessor supports several :txtref:`dataset` implementations to be passed in,
+   it is not necessary for an accessor to support all access modes for every
+   input object. For example, tables shall support a single read-only mode
+   according to their :txtref:`<table> concept` definition.
 
 4. Provide the names for read and write operations following the pattern:
 
@@ -36,7 +35,7 @@ Each accessor implementation shall:
 
    - :code:`push_*()` for writing
 
-5. Be lightweight. Its constructors from :ref:`dataset` implementations
+5. Be lightweight. Its constructors from :txtref:`dataset` implementations
    shall not have heavy operations such as copy of data, reading, writing, any
    sort of conversions. These operations shall be performed by heavy operations
    :code:`pull_*()` and :code:`push_*()`. It is not necessary to have copy- or
@@ -51,9 +50,9 @@ Accessor Types
 --------------
 
 |dal_short_name| defines a set of accessor classes. Each class is associated
-with a single specific way of interacting with data within a :ref:`dataset`. The
-following table briefly explains these classes and shows which :ref:`dataset`
-implementations are supported by each accessor type.
+with a single specific way of interacting with data within a :txtref:`dataset`.
+The following table briefly explains these classes and shows which
+:txtref:`dataset` implementations are supported by each accessor type.
 
 .. list-table::
    :header-rows: 1

--- a/source/elements/oneDAL/source/data_management/index.rst
+++ b/source/elements/oneDAL/source/data_management/index.rst
@@ -7,10 +7,10 @@ Data management
 
 This section includes descriptions of concepts and objects that operate on data.
 For |dal_short_name|, such set of operations, or **data management**, is
-distributed between different stages of the :ref:`data analytics pipeline
+distributed between different stages of the :txtref:`data analytics pipeline
 <data_analytics_pipeline>`. From a perspective of data management, this pipeline
 contains three main steps of data acquisition, preparation, and computation (see
-:ref:`the picture below <typical_data_management_flow>`):
+:txtref:`the picture below <typical_data_management_flow>`):
 
 1. Raw data acquisition
 
@@ -19,7 +19,7 @@ contains three main steps of data acquisition, preparation, and computation (see
 
 2. Data preparation
 
-  - Support different in-memory :capterm:`data formats <Data format>`.
+  - Support different in-memory :capterm:`data formats <data format>`.
   - Compress and decompress the data.
   - Convert the data into numeric representation.
   - Recover missing values.
@@ -47,7 +47,7 @@ Key concepts
 ============
 
 |dal_short_name| provides a set of concepts to operate on out-of-memory and
-in-memory data during different stages of the :ref:`data analytics pipeline
+in-memory data during different stages of the :txtref:`data analytics pipeline
 <data_analytics_pipeline>`.
 
 .. _dataset:
@@ -73,8 +73,8 @@ example:
 2. At the preparation stage, it is converted into a numerical
    representation.
 
-3. At the computation stage, it is used as one of the :ref:`inputs <Input>` or
-   :ref:`results <Result>` of an algorithm or a :ref:`descriptor <descriptors>`
+3. At the computation stage, it is used as one of the :txtref:`inputs <Input>` or
+   :txtref:`results <Result>` of an algorithm or a :txtref:`descriptor <descriptors>`
    properties.
 
 .. _data-source:
@@ -106,7 +106,7 @@ following:
   feature>` and :capterm:`continuous <continuous feature>` data values into one
   of the numeric :capterm:`data formats <data format>`.
 
-For details, see :ref:`data-sources` section.
+For details, see :txtref:`data-sources` section.
 
 .. _table:
 
@@ -126,8 +126,8 @@ used at the data preparation and data processing stages for the following:
 - To transfer memory ownership of the data from user application to the table,
   or share it between them.
 
-- To connect with the :ref:`data-source` to convert from an out-of-memory into
-  an in-memory dataset representation.
+- To connect with the :txtref:`data-source` to convert from an out-of-memory
+  into an in-memory dataset representation.
 
 - To support streaming of the data to the algorithm.
 
@@ -141,7 +141,7 @@ implementations shall be :capterm:`immutable <immutability>`.
 This concept has different logical organization and physical :capterm:`format of
 the data <data format>`:
 
-- Logically, a table is a :ref:`dataset` with :math:`n` rows and
+- Logically, a table is a :txtref:`dataset` with :math:`n` rows and
   :math:`p` columns. Each row represents an :capterm:`observation` and each
   column is a :capterm:`feature` of a dataset. Physical amount of bytes needed
   to store the data differ from the number of elements :math:`n \times p` within
@@ -153,18 +153,18 @@ the data <data format>`:
   of arrays of different :capterm:`data types <data type>`, in a
   compressed-sparse-row format.
 
-For details, see :ref:`tables` section.
+For details, see :txtref:`tables` section.
 
 .. _metadata:
 
 Metadata
 --------
 
-Metadata concept is assotiated with a :ref:`dataset` and holds information about
-its structure and type. This information shall be enough to determine the
+Metadata concept is assotiated with a :txtref:`dataset` and holds information
+about its structure and type. This information shall be enough to determine the
 particular type of a dataset, and it helps to understand how to interact with a
 dataset in |dal_short_name| (for example, how to use it at a particular stage of
-:ref:`data analytics pipeline <data_analytics_pipeline>` or how to access its
+:txtref:`data analytics pipeline <data_analytics_pipeline>` or how to access its
 data).
 
 For each dataset, its metadata shall contain:
@@ -180,9 +180,9 @@ For each dataset, its metadata shall contain:
 .. note::
   Metadata can contain both compile-time and run-time information. For example,
   basic compile-time metadata is the type of a dataset - whether it is a
-  particular :ref:`data-source` or a :ref:`table`. Run-time information can
-  contain the :capterm:`feature` types and :capterm:`data types <data type>` of
-  a dataset.
+  particular :txtref:`data-source` or a :txtref:`table`. Run-time information
+  can contain the :capterm:`feature` types and :capterm:`data types <data type>`
+  of a dataset.
 
 .. _table-builder:
 
@@ -190,29 +190,28 @@ Table builder
 -------------
 
 A table :capterm:`builder` is a concept that is associated with a particular
-:ref:`table` type and is used at the data preparation and data processing stages
-for:
+:txtref:`table` type and is used at the data preparation and data processing
+stages for:
 
-- Iterative construction of a :ref:`table` from another :ref:`tables <table>` or
-  a different in-memory :ref:`dataset` representations.
+- Iterative construction of a :txtref:`table` from another :txtref:`<table>s` or
+  a different in-memory :txtref:`dataset` representations.
 
-- Construction of a :ref:`table` from different entities that hold blocks of
+- Construction of a :txtref:`table` from different entities that hold blocks of
   data, such as arrays, pointers to the memory, external entities.
 
-- Changing dataset values. Since :ref:`table` is an
+- Changing dataset values. Since :txtref:`table` is an
   :capterm:`immutable <immutability>` dataset, a builder provides the ability to
   change the values in a dataset under construction.
 
-- Encapsulating construction process of a :ref:`table`. This is used to hide the
+- Encapsulating construction process of a :txtref:`table`. This is used to hide the
   implementation details as they are irrelevant for users. This also allow to
   select the most appropriate table implementation for each particular case.
 
-- Providing additional information on how to create a :ref:`table` inside an
-  algorithm for :ref:`results  <Result>`. This information includes metadata,
-  memory allocators that shall be used, or even a particular table
-  implementation.
+- Providing additional information on how to create a :txtref:`table` inside an
+  algorithm for :txtref:`<result>s`. This information includes metadata, memory
+  allocators that shall be used, or even a particular table implementation.
 
-For details, see :ref:`table-builders` section.
+For details, see :txtref:`table-builders` section.
 
 .. _accessor:
 
@@ -220,17 +219,17 @@ Accessor
 --------
 
 Accessor is a concept that defines a single way to get the data from an
-in-memory numerical :ref:`dataset`. It allows:
+in-memory numerical :txtref:`dataset`. It allows:
 
 - To have unified access to the data from various sets of different objects,
-  such as :ref:`tables <Table>` or :ref:`table builders <table-builder>`,
+  such as :txtref:`<table>s` or :txtref:`<table-builder>s`,
   without exposing their implementation details.
 
 - To convert a variety of numeric :capterm:`data formats <data format>` into a
   smaller set of formats.
 
 - To provide a :capterm:`flat <flat data>` view on the data blocks of a
-  :ref:`dataset` for better a data locality. For example, some accessor
+  :txtref:`dataset` for better a data locality. For example, some accessor
   implementation returns :capterm:`feature` values as a contiguous array, while
   the original dataset stored row-by-row (there are strides between values of a
   single feature).
@@ -240,25 +239,25 @@ in-memory numerical :ref:`dataset`. It allows:
 
 - To have read-only, read-write and write-only access to the data. Accessor
   implementations are not required to have read-write and write-only access
-  modes for :capterm:`immutable <immutability>` entities like :ref:`tables
-  <Table>`.
+  modes for :capterm:`immutable <immutability>` entities like
+  :txtref:`<table>s`.
 
-For details, see :ref:`accessors` section.
+For details, see :txtref:`accessors` section.
 
 Use-case example for table, accessor and table builder
 ------------------------------------------------------
 
-This section provides a basic usage scenario of the :ref:`table`,
-:ref:`table-builder`, and :ref:`accessor` concepts and demonstrates the
-relations between them. :ref:`The following diagram
+This section provides a basic usage scenario of the :txtref:`table`,
+:txtref:`table-builder`, and :txtref:`accessor` concepts and demonstrates the
+relations between them. :txtref:`The following diagram
 <data_management_sequence_diagram>` shows objects of these concepts, which are
 highlighted by colors:
 
-- :ref:`Table builder <table-builder>` objects are blue.
+- :txtref:`Table builder <table-builder>` objects are blue.
 
-- :ref:`Table <table>` objects are cyan.
+- :txtref:`Table <table>` objects are cyan.
 
-- :ref:`Accessors <Accessor>` are yellow.
+- :txtref:`Accessors <Accessor>` are yellow.
 
 - Grey objects are not a part of |dal_short_name| specification and they are
   provided just for illustration purposes.
@@ -269,11 +268,11 @@ highlighted by colors:
   :width: 800
   :alt: Sequence diagram of accessor-builder-table relations
 
-To perform computations on a dataset, one shall create a :ref:`table` object
-first. It can be done using a :ref:`data-source` or a :ref:`table-builder`
+To perform computations on a dataset, one shall create a :txtref:`table` object
+first. It can be done using a :txtref:`data-source` or a :txtref:`table-builder`
 object depending on the situation. The diagram briefly shows the situation when
-:ref:`table` is interatively created from a various external entities (not shown
-on a diagram) using a :ref:`table-builder`.
+:txtref:`table` is interatively created from a various external entities (not
+shown on a diagram) using a :txtref:`table-builder`.
 
 Once a table object is created, the data inside it can be accessed by its own
 interface or with a help of a read-only accessor as shown on the diagram. The

--- a/source/elements/oneDAL/source/data_management/table_builders.rst
+++ b/source/elements/oneDAL/source/data_management/table_builders.rst
@@ -4,20 +4,20 @@
 Table Builders
 ==============
 
-This section contains definitions of classes that implement :ref:`table-builder`
-concept.
+This section contains definitions of classes that implement
+:txtref:`table-builder` concept.
 
 ------------
 Requirements
 ------------
 
-Each implementation of :ref:`table-builder` concept shall:
+Each implementation of :txtref:`table-builder` concept shall:
 
-1. Provide the ability to create a single :ref:`table` concept implementation.
-   Each builder shall be associated with a single table type.
+1. Provide the ability to create a single :txtref:`table` concept
+   implementation. Each builder shall be associated with a single table type.
 
 2. Be a stateful object which state is used to access data inside
-   builder via :ref:`accessors <Accessors>` or to create a table object.
+   builder via :txtref:`accessors` or to create a table object.
 
 3. Provide :code:`build()` member function that creates a new table
    object based on the current snapshot of a builder state.
@@ -28,7 +28,7 @@ Table Builder Types
 -------------------
 
 |dal_short_name| defines a set of accessor classes each associated with a single
-:ref:`table` implementation.
+:txtref:`table` implementation.
 
 .. list-table::
    :header-rows: 1
@@ -36,11 +36,11 @@ Table Builder Types
    * - Table builder type
      - Description
    * - simple_homogen_table_builder_
-     - Allows to create :ref:`homogen_table` from raw pointers and standard C++
-       smart pointers.
+     - Allows to create :txtref:`homogen_table <homogen_table>` from raw
+       pointers and standard C++ smart pointers.
    * - simple_soa_table_builder_
-     - Allows to create :ref:`soa_table` from raw pointers and standard C++
-       smart pointers.
+     - Allows to create :txtref:`soa_table <soa_table>` from raw pointers and
+       standard C++ smart pointers.
 
 .. _simple_homogen_table_builder:
 

--- a/source/elements/oneDAL/source/data_management/tables.rst
+++ b/source/elements/oneDAL/source/data_management/tables.rst
@@ -6,33 +6,33 @@
 Tables
 ======
 
-This section describes the types related to the :ref:`table <table>` and
-:ref:`metadata <metadata>` concepts. |dal_short_name| defines the following
-types that implement these concepts:
+This section describes the types related to the :txtref:`table` and
+:txtref:`metadata` concepts. |dal_short_name| defines the following types that
+implement these concepts:
 
 - The :code:`table` is a base class that implements the table concept and
-  provides capability to get a metadata. Each implementation of the :ref:`table
-  <table>` concept shall be derived from the :code:`table` class (for more
-  details, see :ref:`table_api`).
+  provides capability to get a metadata. Each implementation of the
+  :txtref:`table` concept shall be derived from the :code:`table` class (for
+  more details, see :txtref:`table_API` section).
 
 - The :code:`table_meta` class implements the metadata concept for the
   table. Each derived table type may provide its own implementation of the
   :code:`table_meta` that extends the metadata concept (for more details, see
-  :ref:`Metadata API`).
+  :txtref:`metadata_API` section).
 
 
 ------------
 Requirements
 ------------
 
-Each implementation of :ref:`table <table>` concept shall:
+Each implementation of :txtref:`table` concept shall:
 
 1. Follow definition of the table concept.
 
 2. Be derived from the :code:`table` class. The behavior of this class can be
    extended, but cannot be weaken.
 
-3. Provide an implementation of the :ref:`metadata <metadata>` concept derived
+3. Provide an implementation of the :txtref:`metadata` concept derived
    from the :code:`table_meta` class.
 
 4. Be :term:`reference-counted <Reference-counted object>`. An assignment
@@ -52,8 +52,8 @@ Each implementation of :ref:`table <table>` concept shall:
 Table Types
 -----------
 
-|dal_short_name| defines a set of classes. Each class implements the :ref:`table
-<table>` concept and represents a specific data format.
+|dal_short_name| defines a set of classes. Each class implements the
+:txtref:`table` concept and represents a specific data format.
 
 .. list-table::
    :header-rows: 1
@@ -62,7 +62,7 @@ Table Types
    * - Table type
      - Description
 
-   * - :ref:`table <table_api>`
+   * - :txtref:`table <table_API>`
      - A common implementation of the table concept. Base class for
        other table types.
 
@@ -82,7 +82,7 @@ Table Types
      - Sparse homogeneous table which data are stored in compressed sparse row
        (CSR) format.
 
-.. _table_api:
+.. _table_API:
 
 ---------
 Table API
@@ -182,8 +182,8 @@ Class ``homogen_table`` is an implementation of a table type
 for which the following is true:
 
 - Its data is dense and it is stored as one contiguous memory block
-- All features have the same :ref:`data type <Data type>`
-  (but :ref:`feature types <Feature type>` may differ)
+- All features have the same :txtref:`data type <Data type>`
+  (but :txtref:`feature types <Feature type>` may differ)
 
 ::
 
@@ -278,7 +278,7 @@ Compressed-sparse-row table
 ---------------------------
 TBD
 
-.. _Metadata API:
+.. _metadata_API:
 
 ------------
 Metadata API

--- a/source/elements/oneDAL/source/introduction.rst
+++ b/source/elements/oneDAL/source/introduction.rst
@@ -27,25 +27,25 @@ end-to-end analytics frameworks.
 
 |dal_short_name| consists of the following major components:
 
- - The :ref:`Data Management <data_management>` component includes
+ - The :txtref:`Data Management <data_management>` component includes
    classes and utilities for data acquisition, initial preprocessing
    and normalization, for data conversion into numeric formats
    (performed by one of supported Data Sources), and for model
    representation.
 
- - The :ref:`Algorithms <algorithms>` component consists of classes
+ - The :txtref:`Algorithms <algorithms>` component consists of classes
    that implement algorithms for data analysis (data mining) and data
    modeling (training and prediction). These algorithms include
    clustering, classification, regression, and recommendation
    algorithms.  Algorithms support the following computation modes:
 
-   - :ref:`Batch processing <Batch>`: algorithms work with the entire
+   - :txtref:`Batch processing <Batch>`: algorithms work with the entire
      data set to produce the final result
 
-   - :ref:`Online processing <Online>`: algorithms process a data set
+   - :txtref:`Online processing <Online>`: algorithms process a data set
      in blocks streamed into the device’s memory
 
-   - :ref:`Distributed processing <Distributed>`: algorithms operate
+   - :txtref:`Distributed processing <Distributed>`: algorithms operate
      on a data set distributed across several devices (compute nodes)
 
      Distributed algorithms in |dal_short_name| are abstracted from

--- a/source/elements/oneDAL/source/programming_model/algorithm_anatomy.rst
+++ b/source/elements/oneDAL/source/programming_model/algorithm_anatomy.rst
@@ -52,8 +52,8 @@ computational methods. A descriptor serves as:
   a stateful object whose state changes after an operation is applied.
 
 Each oneDAL algorithm has its own dedicated namespace, where the corresponding
-descriptor is defined (for more details, see :ref:`common_namespaces`).
-Descriptor, in its turn, defines the following:
+descriptor is defined (for more details, see :txtref:`Namespaces
+<common_namespaces>`). Descriptor, in its turn, defines the following:
 
 - **Template parameters.** A descriptor is allowed to have any number of template
   parameters, but shall support at least two:


### PR DESCRIPTION
This PR proposes a new custom rule `txtref`. As a standard `ref` rule, this provides references to some locations in a document.

Consider next reference declaration:
```rst
:: _some_ref:
Some reference
```
- `:ref:'some_ref'` will result to the text after `some_ref` declaration: `Some reference`
- `txtref:'some_ref'` will result to `some ref` and points to the same destination as a `ref` clause

**Rules of `txtref` role** 
1. **:txtref:'some_text'** will create a link to `some_text` destination and results to the original text of the link with delimiter characters (`-` and `_`) replaced by spaces:
   - :txtref:'some_text' -> some text
   -  :txtref:'some-text' -> some text
   - :txtref:'some_another-text' -> some another text
2. **:txtref:'Table_API'** will create a link to `Table_API` and results to `table API`, replacing the first capital letter by lowercase one
3. **:txtref:'some text link <some_text>'** will act the same as `:ref:` rule poining to some_text link and aliasing it by "some text link" text.
4. **:txtref:<some_object>s** -> someobjects, with reference to some_object destination. It will help to shorten references like "Iterative construction of a :ref:`table` from another :ref:`tables <table>`"