### PR TITLE
[DAL] Add task to template parameters for all algos

### DIFF
--- a/source/elements/oneDAL/dalapi/directives.py
+++ b/source/elements/oneDAL/dalapi/directives.py
@@ -201,13 +201,13 @@ class ListingDirective(DoxyDirective):
 
 
 @directive
-class ComputeMethodsDirective(DoxyDirective):
+class TagsNamespaceDirective(DoxyDirective):
     required_arguments = 1
     optional_arguments = 0
     has_content = False
 
     def rst(self, x: RstBuilder):
-        methods_namespace = self.arguments[0] + '::method'
+        methods_namespace = self.arguments[0]
         method_ns = self.ctx.index.find(methods_namespace)
         self.add_listing(method_ns, x, remove_empty_lines=True)
         self._add_classes(method_ns, x)

--- a/source/elements/oneDAL/dalapi/extension.py
+++ b/source/elements/oneDAL/dalapi/extension.py
@@ -285,7 +285,7 @@ def setup(app):
     app.add_directive('onedal_class', directives.ClassDirective(ctx))
     app.add_directive('onedal_func', directives.FunctionDirective(ctx))
     app.add_directive('onedal_code', directives.ListingDirective(ctx))
-    app.add_directive('onedal_compute_methods', directives.ComputeMethodsDirective(ctx))
+    app.add_directive('onedal_tags_namespace', directives.TagsNamespaceDirective(ctx))
 
     app.add_config_value('onedal_project_dir', '.', 'env')
 

