### PR TITLE
Update oneVPL and Media SDK product names

### DIFF
--- a/source/elements/oneVPL/include/onevpl/mfxdefs.h
+++ b/source/elements/oneVPL/include/onevpl/mfxdefs.h
@@ -31,8 +31,8 @@
   #define MFX_VERSION_MINOR ((MFX_VERSION) % 1000)
 #endif
 
-/*! This is correspondent version of MediaSDK Legacy API which is used as a basis 
-   for the current oneVPL API. */
+/*! This is correspondent version of the Intel(r) Media SDK legacy API that is used as a basis 
+   for the current oneAPI Video Processing Library (oneVPL) API. */
 
 #define MFX_LEGACY_VERSION 1034
 
@@ -58,7 +58,7 @@ extern "C"
 /* The general rule for alignment is following:
    - structures with pointers have 4/8 bytes alignment on 32/64 bit systems
    - structures with fields of type mfxU64/mfxF64 (unsigned long long / double)
-     have alignment 8 bytes on 64 bit and 32 bit Windows, on Linux alignment is 4 bytes
+     have alignment 8 bytes on 64 bit and 32 bit Windows*, on Linux* alignment is 4 bytes
    - all the rest structures are 4 bytes aligned
    - there are several exceptions: some structs which had 4-byte alignment were extended
      with pointer / long type fields; such structs have 4-byte alignment to keep binary
@@ -70,11 +70,11 @@ extern "C"
 #if defined(_WIN64) || defined(__LP64__)
     #define MFX_PACK_BEGIN_STRUCT_W_PTR()    MFX_PACK_BEGIN_X(8)
     #define MFX_PACK_BEGIN_STRUCT_W_L_TYPE() MFX_PACK_BEGIN_X(8)
-/* 32-bit ILP32 data model Windows (Intel architecture) */
+/* 32-bit ILP32 data model Windows* (Intel(r) architecture) */
 #elif defined(_WIN32) || defined(_M_IX86) && !defined(__linux__)
     #define MFX_PACK_BEGIN_STRUCT_W_PTR()    MFX_PACK_BEGIN_X(4)
     #define MFX_PACK_BEGIN_STRUCT_W_L_TYPE() MFX_PACK_BEGIN_X(8)
-/* 32-bit ILP32 data model Linux */
+/* 32-bit ILP32 data model Linux* */
 #elif defined(__ILP32__)
     #define MFX_PACK_BEGIN_STRUCT_W_PTR()    MFX_PACK_BEGIN_X(4)
     #define MFX_PACK_BEGIN_STRUCT_W_L_TYPE() MFX_PACK_BEGIN_X(4)

--- a/source/elements/oneVPL/include/onevpl/mfxstructures.h
+++ b/source/elements/oneVPL/include/onevpl/mfxstructures.h
@@ -2291,7 +2291,7 @@ enum {
 
     MFX_MEMTYPE_INTERNAL_FRAME  = 0x0001, /*!< Allocation request for internal frames */
     MFX_MEMTYPE_EXTERNAL_FRAME  = 0x0002, /*!< Allocation request for I/O frames */
-    MFX_MEMTYPE_EXPORT_FRAME    = 0x0008, /*!< Application requests frame handle export to some associated object. For Linux frame handle can be
+    MFX_MEMTYPE_EXPORT_FRAME    = 0x0008, /*!< Application requests frame handle export to some associated object. For Linux* frame handle can be
                                                considered to be exported to DRM Prime FD, DRM FLink or DRM FrameBuffer Handle. Specifics of export
                                                types and export procedure depends on external frame allocator implementation */
     MFX_MEMTYPE_SHARED_RESOURCE = MFX_MEMTYPE_EXPORT_FRAME, /*!< For DX11 allocation use shared resource bind flag. */


### PR DESCRIPTION
Update legacy and current product names for oneVPL to be
compliant with product names DB guidelines.

Signed-off-by: Kristal Dale <kristal.dale@intel.com>