--- a/source/elements/oneDAL/include/oneapi/dal/kmeans.hpp
+++ b/source/elements/oneDAL/include/oneapi/dal/kmeans.hpp
@@ -15,7 +15,8 @@ namespace method {
 } // namespace method
 
 namespace task {
-   /// Tag-type that parametrizes entities used for solving clustering problem.
+   /// Tag-type that parametrizes entities used for solving
+   /// :capterm:`clustering problem <clustering>` .
    struct clustering {};
 
    /// Alias tag-type for custering task.

--- a/source/elements/oneDAL/include/oneapi/dal/kmeans.hpp
+++ b/source/elements/oneDAL/include/oneapi/dal/kmeans.hpp
@@ -143,9 +143,12 @@ public:
 /// @pre :expr:`input.initial_centroids.row_count == desc.cluster_count`
 /// @pre :expr:`input.initial_centroids.column_count == input.data.column_count`
 /// @post :expr:`result.labels.row_count == input.data.row_count`
+/// @post :expr:`result.labels.column_count == 1`
+/// @post :expr:`result.labels[i] >= 0`
+/// @post :expr:`result.labels[i] < desc.cluster_count`
+/// @post :expr:`result.iteration_count <= desc.max_iteration_count`
 /// @post :expr:`result.model.clusters.row_count == desc.cluster_count`
 /// @post :expr:`result.model.clusters.column_count == input.data.column_count`
-/// @post :expr:`result.iteration_count <= desc.max_iteration_count`
 template <typename Float, typename Method, typename Task>
 train_result<Task> train(const descriptor<Float, Method, Task>& desc,
                          const train_input<Task>& input);
@@ -177,6 +180,7 @@ public:
 template <typename Task = task::by_default>
 class infer_result {
 public:
+   /// Creates a new instance of the class with the default property values.
    infer_result();
 
    /// $n \\times 1$ table with assignments labels to feature
@@ -211,6 +215,9 @@ public:
 /// @pre :expr:`input.model.centroids.row_count == desc.cluster_count`
 /// @pre :expr:`input.model.centroids.column_count == input.data.column_count`
 /// @post :expr:`result.labels.row_count == input.data.row_count`
+/// @post :expr:`result.labels.column_count == 1`
+/// @post :expr:`result.labels[i] >= 0`
+/// @post :expr:`result.labels[i] < desc.cluster_count`
 template <typename Float, typename Method, typename Task>
 infer_result<Task> infer(const descriptor<Float, Method, Task>& desc,
                          const infer_input<Task>& input);

--- a/source/elements/oneDAL/include/oneapi/dal/kmeans.hpp
+++ b/source/elements/oneDAL/include/oneapi/dal/kmeans.hpp
@@ -65,7 +65,7 @@ public:
    /// Creates a new instance of the class with the default property values.
    model();
 
-   /// $k \\times p$ table with the cluster centroids. Each row of the
+   /// A $k \\times p$ table with the cluster centroids. Each row of the
    /// table stores one centroid.
    /// @remark default = table{}
    const table& get_centroids() const;
@@ -86,12 +86,12 @@ public:
    train_input(const table& data = table{},
                const table& initial_centroids = table{});
 
-   /// $n \\times p$ table with the data to be clustered, where each row
+   /// An $n \\times p$ table with the data to be clustered, where each row
    /// stores one feature vector.
    const table& get_data() const;
    train_input& set_data(const table&);
 
-   /// $k \\times p$ table with the initial centroids, where each row
+   /// A $k \\times p$ table with the initial centroids, where each row
    /// stores one centroid.
    const table& get_initial_centroids() const;
    train_input& set_initial_centroids(const table&);
@@ -109,7 +109,7 @@ public:
    /// @remark default = model<Task>{}
    const model<Task>& get_model() const;
 
-   /// $n \\times 1$ table with the labels $y_i$ assigned to the
+   /// An $n \\times 1$ table with the labels $y_i$ assigned to the
    /// samples $x_i$ in the input data, $1 \\leq 1 \\leq n$.
    /// @remark default = table{}
    const table& get_labels() const;
@@ -164,7 +164,7 @@ public:
    infer_input(const model<Task>& m = model<Task>{},
                const table& data = table{});
 
-   /// $n \\times p$ table with the data to be assigned to the clusters,
+   /// An $n \\times p$ table with the data to be assigned to the clusters,
    /// where each row stores one feature vector.
    /// @remark default = model<Task>{}
    const model<Task>& get_model() const;
@@ -184,7 +184,7 @@ public:
    /// Creates a new instance of the class with the default property values.
    infer_result();
 
-   /// $n \\times 1$ table with assignments labels to feature
+   /// An $n \\times 1$ table with assignments labels to feature
    /// vectors in the input data.
    /// @remark default = table{}
    const table& get_labels() const;

--- a/source/elements/oneDAL/include/oneapi/dal/kmeans.hpp
+++ b/source/elements/oneDAL/include/oneapi/dal/kmeans.hpp
@@ -16,10 +16,10 @@ namespace method {
 
 namespace task {
    /// Tag-type that parametrizes entities used for solving
-   /// :capterm:`clustering problem <clustering>` .
+   /// :capterm:`clustering problem <clustering>`.
    struct clustering {};
 
-   /// Alias tag-type for custering task.
+   /// Alias tag-type for the clustering task.
    using by_default = clustering;
 } // namespace task
 
@@ -28,7 +28,7 @@ namespace task {
 ///                :expr:`double`.
 /// @tparam Method Tag-type that specifies an implementation of algorithm. Can
 ///                be :expr:`method::lloyd`.
-/// @tparam Task   Tag-type that specifies type of the problem to solve. Can
+/// @tparam Task   Tag-type that specifies the type of the problem to solve. Can
 ///                be :expr:`task::clustering`.
 template <typename Float = float,
           typename Method = method::by_default,

--- a/source/elements/oneDAL/include/oneapi/dal/kmeans.hpp
+++ b/source/elements/oneDAL/include/oneapi/dal/kmeans.hpp
@@ -1,0 +1,248 @@
+#include <cstdint>
+#include "oneapi/dal/table.hpp"
+#include "oneapi/dal/train.hpp"
+
+namespace oneapi::dal::kmeans {
+
+namespace method {
+   /// Tag-type that denotes `Lloyd's <kmeans_t_math_lloyd_>`_ computational
+   /// method.
+   struct lloyd {};
+
+   /// Alias tag-type for `Lloyd's <kmeans_t_math_lloyd_>`_ computational
+   /// method.
+   using by_default = lloyd;
+} // namespace method
+
+namespace task {
+   /// Tag-type that parametrizes entities used for solving clustering problem.
+   struct clustering {};
+
+   /// Alias tag-type for custering task.
+   using by_default = clustering;
+} // namespace task
+
+/// @tparam Float  The floating-point type that the algorithm uses for
+///                intermediate computations. Can be :expr:`float` or
+///                :expr:`double`.
+/// @tparam Method Tag-type that specifies an implementation of algorithm. Can
+///                be :expr:`method::lloyd`.
+/// @tparam Task   Tag-type that specifies type of the problem to solve. Can
+///                be :expr:`task::clustering`.
+template <typename Float = float,
+          typename Method = method::by_default,
+          typename Task = task::by_default>
+class descriptor {
+public:
+   /// Creates a new instance of the class with the given :literal:`cluster_count`
+   explicit descriptor(std::int64_t cluster_count = 2);
+
+   /// The number of clusters $k$
+   /// @invariant :expr:`cluster_count > 0`
+   /// @remark default = 2
+   int64_t get_cluster_count() const;
+   descriptor& set_cluster_count(int64_t);
+
+   /// The maximum number of iterations $T$
+   /// @invariant :expr:`max_iteration_count >= 0`
+   /// @remark default = 100
+   int64_t get_max_iteration_count() const;
+   descriptor& set_max_iteration_count(int64_t);
+
+   /// The threshold $\\varepsilon$ for the stop condition
+   /// @invariant :expr:`accuracy_threshold >= 0.0`
+   /// @remark default = 0.0
+   double get_accuracy_threshold() const;
+   descriptor& set_accuracy_threshold(double);
+};
+
+/// @tparam Task Tag-type that specifies type of the problem to solve. Can
+///              be :expr:`task::clustering`.
+template <typename Task = task::by_default>
+class model {
+public:
+   /// Creates a new instance of the class with the default property values.
+   model();
+
+   /// $k \\times p$ table with the cluster centroids. Each row of the
+   /// table stores one centroid.
+   /// @remark default = table{}
+   const table& get_centroids() const;
+
+   /// Number of clusters $k$ in the trained model.
+   /// @invariant :expr:`cluster_count == centroids.row_count`
+   /// @remark default = 0
+   int64_t get_cluster_count() const;
+};
+
+/// @tparam Task Tag-type that specifies type of the problem to solve. Can
+///              be :expr:`task::clustering`.
+template <typename Task = task::by_default>
+class train_input {
+public:
+   /// Creates a new instance of the class with the given :literal:`data` and
+   /// :literal:`initial_centroids`
+   train_input(const table& data = table{},
+               const table& initial_centroids = table{});
+
+   /// $n \\times p$ table with the data to be clustered, where each row
+   /// stores one feature vector.
+   const table& get_data() const;
+   train_input& set_data(const table&);
+
+   /// $k \\times p$ table with the initial centroids, where each row
+   /// stores one centroid.
+   const table& get_initial_centroids() const;
+   train_input& set_initial_centroids(const table&);
+};
+
+/// @tparam Task Tag-type that specifies type of the problem to solve. Can
+///              be :expr:`task::clustering`.
+template <typename Task = task::by_default>
+class train_result {
+public:
+   /// Creates a new instance of the class with the default property values.
+   train_result();
+
+   /// The trained K-means model
+   /// @remark default = model<Task>{}
+   const model<Task>& get_model() const;
+
+   /// $n \\times 1$ table with the labels $y_i$ assigned to the
+   /// samples $x_i$ in the input data, $1 \\leq 1 \\leq n$.
+   /// @remark default = table{}
+   const table& get_labels() const;
+
+   /// The number of iterations performed by the algorithm.
+   /// @remark default = 0
+   /// @invariant :expr:`iteration_count >= 0`
+   int64_t get_iteration_count() const;
+
+   /// The value of the objective function $\\Phi_X(C)$, where $C$ is
+   /// :expr:`model.centroids` (see :expr:`kmeans::model::centroids`).
+   /// @invariant :expr:`objective_function_value >= 0.0`
+   double get_objective_function_value() const;
+};
+
+/// Runs the training operation for K-Means clustering. For more details see
+/// :expr:`oneapi::dal::train`.
+///
+/// @tparam Float  The floating-point type that the algorithm uses for
+///                intermediate computations. Can be :expr:`float` or
+///                :expr:`double`.
+/// @tparam Method Tag-type that specifies an implementation of algorithm. Can
+///                be :expr:`method::lloyd`.
+/// @tparam Task   Tag-type that specifies type of the problem to solve. Can
+///                be :expr:`task::clustering`.
+///
+/// @param[in] desc  Descriptor of the algorithm
+/// @param[in] input Input data for the training operation
+/// @return result   Result of the training operation
+///
+/// @pre :expr:`input.data.has_data == true`
+/// @pre :expr:`input.initial_centroids.row_count == desc.cluster_count`
+/// @pre :expr:`input.initial_centroids.column_count == input.data.column_count`
+/// @post :expr:`result.labels.row_count == input.data.row_count`
+/// @post :expr:`result.model.clusters.row_count == desc.cluster_count`
+/// @post :expr:`result.model.clusters.column_count == input.data.column_count`
+/// @post :expr:`result.iteration_count <= desc.max_iteration_count`
+template <typename Float, typename Method, typename Task>
+train_result<Task> train(const descriptor<Float, Method, Task>& desc,
+                         const train_input<Task>& input);
+
+/// @tparam Task Tag-type that specifies type of the problem to solve. Can
+///              be :expr:`task::clustering`.
+template <typename Task = task::by_default>
+class infer_input {
+public:
+   /// Creates a new instance of the class with the given :literal:`model` and
+   /// :literal:`data`
+   infer_input(const model<Task>& m = model<Task>{},
+               const table& data = table{});
+
+   /// $n \\times p$ table with the data to be assigned to the clusters,
+   /// where each row stores one feature vector.
+   /// @remark default = model<Task>{}
+   const model<Task>& get_model() const;
+   infer_input& set_model(const model<Task>&);
+
+   /// The trained K-Means model
+   /// @remark default = table{}
+   const table& get_data() const;
+   infer_input& set_data(const table&);
+};
+
+/// @tparam Task Tag-type that specifies type of the problem to solve. Can
+///              be :expr:`task::clustering`.
+template <typename Task = task::by_default>
+class infer_result {
+public:
+   infer_result();
+
+   /// $n \\times 1$ table with assignments labels to feature
+   /// vectors in the input data.
+   /// @remark default = table{}
+   const table& get_labels() const;
+
+   /// The value of the objective function $\\Phi_X(C)$, where $C$ is
+   /// defined by the corresponding :expr:`infer_input::model::centroids`.
+   /// @invariant :expr:`objective_function_value >= 0.0`
+   /// @remark default = 0.0
+   double get_objective_function_value() const;
+};
+
+/// Runs the inference operation for K-Means clustering. For more details see
+/// :expr:`oneapi::dal::infer`.
+///
+/// @tparam Float  The floating-point type that the algorithm uses for
+///                intermediate computations. Can be :expr:`float` or
+///                :expr:`double`.
+/// @tparam Method Tag-type that specifies an implementation of algorithm. Can
+///                be :expr:`method::lloyd`.
+/// @tparam Task   Tag-type that specifies type of the problem to solve. Can
+///                be :expr:`task::clustering`.
+///
+/// @param[in] desc  Descriptor of the algorithm
+/// @param[in] input Input data for the inference operation
+/// @return result   Result of the inference operation
+///
+
+/// @pre :expr:`input.data.has_data == true`
+/// @pre :expr:`input.model.centroids.row_count == desc.cluster_count`
+/// @pre :expr:`input.model.centroids.column_count == input.data.column_count`
+/// @post :expr:`result.labels.row_count == input.data.row_count`
+template <typename Float, typename Method, typename Task>
+infer_result<Task> infer(const descriptor<Float, Method, Task>& desc,
+                         const infer_input<Task>& input);
+
+} // namespace oneapi::dal::kmeans
+
+namespace oneapi::dal::kmeans::example {
+
+kmeans::model<> run_training(const table& data,
+                             const table& initial_centroids) {
+   const auto kmeans_desc = kmeans::descriptor<float>{}
+      .set_cluster_count(10)
+      .set_max_iteration_count(50)
+      .set_accuracy_threshold(1e-4);
+
+   const auto result = train(kmeans_desc, data, initial_centroids);
+
+   print_table("labels", result.get_labels());
+   print_table("centroids", result.get_model().get_centroids());
+   print_value("objective", result.get_objective_function_value());
+
+   return result.get_model();
+}
+
+table run_inference(const kmeans::model<>& model,
+                    const table& new_data) {
+   const auto kmeans_desc = kmeans::descriptor<float>{}
+      .set_cluster_count(model.get_cluster_count());
+
+   const auto result = infer(kmeans_desc, model, new_data);
+
+   print_table("labels", result.get_labels());
+}
+
+} // oneapi::dal::kmeans::example

--- a/source/elements/oneDAL/include/oneapi/dal/knn.hpp
+++ b/source/elements/oneDAL/include/oneapi/dal/knn.hpp
@@ -18,8 +18,8 @@ namespace method {
 } // namespace method
 
 namespace task {
-   /// Tag-type that parametrizes entities used for solving classification
-   /// problem.
+   /// Tag-type that parametrizes entities used for solving
+   /// :capterm:`classification problem <classification>`.
    struct classification {};
 
    /// Alias tag-type for classification task.

--- a/source/elements/oneDAL/include/oneapi/dal/knn.hpp
+++ b/source/elements/oneDAL/include/oneapi/dal/knn.hpp
@@ -114,8 +114,8 @@ public:
 ///
 /// @pre :expr:`input.data.has_data == true`
 /// @pre :expr:`input.labels.has_data == true`
-/// @pre :expr:`input.data.rows == input.labels.rows`
-/// @pre :expr:`input.data.columns == 1`
+/// @pre :expr:`input.data.row_count == input.labels.row_count`
+/// @pre :expr:`input.labels.column_count == 1`
 /// @pre :expr:`input.labels[i] >= 0`
 /// @pre :expr:`input.labels[i] < desc.class_count`
 template <typename Float, typename Method, typename Task>
@@ -127,6 +127,8 @@ train_result<Task> train(const descriptor<Float, Method, Task>& desc,
 template <typename Task = task::by_default>
 class infer_input {
 public:
+   /// Creates a new instance of the class with the given :literal:`model`
+   /// and :literal:`data` property values
    infer_input(const model<Task>& m = model<Task>{},
                const table& data = table{});
 
@@ -146,6 +148,7 @@ public:
 template <typename Task = task::by_default>
 class infer_result {
 public:
+   /// Creates a new instance of the class with the default property values.
    infer_result();
 
    /// The predicted labels
@@ -170,8 +173,8 @@ public:
 /// @return   result Result of the inference operation
 ///
 /// @pre  :expr:`input.data.has_data == true`
-/// @post :expr:`result.labels.rows == input.data.rows`
-/// @post :expr:`result.labels.columns == 1`
+/// @post :expr:`result.labels.row_count == input.data.row_count`
+/// @post :expr:`result.labels.column_count == 1`
 /// @post :expr:`result.labels[i] >= 0`
 /// @post :expr:`result.labels[i] < desc.class_count`
 template <typename Float, typename Method, typename Task>

--- a/source/elements/oneDAL/include/oneapi/dal/pca.hpp
+++ b/source/elements/oneDAL/include/oneapi/dal/pca.hpp
@@ -50,7 +50,7 @@ public:
    descriptor& set_component_count(int64_t);
 
    /// Specifies whether the algorithm applies the `Sign-flip technique`_.
-   /// If it is `true`, directions of the eigenvectors must be deterministic.
+   /// If it is `true`, the directions of the eigenvectors must be deterministic.
    /// @remark default = true
    bool get_deterministic() const;
    descriptor& set_deterministic(bool);
@@ -64,7 +64,7 @@ public:
    /// Creates a new instance of the class with the default property values.
    model();
 
-   /// $r \\times p$ table with the eigenvectors. Each row contains one
+   /// An $r \\times p$ table with the eigenvectors. Each row contains one
    /// eigenvector.
    /// @remark default = table{}
    const table& get_eigenvectors() const;
@@ -84,7 +84,7 @@ public:
    /// property value
    train_input(const table& data = table{});
 
-   /// $n \\times p$ table with the training data, where each row stores one
+   /// An $n \\times p$ table with the training data, where each row stores one
    /// feature vector.
    /// @remark default = table{}
    const table& get_data() const;
@@ -103,29 +103,29 @@ public:
    /// @remark default = model<Task>{}
    const model<Task>& get_model() const;
 
-   /// $1 \\times r$ table that contains mean value for the first $r$
+   /// A $1 \\times r$ table that contains the mean values for the first $r$
    /// features.
    /// @remark default = table{}
    const table& get_means() const;
 
-   /// $1 \\times r$ table that contains variance for the first $r$
+   /// A $1 \\times r$ table that contains the variances for the first $r$
    /// features.
    /// @remark default = table{}
    const table& get_variances() const;
 
-   /// $1 \\times r$ table that contains eigenvalue for for the first
+   /// A $1 \\times r$ table that contains the eigenvalues for for the first
    /// $r$ features.
    /// @remark default = table{}
    const table& get_eigenvalues() const;
 
-   /// $r \\times p$ table with the eigenvectors. Each row contains one
+   /// An $r \\times p$ table with the eigenvectors. Each row contains one
    /// eigenvector.
    /// @remark default = table{}
    /// @invariant :expr:`eigenvectors == model.eigenvectors`
    const table& get_eigenvectors() const;
 };
 
-/// Runs the training operation for PCA. For more details see
+/// Runs the training operation for PCA. For more details, see
 /// :expr:`oneapi::dal::train`.
 ///
 /// @tparam Float  The floating-point type that the algorithm uses for
@@ -207,7 +207,7 @@ public:
 ///
 /// @pre :expr:`input.data.has_data == true`
 /// @pre :expr:`input.model.eigenvectors.row_count == desc.component_count`
-/// @pre :expr:`input.model.eigenvectors.column_count = input.data.column_count`
+/// @pre :expr:`input.model.eigenvectors.column_count == input.data.column_count`
 /// @post :expr:`result.transformed_data.row_count == input.data.row_count`
 /// @post :expr:`result.transformed_data.column_count == desc.component_count`
 template <typename Float, typename Method, typename Task>

--- a/source/elements/oneDAL/include/oneapi/dal/pca.hpp
+++ b/source/elements/oneDAL/include/oneapi/dal/pca.hpp
@@ -18,8 +18,8 @@ namespace method {
 } // namespace method
 
 namespace task {
-   /// Tag-type that parametrizes entities used for solving dimensionality
-   /// reduction problem.
+   /// Tag-type that parametrizes entities used for solving
+   /// :capterm:`dimensionality reduction problem <dimensionality reduction>`.
    struct dim_reduction {};
 
    /// Alias tag-type for dimensionality reduction task.

--- a/source/elements/oneDAL/include/oneapi/dal/pca.hpp
+++ b/source/elements/oneDAL/include/oneapi/dal/pca.hpp
@@ -5,14 +5,14 @@
 namespace oneapi::dal::pca {
 
 namespace method {
-   /// Tag-type that denotes `brute-force <pca_t_math_cov>`_ computational
+   /// Tag-type that denotes `Covariance <pca_t_math_cov_>`_ computational
    /// method.
    struct cov {};
 
-   /// Tag-type that denotes `k-d tree <pca_t_math_svd>`_ computational method.
+   /// Tag-type that denotes `SVD <pca_t_math_svd_>`_ computational method.
    struct svd {};
 
-   /// Alias tag-type for `brute-force <pca_t_math_cov>`_ computational
+   /// Alias tag-type for `Covariance <pca_t_math_cov_>`_ computational
    /// method.
    using by_default = cov;
 } // namespace method

--- a/source/elements/oneDAL/include/oneapi/dal/pca.hpp
+++ b/source/elements/oneDAL/include/oneapi/dal/pca.hpp
@@ -1,0 +1,246 @@
+#include <cstdint>
+#include "oneapi/dal/table.hpp"
+#include "oneapi/dal/train.hpp"
+
+namespace oneapi::dal::pca {
+
+namespace method {
+   /// Tag-type that denotes `brute-force <pca_t_math_cov>`_ computational
+   /// method.
+   struct cov {};
+
+   /// Tag-type that denotes `k-d tree <pca_t_math_svd>`_ computational method.
+   struct svd {};
+
+   /// Alias tag-type for `brute-force <pca_t_math_cov>`_ computational
+   /// method.
+   using by_default = cov;
+} // namespace method
+
+namespace task {
+   /// Tag-type that parametrizes entities used for solving dimensionality
+   /// reduction problem.
+   struct dimensionality_reduction {};
+
+   /// Alias tag-type for dimensionality reduction task.
+   using by_default = dimensionality_reduction;
+} // namespace task
+
+/// @tparam Float  The floating-point type that the algorithm uses for
+///                intermediate computations. Can be :expr:`float` or
+///                :expr:`double`.
+/// @tparam Method Tag-type that specifies an implementation of algorithm. Can
+///                be :expr:`method::cov` or :expr:`method::svd`.
+/// @tparam Task   Tag-type that specifies type of the problem to solve. Can
+///                be :expr:`task::dimensionality_reduction`.
+template <typename Float = float,
+          typename Method = method::by_default,
+          typename Task = task::by_default>
+class descriptor {
+public:
+   /// Creates a new instance of the class with the given :literal:`component_count`
+   /// property value
+   explicit descriptor(std::int64_t component_count = 0);
+
+   /// The number of principal components $r$. If it is zero, the algorithm
+   /// computes the eigenvectors for all features, $r = p$.
+   /// @remark default = 0
+   /// @invariant :expr:`component_count >= 0`
+   int64_t get_component_count() const;
+   descriptor& set_component_count(int64_t);
+
+   /// Specifies whether the algorithm applies the `Sign-flip technique`_.
+   /// If it is `true`, directions of the eigenvectors must be deterministic.
+   /// @remark default = true
+   bool get_deterministic() const;
+   descriptor& set_deterministic(bool);
+};
+
+/// @tparam Task Tag-type that specifies type of the problem to solve. Can
+///              be :expr:`task::dimensionality_reduction`.
+template <typename Task = task::by_default>
+class model {
+public:
+   /// Creates a new instance of the class with the default property values.
+   model();
+
+   /// $r \\times p$ table with the eigenvectors. Each row contains one
+   /// eigenvector.
+   /// @remark default = table{}
+   const table& get_eigenvectors() const;
+
+   /// The number of components $r$ in the trained model.
+   /// @invariant :expr:`component_count == eigenvectors.row_count`
+   /// @remark default = 0
+   int64_t get_component_count() const;
+};
+
+/// @tparam Task Tag-type that specifies type of the problem to solve. Can
+///              be :expr:`task::dimensionality_reduction`.
+template <typename Task = task::by_default>
+class train_input {
+public:
+   /// Creates a new instance of the class with the given :literal:`data`
+   /// property value
+   train_input(const table& data = table{});
+
+   /// $n \\times p$ table with the training data, where each row stores one
+   /// feature vector.
+   /// @remark default = table{}
+   const table& get_data() const;
+   train_input& set_data(const table&);
+};
+
+/// @tparam Task Tag-type that specifies type of the problem to solve. Can
+///              be :expr:`task::dimensionality_reduction`.
+template <typename Task = task::by_default>
+class train_result {
+public:
+   /// Creates a new instance of the class with the default property values.
+   train_result();
+
+   /// The trained PCA model
+   /// @remark default = model<Task>{}
+   const model<Task>& get_model() const;
+
+   /// $1 \\times r$ table that contains mean value for the first $r$
+   /// features.
+   /// @remark default = table{}
+   const table& get_means() const;
+
+   /// $1 \\times r$ table that contains variance for the first $r$
+   /// features.
+   /// @remark default = table{}
+   const table& get_variances() const;
+
+   /// $1 \\times r$ table that contains eigenvalue for for the first
+   /// $r$ features.
+   /// @remark default = table{}
+   const table& get_eigenvalues() const;
+
+   /// $r \\times p$ table with the eigenvectors. Each row contains one
+   /// eigenvector.
+   /// @remark default = table{}
+   /// @invariant :expr:`eigenvectors == model.eigenvectors`
+   const table& get_eigenvectors() const;
+};
+
+/// Runs the training operation for PCA. For more details see
+/// :expr:`oneapi::dal::train`.
+///
+/// @tparam Float  The floating-point type that the algorithm uses for
+///                intermediate computations. Can be :expr:`float` or
+///                :expr:`double`.
+/// @tparam Method Tag-type that specifies an implementation of algorithm. Can
+///                be :expr:`method::cov` or :expr:`method::svd`.
+/// @tparam Task   Tag-type that specifies type of the problem to solve. Can
+///                be :expr:`task::dimensionality_reduction`.
+///
+/// @param[in] desc  Descriptor of the algorithm
+/// @param[in] input Input data for the training operation
+/// @return result   Result of the training operation
+///
+/// @pre :expr:`input.data.has_data == true`
+/// @pre :expr:`input.data.column_count >= desc.component_count`
+/// @post :expr:`result.means.row_count == 1`
+/// @post :expr:`result.means.column_count == desc.component_count`
+/// @post :expr:`result.variances.row_count == 1`
+/// @post :expr:`result.variances.column_count == desc.component_count`
+/// @post :expr:`result.variances[i] >= 0.0`
+/// @post :expr:`result.eigenvalues.row_count == 1`
+/// @post :expr:`result.eigenvalues.column_count == desc.component_count`
+/// @post :expr:`result.model.eigenvectors.row_count == 1`
+/// @post :expr:`result.model.eigenvectors.column_count == desc.component_count`
+template <typename Float, typename Method, typename Task>
+train_result<Task> train(const descriptor<Float, Method, Task>& desc,
+                         const train_input<Task>& input);
+
+/// @tparam Task Tag-type that specifies type of the problem to solve. Can
+///              be :expr:`task::dimensionality_reduction`.
+template <typename Task = task::by_default>
+class infer_input {
+public:
+   /// Creates a new instance of the class with the given :literal:`model`
+   /// and :literal:`data` property values
+   infer_input(const model<Task>& m = model<Task>{},
+               const table& data = table{});
+
+   /// The trained PCA model
+   /// @remark default = model<Task>{}
+   const model<Task>& get_model() const;
+   infer_input& set_model(const model&);
+
+   /// The dataset for inference $X'$
+   /// @remark default = table{}
+   const table& get_data() const;
+   infer_input& set_data(const table&);
+};
+
+/// @tparam Task Tag-type that specifies type of the problem to solve. Can
+///              be :expr:`task::dimensionality_reduction`.
+template <typename Task = task::by_default>
+class infer_result {
+public:
+   /// Creates a new instance of the class with the default property values.
+   infer_result();
+
+   /// $n \\times r$ table that contains data projected to the $r$
+   /// principal components.
+   /// @remark default = table{}
+   const table& get_transformed_data() const;
+};
+
+/// Runs the inference operation for PCA. For more details see
+/// :expr:`oneapi::dal::infer`.
+///
+/// @tparam Float  The floating-point type that the algorithm uses for
+///                intermediate computations. Can be :expr:`float` or
+///                :expr:`double`.
+/// @tparam Method Tag-type that specifies an implementation of algorithm. Can
+///                be :expr:`method::cov` or :expr:`method::svd`.
+/// @tparam Task   Tag-type that specifies type of the problem to solve. Can
+///                be :expr:`task::dimensionality_reduction`.
+///
+/// @param[in] desc  Descriptor of the algorithm
+/// @param[in] input Input data for the inference operation
+/// @return result   Result of the inference operation
+///
+/// @pre :expr:`input.data.has_data == true`
+/// @pre :expr:`input.model.eigenvectors.row_count == desc.component_count`
+/// @pre :expr:`input.model.eigenvectors.column_count = input.data.column_count`
+/// @post :expr:`result.transformed_data.row_count == input.data.row_count`
+/// @post :expr:`result.transformed_data.column_count == desc.component_count`
+template <typename Float, typename Method, typename Task>
+infer_result<Task> infer(const descriptor<Float, Method, Task>& desc,
+                         const infer_input<Task>& input);
+
+} // namespace oneapi::dal::pca
+
+namespace oneapi::dal::pca::example {
+
+pca::model<> run_training(const table& data) {
+   const auto pca_desc = pca::descriptor<float>{}
+      .set_component_count(5)
+      .set_deterministic(true);
+
+   const auto result = train(pca_desc, data);
+
+   print_table("means", result.get_means());
+   print_table("variances", result.get_variances());
+   print_table("eigenvalues", result.get_eigenvalues());
+   print_table("eigenvectors", result.get_eigenvectors());
+
+   return result.get_model();
+}
+
+table run_inference(const pca::model<>& model,
+                    const table& new_data) {
+   const auto pca_desc = pca::descriptor<float>{}
+      .set_component_count(model.get_component_count());
+
+   const auto result = infer(pca_desc, model, new_data);
+
+   print_table("labels", result.get_transformed_data());
+}
+
+} // oneapi::dal::pca::example

--- a/source/elements/oneDAL/include/oneapi/dal/pca.hpp
+++ b/source/elements/oneDAL/include/oneapi/dal/pca.hpp
@@ -20,10 +20,10 @@ namespace method {
 namespace task {
    /// Tag-type that parametrizes entities used for solving dimensionality
    /// reduction problem.
-   struct dimensionality_reduction {};
+   struct dim_reduction {};
 
    /// Alias tag-type for dimensionality reduction task.
-   using by_default = dimensionality_reduction;
+   using by_default = dim_reduction;
 } // namespace task
 
 /// @tparam Float  The floating-point type that the algorithm uses for
@@ -32,7 +32,7 @@ namespace task {
 /// @tparam Method Tag-type that specifies an implementation of algorithm. Can
 ///                be :expr:`method::cov` or :expr:`method::svd`.
 /// @tparam Task   Tag-type that specifies type of the problem to solve. Can
-///                be :expr:`task::dimensionality_reduction`.
+///                be :expr:`task::dim_reduction`.
 template <typename Float = float,
           typename Method = method::by_default,
           typename Task = task::by_default>
@@ -57,7 +57,7 @@ public:
 };
 
 /// @tparam Task Tag-type that specifies type of the problem to solve. Can
-///              be :expr:`task::dimensionality_reduction`.
+///              be :expr:`task::dim_reduction`.
 template <typename Task = task::by_default>
 class model {
 public:
@@ -76,7 +76,7 @@ public:
 };
 
 /// @tparam Task Tag-type that specifies type of the problem to solve. Can
-///              be :expr:`task::dimensionality_reduction`.
+///              be :expr:`task::dim_reduction`.
 template <typename Task = task::by_default>
 class train_input {
 public:
@@ -92,7 +92,7 @@ public:
 };
 
 /// @tparam Task Tag-type that specifies type of the problem to solve. Can
-///              be :expr:`task::dimensionality_reduction`.
+///              be :expr:`task::dim_reduction`.
 template <typename Task = task::by_default>
 class train_result {
 public:
@@ -134,7 +134,7 @@ public:
 /// @tparam Method Tag-type that specifies an implementation of algorithm. Can
 ///                be :expr:`method::cov` or :expr:`method::svd`.
 /// @tparam Task   Tag-type that specifies type of the problem to solve. Can
-///                be :expr:`task::dimensionality_reduction`.
+///                be :expr:`task::dim_reduction`.
 ///
 /// @param[in] desc  Descriptor of the algorithm
 /// @param[in] input Input data for the training operation
@@ -156,7 +156,7 @@ train_result<Task> train(const descriptor<Float, Method, Task>& desc,
                          const train_input<Task>& input);
 
 /// @tparam Task Tag-type that specifies type of the problem to solve. Can
-///              be :expr:`task::dimensionality_reduction`.
+///              be :expr:`task::dim_reduction`.
 template <typename Task = task::by_default>
 class infer_input {
 public:
@@ -177,7 +177,7 @@ public:
 };
 
 /// @tparam Task Tag-type that specifies type of the problem to solve. Can
-///              be :expr:`task::dimensionality_reduction`.
+///              be :expr:`task::dim_reduction`.
 template <typename Task = task::by_default>
 class infer_result {
 public:
@@ -199,7 +199,7 @@ public:
 /// @tparam Method Tag-type that specifies an implementation of algorithm. Can
 ///                be :expr:`method::cov` or :expr:`method::svd`.
 /// @tparam Task   Tag-type that specifies type of the problem to solve. Can
-///                be :expr:`task::dimensionality_reduction`.
+///                be :expr:`task::dim_reduction`.
 ///
 /// @param[in] desc  Descriptor of the algorithm
 /// @param[in] input Input data for the inference operation

--- a/source/elements/oneDAL/include/oneapi/dal/pca.hpp
+++ b/source/elements/oneDAL/include/oneapi/dal/pca.hpp
@@ -184,7 +184,7 @@ public:
    /// Creates a new instance of the class with the default property values.
    infer_result();
 
-   /// $n \\times r$ table that contains data projected to the $r$
+   /// An $n \\times r$ table that contains data projected to the $r$
    /// principal components.
    /// @remark default = table{}
    const table& get_transformed_data() const;

--- a/source/elements/oneDAL/make.bat
+++ b/source/elements/oneDAL/make.bat
@@ -1,0 +1,29 @@
+@echo off
+if /I %1 == html goto :html
+if /I %1 == pdf goto :pdf
+if /I %1 == doxygen goto :doxygen
+if /I %1 == parse-doxygen goto :parse-doxygen
+if /I %1 == clean goto :clean
+
+:html
+sphinx-build -M html source build -q
+goto :eof
+
+:pdf
+sphinx-build -M latexpdf source build -q
+goto :eof
+
+:doxygen
+doxygen
+goto :eof
+
+:parse-doxygen
+if not exist build mkdir build
+python -m dalapi.doxypy.cli doxygen/xml --compact > build/tree.yaml
+goto :eof
+
+:clean
+rd /s /q "build\doctrees"
+rd /s /q "build\html"
+rd /s /q "build\latex"
+goto :eof

--- a/source/elements/oneDAL/make.bat
+++ b/source/elements/oneDAL/make.bat
@@ -3,6 +3,7 @@ if /I %1 == html goto :html
 if /I %1 == pdf goto :pdf
 if /I %1 == doxygen goto :doxygen
 if /I %1 == parse-doxygen goto :parse-doxygen
+if /I %1 == gh-pages goto :gh-pages
 if /I %1 == clean goto :clean
 
 :html
@@ -23,7 +24,34 @@ python -m dalapi.doxypy.cli doxygen/xml --compact > build/tree.yaml
 goto :eof
 
 :clean
-rd /s /q "build\doctrees"
-rd /s /q "build\html"
-rd /s /q "build\latex"
+rd /s /q build
+goto :eof
+
+:gh-pages
+set gh_pages=build\gh-pages
+for /f %%i in ('git branch --show-current') do set git_branch=%%i
+for /f %%i in ('git remote get-url origin') do set git_url=%%i
+
+if not exist %gh_pages% (
+    if not exist build mkdir build
+    pushd build
+    git clone --single-branch --branch gh-pages %git_url% gh-pages
+    popd
+)
+
+if not exist %gh_pages%\%git_branch% mkdir %gh_pages%\%git_branch%
+if not exist build\html (
+    echo Error: build\html directory does not exist, build html first
+    goto :eof
+)
+xcopy "build\html\*" %gh_pages%\%git_branch% /y /s
+rd /s /q %gh_pages%\%git_branch%\.nojekyll
+
+pushd %gh_pages%
+git checkout gh-pages
+git pull --rebase origin gh-pages
+git add .
+git commit -m "Update gh-pages for %git_branch%"
+git push origin gh-pages
+popd
 goto :eof

--- a/source/elements/oneDAL/source/algorithms/clustering/index.rst
+++ b/source/elements/oneDAL/source/algorithms/clustering/index.rst
@@ -3,4 +3,6 @@ Clustering
 ==========
 
 .. toctree::
+   :titlesonly:
+
    kmeans.rst

--- a/source/elements/oneDAL/source/algorithms/clustering/kmeans.rst
+++ b/source/elements/oneDAL/source/algorithms/clustering/kmeans.rst
@@ -4,10 +4,9 @@
 =======
 K-Means
 =======
-
-The K-Means algorithm partitions :math:`n` feature vectors into :math:`k`
-*clusters* minimizing some criterion. Each cluster is characterized by a
-representative point, called *a centroid*.
+The K-Means algorithm solves :capterm:`clustering` problem by partitioning
+:math:`n` feature vectors into :math:`k` clusters minimizing some criterion.
+Each cluster is characterized by a representative point, called *a centroid*.
 
 .. |t_math| replace:: `Training <kmeans_t_math_>`_
 .. |t_lloyd| replace:: `Lloyd's <kmeans_t_math_lloyd_>`_

--- a/source/elements/oneDAL/source/algorithms/clustering/kmeans.rst
+++ b/source/elements/oneDAL/source/algorithms/clustering/kmeans.rst
@@ -104,13 +104,13 @@ Given the inference set :math:`X' = \{ x_1', \ldots, x_m' \}` of
 :math:`p`-dimensional feature vectors and the set :math:`C = \{ c_1, \ldots, c_k
 \}` of centroids produced at the training stage, the problem is to predict the
 index :math:`y_j' \in \{ 0, \ldots, k-1 \}`, :math:`1 \leq j \leq m`, of the
-centroid according to some method-defined rule.
+centroid in accordance with a method-defined rule.
 
 .. _kmeans_i_math_lloyd:
 
 Inference method: *Lloyd's*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Lloyd's inference method computes the :math:`y_j'` as index of the centroid
+Lloyd's inference method computes the :math:`y_j'` as an index of the centroid
 closest to the feature vector :math:`x_j'`,
 
 .. math::
@@ -131,7 +131,7 @@ Inference
 ---------------------
 Programming Interface
 ---------------------
-All type and function in this section shall be declared in the
+All types and functions in this section shall be declared in the
 ``oneapi::dal::kmeans`` namespace and be available via inclusion of the
 ``oneapi/dal/algo/kmeans.hpp`` header file.
 

--- a/source/elements/oneDAL/source/algorithms/clustering/kmeans.rst
+++ b/source/elements/oneDAL/source/algorithms/clustering/kmeans.rst
@@ -131,6 +131,9 @@ Inference
 ---------------------
 Programming Interface
 ---------------------
+All type and function in this section shall be declared in the
+``oneapi::dal::kmeans`` namespace and be available via inclusion of the
+``oneapi/dal/algo/kmeans.hpp`` header file.
 
 Descriptor
 ----------

--- a/source/elements/oneDAL/source/algorithms/clustering/kmeans.rst
+++ b/source/elements/oneDAL/source/algorithms/clustering/kmeans.rst
@@ -9,6 +9,33 @@ The K-Means algorithm partitions :math:`n` feature vectors into :math:`k`
 *clusters* minimizing some criterion. Each cluster is characterized by a
 representative point, called *a centroid*.
 
+.. |t_math| replace:: `Training <kmeans_t_math_>`_
+.. |t_lloyd| replace:: `Lloyd's <kmeans_t_math_lloyd_>`_
+.. |t_input| replace:: `train_input <kmeans_t_api_input_>`_
+.. |t_result| replace:: `train_result <kmeans_t_api_result_>`_
+.. |t_op| replace:: `train(...) <kmeans_t_api_>`_
+
+.. |i_math| replace:: `Inference <kmeans_i_math_>`_
+.. |i_lloyd| replace:: `Lloyd's <kmeans_i_math_lloyd_>`_
+.. |i_input| replace:: `infer_input <kmeans_i_api_input_>`_
+.. |i_result| replace:: `infer_result <kmeans_i_api_result_>`_
+.. |i_op| replace:: `infer(...) <kmeans_i_api_>`_
+
+=============== =========================== ======== =========== ============
+ **Operation**  **Computational methods**     **Programming Interface**
+--------------- --------------------------- ---------------------------------
+   |t_math|             |t_lloyd|            |t_op|   |t_input|   |t_result|
+   |i_math|             |i_lloyd|            |i_op|   |i_input|   |i_result|
+=============== =========================== ======== =========== ============
+
+------------------------
+Mathematical formulation
+------------------------
+
+.. _kmeans_t_math:
+
+Training
+--------
 Given the training set :math:`X = \{ x_1, \ldots, x_n \}` of
 :math:`p`-dimensional feature vectors and a positive integer :math:`k`, the
 problem is to find a set :math:`C = \{ c_1, \ldots, c_k \}` of
@@ -31,10 +58,10 @@ Expression :math:`\|\cdot\|` denotes :math:`L_2` `norm
    version of the oneDAL spec defines only Euclidean distance case.
 
 
---------------
-Lloyd's method
---------------
+.. _kmeans_t_math_lloyd:
 
+Training method: *Lloyd's*
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 The Lloyd's method [Lloyd82]_ consists in iterative updates of centroids by
 applying the alternating *Assignment* and *Update* steps, where :math:`t`
 denotes a index of the current iteration, e.g., :math:`C^{(t)} = \{ c_1^{(t)},
@@ -69,430 +96,99 @@ The steps (1) and (2) are performed until the following **stop condition**,
 is satisfied or number of iterations exceeds the maximal value :math:`T` defined
 by the user.
 
+
+.. _kmeans_i_math:
+
+Inference
+---------
+Given the inference set :math:`X' = \{ x_1', \ldots, x_m' \}` of
+:math:`p`-dimensional feature vectors and the set :math:`C = \{ c_1, \ldots, c_k
+\}` of centroids produced at the training stage, the problem is to predict the
+index :math:`y_j' \in \{ 0, \ldots, k-1 \}`, :math:`1 \leq j \leq m`, of the
+centroid according to some method-defined rule.
+
+.. _kmeans_i_math_lloyd:
+
+Inference method: *Lloyd's*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Lloyd's inference method computes the :math:`y_j'` as index of the centroid
+closest to the feature vector :math:`x_j'`,
+
+.. math::
+   y_j' = \mathrm{arg}\min_{1 \leq l \leq k} \| x_j' - c_l \|^2, \quad 1 \leq j \leq m.
+
+
 -------------
 Usage example
 -------------
-::
+Training
+--------
+.. onedal_code:: oneapi::dal::kmeans::example::run_training
 
-   oneapi::dal::kmeans::model run_training(const oneapi::dal::table& data,
-                                           const oneapi::dal::table& initial_centroids) {
+Inference
+---------
+.. onedal_code:: oneapi::dal::kmeans::example::run_inference
 
-      const auto kmeans_desc = oneapi::dal::kmeans::desc<float>{}
-         .set_cluster_count(10)
-         .set_max_iteration_count(50)
-         .set_accuracy_threshold(1e-4);
-
-      const auto result = oneapi::dal::train(kmeans_desc, data, initial_centroids);
-
-      print_table("labels", result.get_labels());
-      print_table("centroids", result.get_model().get_centroids());
-      print_value("objective", result.get_objective_function_value());
-
-      return result.get_model();
-   }
-
-
-::
-
-   oneapi::dal::table run_inference(const oneapi::dal::kmeans::model& model,
-                               const oneapi::dal::table& new_data) {
-
-      const auto kmeans_desc = oneapi::dal::kmeans::desc<float>{}
-         .set_cluster_count(model.get_cluster_count());
-
-      const auto result = oneapi::dal::infer(kmeans_desc, model, new_data);
-
-      print_table("labels", result.get_labels());
-   }
-
-
----
-API
----
-
-Methods
--------
-::
-
-   namespace method {
-      struct lloyd {};
-      using by_default = lloyd;
-   } // namespace method
-
-.. namespace:: oneapi::dal::kmeans::method
-.. struct:: lloyd
-
-   Tag-type that denotes `Lloyd's method`_.
-
-
-.. type:: by_default = lloyd
-
-   Alias tag-type for the `Lloyd's method`_.
-
+---------------------
+Programming Interface
+---------------------
 
 Descriptor
 ----------
-::
+.. onedal_class:: oneapi::dal::kmeans::descriptor
 
-   template <typename Float = float,
-             typename Method = method::by_default>
-   class desc {
-   public:
-      desc();
+Method tags
+~~~~~~~~~~~
+.. onedal_tags_namespace:: oneapi::dal::kmeans::method
 
-      int64_t get_cluster_count() const;
-      int64_t get_max_iteration_count() const;
-      double get_accuracy_threshold() const;
-
-      desc& set_cluster_count(int64_t);
-      desc& set_max_iteration_count(int64_t);
-      desc& set_accuracy_threshold(double);
-   };
-
-.. namespace:: oneapi::dal::kmeans
-.. class:: template<typename Float = float, \
-                    typename Method = method::by_default> \
-           desc
-
-   :tparam Float: The floating-point type that the algorithm uses for
-                  intermediate computations. Can be :expr:`float` or :expr:`double`.
-
-   :tparam Method: Tag-type that specifies an implementation of K-Means
-                   algorithm. Can be :expr:`method::lloyd` or
-                   :expr:`method::by_default`.
-
-   .. function:: desc()
-
-      Creates new instance of descriptor with the default attribute values.
-
-   .. member:: std::int64_t cluster_count = 2
-
-      The number of clusters :math:`k`.
-
-      Getter & Setter
-         | ``std::int64_t get_cluster_count() const``
-         | ``desc& set_cluster_count(std::int64_t)``
-
-      Invariants
-         | :expr:`cluster_count > 0`
-
-
-   .. member:: std::int64_t max_iteration_count = 100
-
-      The maximum number of iterations :math:`T`.
-
-      Getter & Setter
-         | ``std::int64_t get_max_iteration_count() const``
-         | ``desc& set_max_iteration_count(std::int64_t)``
-
-      Invariants
-         | :expr:`max_iteration_count >= 0`
-
-
-   .. member:: double accuracy_threshold = 0.0
-
-      The threshold :math:`\varepsilon` for the stop condition.
-
-      Getter & Setter
-         | ``double get_accuracy_threshold() const``
-         | ``desc& set_accuracy_threshold(double)``
-
-      Invariants
-         | :expr:`accuracy_threshold >= 0.0`
-
+Task tags
+~~~~~~~~~
+.. onedal_tags_namespace:: oneapi::dal::kmeans::task
 
 Model
 -----
-::
+.. onedal_class:: oneapi::dal::kmeans::model
 
-   class model {
-   public:
-      model();
 
-      const table& get_centroids() const;
-      int64_t get_cluster_count() const;
-   };
+.. _kmeans_t_api:
 
-.. class:: model
-
-   .. function:: model()
-
-      Creates a model with the default attribute values.
-
-
-   .. member:: table centroids = table()
-
-      :math:`k \times p` table with the cluster centroids. Each row of the table
-      stores one centroid.
-
-      Getter
-         | ``const table& get_centroids() const``
-
-
-   .. member:: std::int64_t cluster_count = 0
-
-      Number of clusters :math:`k` in the trained model.
-
-      Getter
-         | ``std::int64_t get_cluster_count() const``
-
-      Invariants
-         | :expr:`cluster_count == centroids.row_count`
-
-
-Training :expr:`oneapi::dal::train(...)`
-----------------------------------------
-Input
-~~~~~
-::
-
-   class train_input {
-   public:
-      train_input();
-      train_input(const table& data);
-      train_input(const table& data, const table& initial_centroids);
-
-      const table& get_data() const;
-      const table& get_initial_centroids() const;
-
-      train_input& set_data(const table&);
-      train_input& set_initial_centroids(const table&);
-   };
-
-.. class:: train_input
-
-   .. function:: train_input()
-
-      Creates input for the training operation with the default attribute
-      values.
-
-
-   .. function:: train_input(const table& data)
-
-      Creates input for the training operation with the given :expr:`data`, the
-      other attributes get default values.
-
-
-   .. function:: train_input(const table& data, const table& initial_centroids)
-
-      Creates input for the training operation with the given data and
-      :expr:`initial_centroids`.
-
-
-   .. member:: table data = table()
-
-      :math:`n \times p` table with the data to be clustered, where each row
-      stores one feature vector.
-
-      Getter & Setter
-         | ``const table& get_data() const``
-         | ``train_input& set_data(const table&)``
-
-
-   .. member:: table initial_centroids = table()
-
-      :math:`k \times p` table with the initial centroids, where each row
-      stores one centroid.
-
-      Getter & Setter
-         | ``const table& get_initial_centroids() const``
-         | ``train_input& set_initial_centroids(const table&)``
-
-
-Result
-~~~~~~
-::
-
-   class train_result {
-   public:
-      train_result();
-
-      const model& get_model() const;
-      const table& get_labels() const;
-      int64_t get_iteration_count() const;
-      double get_objective_function_value() const;
-   };
-
-.. class:: train_result
-
-   .. function:: train_result()
-
-      Creates result of the training operation with the default attribute
-      values.
-
-
-   .. member:: kmeans::model model = kmeans::model()
-
-      The trained K-means model.
-
-      Getter
-         | ``const model& get_model() const``
-
-
-   .. member:: table labels = table()
-
-      :math:`n \times 1` table with the labels :math:`y_i` assigned to the
-      samples :math:`x_i` in the input data, :math:`1 \leq 1 \leq n`.
-
-      Getter
-         | ``const table& get_labels() const``
-
-
-   .. member:: std::int64_t iteration_count = 0
-
-      The number of iterations performed by the algorithm.
-
-      Invariants
-         | :expr:`iteration_count >= 0`
-
-
-   .. member:: double objective_function_value = 0.0
-
-      The value of the objective function :math:`\Phi_X(C)`, where :math:`C` is
-      :expr:`model.centroids` (see :expr:`kmeans::model::centroids`).
-
-      Invariants
-         | :expr:`objective_function_value >= 0.0`
-
-
-Operation semantics
-~~~~~~~~~~~~~~~~~~~
-.. namespace:: oneapi::dal
-.. function:: template <typename Descriptor> \
-              kmeans::train_result train(const Descriptor& desc, \
-                                         const kmeans::train_input& input)
-
-   :tparam Descriptor: K-Means algorithm descriptor :expr:`kmeans::desc`.
-
-   Preconditions
-      | :expr:`input.data.is_empty == false`
-      | :expr:`input.initial_centroids.is_empty == false`
-      | :expr:`input.initial_centroids.row_count == desc.cluster_count`
-      | :expr:`input.initial_centroids.column_count == input.data.column_count`
-
-   Postconditions
-      | :expr:`result.labels.is_empty == false`
-      | :expr:`result.labels.row_count == input.data.row_count`
-      | :expr:`result.model.centroids.is_empty == false`
-      | :expr:`result.model.clusters.row_count == desc.cluster_count`
-      | :expr:`result.model.clusters.column_count == input.data.column_count`
-      | :expr:`result.iteration_count <= desc.max_iteration_count`
-
-
-Inference :expr:`oneapi::dal::infer(...)`
------------------------------------------
+Training :expr:`train(...)`
+--------------------------------
+.. _kmeans_t_api_input:
 
 Input
 ~~~~~
-::
-
-   class infer_input {
-   public:
-      infer_input();
-      infer_input(const model& m);
-      infer_input(const model& m, const table& data);
-
-      const model& get_model() const;
-      const table& get_data() const;
-
-      infer_input& set_model(const model&);
-      infer_input& set_data(const table&);
-   };
-
-.. namespace:: oneapi::dal::kmeans
-.. class:: infer_input
-
-   .. function:: infer_input()
-
-      Creates input for the inference operation with the default attribute
-      values.
+.. onedal_class:: oneapi::dal::kmeans::train_input
 
 
-   .. function:: infer_input(const kmeans::model& model)
-
-      Creates input for the inference operation with the given :expr:`model`, the
-      other attributes get default values.
-
-
-   .. function:: infer_input(const kmeans::model& model, const table& data)
-
-      Creates input for the inference operation with the given :expr:`model` and
-      :expr:`data`.
-
-
-   .. member:: table data = table()
-
-      :math:`n \times p` table with the data to be assigned to the clusters,
-      where each row stores one feature vector.
-
-      Getter & Setter
-         | ``const table& get_data() const``
-         | ``infer_input& set_data(const table&)``
-
-
-   .. member:: kmeans::model model = kmeans::model()
-
-      The trained K-Means model (see :expr:`kmeans::model`).
-
-      Getter & Setter
-         | ``const kmeans::model& get_model() const``
-         | ``infer_input& set_model(const kmeans::model&)``
-
+.. _kmeans_t_api_result:
 
 Result
 ~~~~~~
-::
+.. onedal_class:: oneapi::dal::kmeans::train_result
 
-   class infer_result {
-   public:
-      infer_result();
-
-      const table& get_labels() const;
-      double get_objective_function_value() const;
-   };
+Operation
+~~~~~~~~~
+.. onedal_func:: oneapi::dal::kmeans::train
 
 
-.. class:: infer_result
+.. _kmeans_i_api:
 
-   .. function:: infer_result()
+Inference :expr:`infer(...)`
+----------------------------
+.. _kmeans_i_api_input:
 
-      Creates result of the inference operation with the default attribute
-      values.
-
-
-   .. member:: table labels = table()
-
-      :math:`n \times 1` table with assignments labels to feature vectors in the
-      input data.
-
-      Getter
-         | ``const table& get_labels() const``
+Input
+~~~~~
+.. onedal_class:: oneapi::dal::kmeans::infer_input
 
 
-   .. member:: double objective_function_value = 0.0
+.. _kmeans_i_api_result:
 
-      The value of the objective function :math:`\Phi_X(C)`, where :math:`C` is
-      defined by the corresponding :expr:`infer_input::model::centroids`.
+Result
+~~~~~~
+.. onedal_class:: oneapi::dal::kmeans::infer_result
 
-      Invariants
-         | :expr:`objective_function_value >= 0.0`
-
-
-Operation semantics
-~~~~~~~~~~~~~~~~~~~
-.. namespace:: oneapi::dal
-.. function:: template <typename Descriptor> \
-              kmeans::infer_result infer(const Descriptor& desc, \
-                                         const kmeans::infer_input& input)
-
-   :tparam Descriptor: K-Means algorithm descriptor :expr:`kmeans::desc`.
-
-   Preconditions
-      | :expr:`input.data.is_empty == false`
-      | :expr:`input.model.centroids.is_empty == false`
-      | :expr:`input.model.centroids.row_count == desc.cluster_count`
-      | :expr:`input.model.centroids.column_count == input.data.column_count`
-
-   Postconditions
-      | :expr:`result.labels.is_empty == false`
-      | :expr:`result.labels.row_count == input.data.row_count`
+Operation
+~~~~~~~~~
+.. onedal_func:: oneapi::dal::kmeans::infer

--- a/source/elements/oneDAL/source/algorithms/decomposition/index.rst
+++ b/source/elements/oneDAL/source/algorithms/decomposition/index.rst
@@ -3,4 +3,6 @@ Decomposition
 =============
 
 .. toctree::
+   :titlesonly:
+
    pca.rst

--- a/source/elements/oneDAL/source/algorithms/decomposition/pca.rst
+++ b/source/elements/oneDAL/source/algorithms/decomposition/pca.rst
@@ -17,31 +17,56 @@ possibly correlated features to a new set of uncorrelated features, called
 principal components. Principal components are the directions of the largest
 variance, that is, the directions where the data is mostly spread out.
 
+.. |t_math| replace:: `Training <pca_t_math_>`_
+.. |t_cov| replace:: `Covariance <pca_t_math_cov_>`_
+.. |t_svd| replace:: `SVD <pca_t_math_svd_>`_
+.. |t_input| replace:: `train_input <pca_t_api_input_>`_
+.. |t_result| replace:: `train_result <pca_t_api_result_>`_
+.. |t_op| replace:: `train(...) <pca_t_api_>`_
+
+.. |i_math| replace:: `Inference <pca_i_math_>`_
+.. |i_cov| replace:: `Covariance <pca_i_math_cov_>`_
+.. |i_svd| replace:: `SVD <pca_i_math_svd_>`_
+.. |i_input| replace:: `infer_input <pca_i_api_input_>`_
+.. |i_result| replace:: `infer_result <pca_i_api_result_>`_
+.. |i_op| replace:: `infer(...) <pca_i_api_>`_
+
+=============== ============= ============= ======== =========== ============
+ **Operation**  **Computational methods**     **Programming Interface**
+--------------- --------------------------- ---------------------------------
+   |t_math|        |t_cov|       |t_svd|     |t_op|   |t_input|   |t_result|
+   |i_math|        |i_cov|       |i_svd|     |i_op|   |i_input|   |i_result|
+=============== ============= ============= ======== =========== ============
+
+------------------------
+Mathematical formulation
+------------------------
+
+.. _pca_t_math:
+
+Training
+--------
 Given the training set :math:`X = \{ x_1, \ldots, x_n \}` of
 :math:`p`-dimensional feature vectors and the number of principal components
 :math:`r`, the problem is to compute :math:`r` principal directions
-(:math:`p`-dimensional eigenvectors) for the training set. The eigenvectors can
-be grouped into the :math:`r \times p` matrix :math:`T` that contains one
-eigenvector in each row.
+(:math:`p`-dimensional eigenvectors [Lang87]_) for the training set. The
+eigenvectors can be grouped into the :math:`r \times p` matrix :math:`T` that
+contains one eigenvector in each row.
 
-oneDAL specifies two methods for PCA computation:
+.. _pca_t_math_cov:
 
-#. `Covariance-based method`_
-#. `SVD-based method`_
-
------------------------
-Covariance-based method
------------------------
+Training method: *Covariance*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [TBD]
 
-----------------
-SVD-based method
-----------------
+.. _pca_t_math_svd:
+
+Training method: *SVD*
+~~~~~~~~~~~~~~~~~~~~~~
 [TBD]
 
--------------------
 Sign-flip technique
--------------------
+~~~~~~~~~~~~~~~~~~~
 Eigenvectors computed by some eigenvalue solvers are not uniquely defined due to
 sign ambiguity. To get the deterministic result, a sign-flip technique should be
 applied. One of the sign-flip techniques proposed in [Bro07]_ requires the
@@ -68,397 +93,105 @@ signum function,
    arbitrary technique that modifies the eigenvectors' signs.
 
 
+.. _pca_i_math:
+
+Inference
+---------
+Given the inference set :math:`X' = \{ x_1', \ldots, x_m' \}` of
+:math:`p`-dimensional feature vectors and the :math:`r \times p` matrix
+:math:`T` produced at the training stage, the problem is to transform :math:`X'`
+to the set :math:`X'' = \{ x_1'', \ldots, x_m'' \}`, where :math:`x_{j}''` is
+:math:`r`-dimensional feature vector, :math:`1 \leq j \leq m`.
+
+The feature vector :math:`x_{j}''` is computed by applying linear transformation
+[Lang87]_ with the matrix :math:`T` to the feature vector :math:`x_{j}'`,
+
+.. math::
+   :label: x_transform
+
+   x_{j}'' = T x_{j}', \quad 1 \leq j \leq m.
+
+
+.. _pca_i_math_cov:
+.. _pca_i_math_svd:
+
+Inference methods: *Covariance* and *SVD*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Covariance and SVD inference methods compute :math:`x_{j}''` according to
+:eq:`x_transform`.
+
+
 -------------
 Usage example
 -------------
-::
+Training
+--------
+.. onedal_code:: oneapi::dal::pca::example::run_training
 
-   oneapi::dal::pca::model run_training(const oneapi::dal::table& data) {
+Inference
+---------
+.. onedal_code:: oneapi::dal::pca::example::run_inference
 
-      const auto pca_desc = oneapi::dal::pca::desc<float>{}
-         .set_component_count(5)
-         .set_deterministic(true);
-
-      const auto result = oneapi::dal::train(pca_desc, data);
-
-      print_table("means", result.get_means());
-      print_table("variances", result.get_variances());
-      print_table("eigenvalues", result.get_eigenvalues());
-      print_table("eigenvectors", result.get_model().get_eigenvectors());
-
-      return result.get_model();
-   }
-
-
-::
-
-   oneapi::dal::table run_inference(const oneapi::dal::pca::model& model,
-                               const oneapi::dal::table& new_data) {
-
-      const auto pca_desc = oneapi::dal::pca::desc<float>{}
-         .set_component_count(model.get_component_count());
-
-      const auto result = oneapi::dal::infer(pca_desc, model, new_data);
-
-      print_table("labels", result.get_transformed_data());
-   }
-
-
----
-API
----
-Methods
--------
-::
-
-   namespace method {
-      struct cov {};
-      struct svd {};
-      using by_default = cov;
-   } // namespace method
-
-
-.. namespace:: oneapi::dal::pca::method
-
-.. struct:: cov
-
-   Tag-type that denotes `Covariance-based method`_.
-
-
-.. struct:: svd
-
-   Tag-type that denotes `SVD-based method`_.
-
-
-.. type:: by_default = cov
-
-   Alias tag-type for the `Covariance-based method`_.
-
+---------------------
+Programming Interface
+---------------------
 
 Descriptor
 ----------
-::
+.. onedal_class:: oneapi::dal::pca::descriptor
 
-   template <typename Float = float,
-             typename Method = method::by_default>
-   class desc {
-   public:
-      desc();
+Method tags
+~~~~~~~~~~~
+.. onedal_tags_namespace:: oneapi::dal::pca::method
 
-      int64_t get_component_count() const;
-      bool get_deterministic() const;
-
-      desc& set_component_count(int64_t);
-      desc& set_deterministic(bool);
-   };
-
-.. namespace:: oneapi::dal::pca
-
-.. class:: template<typename Float = float, \
-                    typename Method = method::by_default> \
-           desc
-
-   :tparam Float: The floating-point type that the algorithm uses for
-                  intermediate computations. Can be :expr:`float` or :expr:`double`.
-
-   :tparam Method: Tag-type that specifies an implementation of PCA algorithm.
-                   Can be :expr:`method::cov`, :expr:`method::svd` or
-                   :expr:`method::by_default`.
-
-   .. function:: desc()
-
-      Creates a new instance of the descriptor with the default attribute
-      values.
-
-
-   .. member:: std::int64_t component_count = 0
-
-      The number of principal components :math:`r`. If it is zero, the algorithm
-      computes the eigenvectors for all features, :math:`r = p`.
-
-      Getter & Setter
-         | ``std::int64_t get_component_count() const``
-         | ``desc& set_component_count(std::int64_t)``
-
-      Invariants
-         | :expr:`component_count >= 0`
-
-
-   .. member:: bool set_deterministic = true
-
-      Specifies whether the algorithm applies the `Sign-flip technique`_ or uses
-      a deterministic eigenvalues solver. If it is `true`, directions of the
-      eigenvectors must be deterministic.
-
-      Getter & Setter
-         | ``bool get_deterministic() const``
-         | ``desc& set_deterministic(bool)``
-
+Task tags
+~~~~~~~~~
+.. onedal_tags_namespace:: oneapi::dal::pca::task
 
 Model
 -----
-::
-
-   class model {
-   public:
-      model();
-
-      const table& get_eigenvectors() const;
-      int64_t get_component_count() const;
-   };
-
-.. class:: model
-
-   .. function:: model()
-
-      Creates a model with the default attribute values.
+.. onedal_class:: oneapi::dal::pca::model
 
 
-   .. member:: table eigenvectors = table()
+.. _pca_t_api:
 
-      :math:`r \times p` table with the eigenvectors. Each row contains one
-      eigenvector.
+Training :expr:`train(...)`
+--------------------------------
+.. _pca_t_api_input:
 
-      Getter
-         | ``const table& get_eigenvectors() const``
-
-
-   .. member:: std::int64_t component_count = 0
-
-      The number of components :math:`r` in the trained model.
-
-      Getter
-         | ``std::int64_t get_component_count() const``
-
-      Invariants
-         | :expr:`component_count == eigenvectors.row_count`
-
-
-
-Training :expr:`oneapi::dal::train(...)`
-----------------------------------------
 Input
 ~~~~~
-::
-
-   class train_input {
-   public:
-      train_input();
-      train_input(const table& data);
-
-      const table& get_data() const;
-
-      train_input& set_data(const table&);
-   };
-
-.. class:: train_input
-
-   .. function:: train_input()
-
-      Creates an input for the training operation with the default attribute
-      values.
+.. onedal_class:: oneapi::dal::pca::train_input
 
 
-   .. function:: train_input(const table& data)
-
-      Creates an input for the training operation with the given :expr:`data`.
-
-
-   .. member:: table data = table()
-
-      :math:`n \times p` table with the training data, where each row stores one
-      feature vector.
-
-      Getter & Setter
-         | ``const table& get_data() const``
-         | ``train_input& set_data(const table&)``
-
+.. _pca_t_api_result:
 
 Result
 ~~~~~~
-::
+.. onedal_class:: oneapi::dal::pca::train_result
 
-   class train_result {
-   public:
-      train_result();
-
-      const model& get_model() const;
-      const table& get_means() const;
-      const table& get_variances() const;
-      const table& get_eigenvalues() const;
-   };
-
-.. class:: train_result
-
-   .. function:: train_result()
-
-      Creates a result of the training operation with the default attribute
-      values.
+Operation
+~~~~~~~~~
+.. onedal_func:: oneapi::dal::pca::train
 
 
-   .. member:: pca::model model = pca::model()
+.. _pca_i_api:
 
-      The trained PCA model.
+Inference :expr:`infer(...)`
+----------------------------
+.. _pca_i_api_input:
 
-      Getter
-         | ``const model& get_model() const``
-
-
-   .. member:: table means = table()
-
-      :math:`1 \times r` table that contains mean value for the first :math:`r`
-      features.
-
-      Getter
-         | ``const table& get_means() const``
-
-
-   .. member:: table variances = table()
-
-      :math:`1 \times r` table that contains variance for the first :math:`r`
-      features.
-
-      Getter
-         | ``const table& get_variances() const``
-
-
-   .. member:: table eigenvalues = table()
-
-      :math:`1 \times r` table that contains eigenvalue for for the first
-      :math:`r` features.
-
-      Getter
-         | ``const table& get_eigenvalues() const``
-
-
-Operation semantics
-~~~~~~~~~~~~~~~~~~~
-.. namespace:: oneapi::dal
-.. function:: template <typename Descriptor> \
-              pca::train_result train(const Descriptor& desc, \
-                                      const pca::train_input& input)
-
-   :tparam Descriptor: PCA algorithm descriptor :expr:`pca::desc`.
-
-   Preconditions
-      | :expr:`input.data.is_empty == false`
-      | :expr:`input.data.column_count >= desc.component_count`
-
-   Postconditions
-      | :expr:`result.means.row_count == 1`
-      | :expr:`result.means.column_count == desc.component_count`
-      | :expr:`result.variances.row_count == 1`
-      | :expr:`result.variances.column_count == desc.component_count`
-      | :expr:`result.variances >= 0.0`
-      | :expr:`result.eigenvalues.row_count == 1`
-      | :expr:`result.eigenvalues.column_count == desc.component_count`
-      | :expr:`result.model.eigenvectors.row_count == 1`
-      | :expr:`result.model.eigenvectors.column_count == desc.component_count`
-
-
-Inference :expr:`oneapi::dal::infer(...)`
------------------------------------------
 Input
 ~~~~~
-::
-
-   class infer_input {
-   public:
-      infer_input();
-      infer_input(const model& m);
-      infer_input(const model& m, const table& data);
-
-      const model& get_model() const;
-      const table& get_data() const;
-
-      infer_input& set_model(const model&);
-      infer_input& set_data(const table&);
-   };
-
-.. namespace:: oneapi::dal::pca
-
-.. class:: infer_input
-
-   .. function:: infer_input()
-
-      Creates an input for the inference operation with the default attribute
-      values.
+.. onedal_class:: oneapi::dal::pca::infer_input
 
 
-   .. function:: infer_input(const pca::model& model)
-
-      Creates an input for the inference operation with the given :expr:`model`,
-      the other attributes get default values.
-
-
-   .. function:: infer_input(const pca::model& model, const table& data)
-
-      Creates an input for the inference operation with the given :expr:`model`
-      and :expr:`data`.
-
-
-   .. member:: table data = table()
-
-      :math:`n \times p` table with the data to be projected to the :math:`r`
-      principal components previously extracted from a training set.
-
-      Getter & Setter
-         | ``const table& get_data() const``
-         | ``infer_input& set_data(const table&)``
-
-
-   .. member:: pca::model model = pca::model()
-
-      The trained PCA model (see :expr:`pca::model`).
-
-      Getter & Setter
-         | ``const pca::model& get_model() const``
-         | ``infer_input& set_model(const pca::model&)``
-
+.. _pca_i_api_result:
 
 Result
 ~~~~~~
-::
+.. onedal_class:: oneapi::dal::pca::infer_result
 
-   class infer_result {
-   public:
-      infer_result();
-
-      const table& get_transformed_data() const;
-   };
-
-
-.. class:: infer_result
-
-   .. function:: infer_result()
-
-      Creates a result of the inference operation with the default attribute
-      values.
-
-
-   .. member:: table transformed_data = table()
-
-      :math:`n \times r` table that contains data projected to the :math:`r`
-      principal components.
-
-      Getter
-         | ``const table& get_transformed_data() const``
-
-
-Operation semantics
-~~~~~~~~~~~~~~~~~~~
-.. namespace:: oneapi::dal
-.. function:: template <typename Descriptor> \
-              pca::infer_result infer(const Descriptor& desc, \
-                                      const pca::infer_input& input)
-
-   :tparam Descriptor: PCA algorithm descriptor :expr:`pca::desc`.
-
-   Preconditions
-      | :expr:`input.data.is_empty == false`
-      | :expr:`input.model.eigenvectors.row_count == desc.component_count`
-      | :expr:`input.model.eigenvectors.column_count = input.data.column_count`
-
-   Postconditions
-      | :expr:`result.transformed_data.row_count == input.data.row_count`
-      | :expr:`result.transformed_data.column_count == desc.component_count`
+Operation
+~~~~~~~~~
+.. onedal_func:: oneapi::dal::pca::infer

--- a/source/elements/oneDAL/source/algorithms/decomposition/pca.rst
+++ b/source/elements/oneDAL/source/algorithms/decomposition/pca.rst
@@ -128,6 +128,9 @@ Inference
 ---------------------
 Programming Interface
 ---------------------
+All type and function in this section shall be declared in the
+``oneapi::dal::pca`` namespace and be available via inclusion of the
+``oneapi/dal/algo/pca.hpp`` header file.
 
 Descriptor
 ----------

--- a/source/elements/oneDAL/source/algorithms/decomposition/pca.rst
+++ b/source/elements/oneDAL/source/algorithms/decomposition/pca.rst
@@ -96,8 +96,9 @@ Given the inference set :math:`X' = \{ x_1', \ldots, x_m' \}` of
 to the set :math:`X'' = \{ x_1'', \ldots, x_m'' \}`, where :math:`x_{j}''` is an
 :math:`r`-dimensional feature vector, :math:`1 \leq j \leq m`.
 
-The feature vector :math:`x_{j}''` is computed through applying linear transformation
-[Lang87]_ with the matrix :math:`T` to the feature vector :math:`x_{j}'`,
+The feature vector :math:`x_{j}''` is computed through applying linear
+transformation [Lang87]_ defined by the matrix :math:`T` to the feature vector
+:math:`x_{j}'`,
 
 .. math::
    :label: x_transform

--- a/source/elements/oneDAL/source/algorithms/decomposition/pca.rst
+++ b/source/elements/oneDAL/source/algorithms/decomposition/pca.rst
@@ -93,10 +93,10 @@ Inference
 Given the inference set :math:`X' = \{ x_1', \ldots, x_m' \}` of
 :math:`p`-dimensional feature vectors and the :math:`r \times p` matrix
 :math:`T` produced at the training stage, the problem is to transform :math:`X'`
-to the set :math:`X'' = \{ x_1'', \ldots, x_m'' \}`, where :math:`x_{j}''` is
+to the set :math:`X'' = \{ x_1'', \ldots, x_m'' \}`, where :math:`x_{j}''` is an
 :math:`r`-dimensional feature vector, :math:`1 \leq j \leq m`.
 
-The feature vector :math:`x_{j}''` is computed by applying linear transformation
+The feature vector :math:`x_{j}''` is computed through applying linear transformation
 [Lang87]_ with the matrix :math:`T` to the feature vector :math:`x_{j}'`,
 
 .. math::
@@ -128,7 +128,7 @@ Inference
 ---------------------
 Programming Interface
 ---------------------
-All type and function in this section shall be declared in the
+All types and functions in this section shall be declared in the
 ``oneapi::dal::pca`` namespace and be available via inclusion of the
 ``oneapi/dal/algo/pca.hpp`` header file.
 

--- a/source/elements/oneDAL/source/algorithms/decomposition/pca.rst
+++ b/source/elements/oneDAL/source/algorithms/decomposition/pca.rst
@@ -4,16 +4,9 @@
 ===================================
 Principal Components Analysis (PCA)
 ===================================
-
-.. TODO: we either need to refer to the literature that describe the algorithm
-.. (in present daal docs we do not always do that) or specify somewhere a single
-.. source that contain all such descriptions and add more refs in individual algos
-.. when necessary. It would help avoid different interpretation of the possible
-.. minor differences and precisely say-we rely on that specific scheme
-
 Principal Component Analysis (PCA) is an algorithm for exploratory data analysis
-and dimensionality reduction. PCA transforms a set of feature vectors of
-possibly correlated features to a new set of uncorrelated features, called
+and :capterm:`dimensionality reduction`. PCA transforms a set of feature vectors
+of possibly correlated features to a new set of uncorrelated features, called
 principal components. Principal components are the directions of the largest
 variance, that is, the directions where the data is mostly spread out.
 

--- a/source/elements/oneDAL/source/algorithms/index.rst
+++ b/source/elements/oneDAL/source/algorithms/index.rst
@@ -10,6 +10,8 @@ These algorithms include matrix decompositions, clustering, classification,
 and regression algorithms, as well as association rules discovery.
 
 .. toctree::
+   :titlesonly:
+
    clustering/index.rst
    nearest_neighbors/index.rst
    decomposition/index.rst

--- a/source/elements/oneDAL/source/algorithms/nearest_neighbors/index.rst
+++ b/source/elements/oneDAL/source/algorithms/nearest_neighbors/index.rst
@@ -3,4 +3,6 @@ Nearest Neighbors (kNN)
 =======================
 
 .. toctree::
+   :titlesonly:
+
    knn_classification.rst

--- a/source/elements/oneDAL/source/algorithms/nearest_neighbors/knn_classification.rst
+++ b/source/elements/oneDAL/source/algorithms/nearest_neighbors/knn_classification.rst
@@ -4,10 +4,9 @@
 =========================================
 k-Nearest Neighbors Classification (k-NN)
 =========================================
-
-:math:`k`-NN classification algorithm infers the class for the new feature
-vector by computing majority vote of the :math:`k` nearest observations from the
-training set.
+:math:`k`-NN :capterm:`classification` algorithm infers the class for the new
+feature vector by computing majority vote of the :math:`k` nearest observations
+from the training set.
 
 
 .. |t_math| replace:: `Training <knn_t_math_>`_

--- a/source/elements/oneDAL/source/algorithms/nearest_neighbors/knn_classification.rst
+++ b/source/elements/oneDAL/source/algorithms/nearest_neighbors/knn_classification.rst
@@ -138,7 +138,7 @@ Inference
 ---------------------
 Programming Interface
 ---------------------
-All type and function in this section shall be declared in the
+All types and functions in this section shall be declared in the
 ``oneapi::dal::knn`` namespace and be available via inclusion of the
 ``oneapi/dal/algo/knn.hpp`` header file.
 

--- a/source/elements/oneDAL/source/algorithms/nearest_neighbors/knn_classification.rst
+++ b/source/elements/oneDAL/source/algorithms/nearest_neighbors/knn_classification.rst
@@ -10,21 +10,19 @@ vector by computing majority vote of the :math:`k` nearest observations from the
 training set.
 
 
-.. |t_math| replace:: `Training <t_math_>`_
-.. |t_api| replace:: `API <t_api_>`_
-.. |t_brute_f| replace:: `Brute-force <t_math_brute_force_>`_
-.. |t_kd_tree| replace:: `k-d tree <t_math_kd_tree_>`_
-.. |t_input| replace:: `train_input <t_api_input_>`_
-.. |t_result| replace:: `train_result <t_api_result_>`_
-.. |t_op| replace:: `train(...) <t_api_>`_
+.. |t_math| replace:: `Training <knn_t_math_>`_
+.. |t_brute_f| replace:: `Brute-force <knn_t_math_brute_force_>`_
+.. |t_kd_tree| replace:: `k-d tree <knn_t_math_kd_tree_>`_
+.. |t_input| replace:: `train_input <knn_t_api_input_>`_
+.. |t_result| replace:: `train_result <knn_t_api_result_>`_
+.. |t_op| replace:: `train(...) <knn_t_api_>`_
 
-.. |i_math| replace:: `Inference <i_math_>`_
-.. |i_api| replace:: `API <i_api_>`_
-.. |i_brute_f| replace:: `Brute-force <i_math_brute_force_>`_
-.. |i_kd_tree| replace:: `k-d tree <i_math_kd_tree_>`_
-.. |i_input| replace:: `infer_input <i_api_input_>`_
-.. |i_result| replace:: `infer_result <i_api_result_>`_
-.. |i_op| replace:: `infer(...) <i_api_>`_
+.. |i_math| replace:: `Inference <knn_i_math_>`_
+.. |i_brute_f| replace:: `Brute-force <knn_i_math_brute_force_>`_
+.. |i_kd_tree| replace:: `k-d tree <knn_i_math_kd_tree_>`_
+.. |i_input| replace:: `infer_input <knn_i_api_input_>`_
+.. |i_result| replace:: `infer_result <knn_i_api_result_>`_
+.. |i_op| replace:: `infer(...) <knn_i_api_>`_
 
 =============== ============= ============= ======== =========== ============
  **Operation**  **Computational methods**     **Programming Interface**
@@ -37,7 +35,7 @@ training set.
 Mathematical formulation
 ------------------------
 
-.. _t_math:
+.. _knn_t_math:
 
 Training
 --------
@@ -49,7 +47,7 @@ the set of class labels, where :math:`y_i \in \{ 0, \ldots, c-1 \}`, :math:`1
 between the feature vectors in training and inference sets at the inference
 stage.
 
-.. _t_math_brute_force:
+.. _knn_t_math_brute_force:
 
 Training method: *brute-force*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -57,7 +55,7 @@ The training operation produces the model that stores all the feature vectors
 from the initial training set :math:`X`.
 
 
-.. _t_math_kd_tree:
+.. _knn_t_math_kd_tree:
 
 Training method: *k-d tree*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -65,7 +63,7 @@ The training operation builds a :math:`k`-:math:`d` tree that partitions the
 training set :math:`X` (for more details, see :txtref:`k-d Tree <kd_tree>`).
 
 
-.. _i_math:
+.. _knn_i_math:
 
 Inference
 ---------
@@ -100,23 +98,22 @@ m`, by performing the following steps:
       \quad 1 \leq j \leq m.
 
 
-.. _i_math_brute_force:
+.. _knn_i_math_brute_force:
 
 Inference method: *brute-force*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The inference operation determines the set :math:`N(x_j')` of the nearest
-feature vectors by iterating over all the pairs :math:`(x_j', x_i)` in the
-implementation defined order, :math:`1 \leq i \leq n`, :math:`1 \leq j \leq m`.
-The final prediction is computed according to the equations :eq:`p_predict` and
-:eq:`y_predict`.
+Brute-force inference method determines the set :math:`N(x_j')` of the
+nearest feature vectors by iterating over all the pairs :math:`(x_j', x_i)` in
+the implementation defined order, :math:`1 \leq i \leq n`, :math:`1 \leq j \leq
+m`. The final prediction is computed according to the equations :eq:`p_predict`
+and :eq:`y_predict`.
 
 
-.. _i_math_kd_tree:
+.. _knn_i_math_kd_tree:
 
 Inference method: *k-d tree*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The inference operation traverses the :math:`k`-:math:`d` tree to find feature
+K-d tree inference method traverses the :math:`k`-:math:`d` tree to find feature
 vectors associated with a leaf node that are closest to :math:`x_j'`, :math:`1
 \leq j \leq m`. The set :math:`\tilde{n}(x_j')` of the currently-known nearest
 :math:`k`-th neighbors is progressively updated during tree traversal. The
@@ -127,6 +124,17 @@ distance between :math:`x_j'` and the most distant feature vector from
 \equiv N(x_j')`. The final prediction is computed according to the equations
 :eq:`p_predict` and :eq:`y_predict`.
 
+-------------
+Usage example
+-------------
+Training
+--------
+.. onedal_code:: oneapi::dal::knn::example::run_training
+
+Inference
+---------
+.. onedal_code:: oneapi::dal::knn::example::run_inference
+
 
 ---------------------
 Programming Interface
@@ -136,27 +144,31 @@ Descriptor
 ----------
 .. onedal_class:: oneapi::dal::knn::descriptor
 
-Computational methods
----------------------
-.. onedal_compute_methods:: oneapi::dal::knn
+Method tags
+~~~~~~~~~~~
+.. onedal_tags_namespace:: oneapi::dal::knn::method
+
+Task tags
+~~~~~~~~~
+.. onedal_tags_namespace:: oneapi::dal::knn::task
 
 Model
 -----
 .. onedal_class:: oneapi::dal::knn::model
 
 
-.. _t_api:
+.. _knn_t_api:
 
 Training :expr:`train(...)`
 --------------------------------
-.. _t_api_input:
+.. _knn_t_api_input:
 
 Input
 ~~~~~
 .. onedal_class:: oneapi::dal::knn::train_input
 
 
-.. _t_api_result:
+.. _knn_t_api_result:
 
 Result
 ~~~~~~
@@ -167,18 +179,18 @@ Operation
 .. onedal_func:: oneapi::dal::knn::train
 
 
-.. _i_api:
+.. _knn_i_api:
 
 Inference :expr:`infer(...)`
 ----------------------------
-.. _i_api_input:
+.. _knn_i_api_input:
 
 Input
 ~~~~~
 .. onedal_class:: oneapi::dal::knn::infer_input
 
 
-.. _i_api_result:
+.. _knn_i_api_result:
 
 Result
 ~~~~~~

--- a/source/elements/oneDAL/source/algorithms/nearest_neighbors/knn_classification.rst
+++ b/source/elements/oneDAL/source/algorithms/nearest_neighbors/knn_classification.rst
@@ -138,6 +138,9 @@ Inference
 ---------------------
 Programming Interface
 ---------------------
+All type and function in this section shall be declared in the
+``oneapi::dal::knn`` namespace and be available via inclusion of the
+``oneapi/dal/algo/knn.hpp`` header file.
 
 Descriptor
 ----------

--- a/source/elements/oneDAL/source/bibliography.rst
+++ b/source/elements/oneDAL/source/bibliography.rst
@@ -38,3 +38,6 @@ For more information about algorithms implemented in |dal_full_name|
    T. Zhang. Solving Large Scale Linear Prediction Problems Using Stochastic
    Gradient Descent Algorithms. ICML 2004: Proceedings Of The Twenty-First
    International Conference On Machine Learning, 919--926, 2004.
+
+.. [Lang87]
+   S. Lang. *Linear Algebra*. Springer-Verlag New York, 1987.

--- a/source/elements/oneDAL/source/glossary.rst
+++ b/source/elements/oneDAL/source/glossary.rst
@@ -51,7 +51,7 @@ Machine learning terms
     Dimensionality reduction
         A problem of transforming a set of :capterm:`feature vectors <feature
         vector>` from a high-dimensional space into a low-dimensional space
-        retaining meaningful properties of the original feature vectors
+        while retaining meaningful properties of the original feature vectors.
 
     Feature
         A particular property or quality of a real object or an event. Has a

--- a/source/elements/oneDAL/source/glossary.rst
+++ b/source/elements/oneDAL/source/glossary.rst
@@ -48,6 +48,11 @@ Machine learning terms
     Dataset
         A collection of :capterm:`observations <observation>`.
 
+    Dimensionality reduction
+        A problem of transforming a set of :capterm:`feature vectors <feature
+        vector>` from a high-dimensional space into a low-dimensional space
+        retaining meaningful properties of the original feature vectors
+
     Feature
         A particular property or quality of a real object or an event. Has a
         defined type and domain. In machine learning problems, features are


### PR DESCRIPTION
Changes:
- Port all API definitions from raw RST to the "Tool"
- Add missing sections about inference
- Add missing examples 
- Add `Task` to template parameters for all algorithms

**Links:**
- K-Means: https://rlnx.github.io/oneapi-spec/task-api/algorithms/clustering/kmeans.html
- kNN: https://rlnx.github.io/oneapi-spec/task-api/algorithms/nearest_neighbors/knn_classification.html
- PCA: https://rlnx.github.io/oneapi-spec/task-api/algorithms/decomposition/pca.html