### PR TITLE
update container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
           DEBIAN_FRONTEND=noninteractive xargs -a ubuntu-packages.txt apt-get install -qq
           python3 -m venv venv
           . venv/bin/activate
+          pip install --upgrade --quiet pip wheel
           pip install --upgrade --quiet -r requirements.txt
     - name: Build doc
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@ doxygen
 build
 _build
 *~
+*.diff
+*.log
 
+/docker/ubuntu-packages.txt
 /docker/requirements.txt
 /docker/install.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
-COPY install.sh requirements.txt /tmp/
+FROM ubuntu:20.04
+COPY ubuntu-packages.txt install.sh requirements.txt /tmp/
 RUN cd /tmp && ./install.sh
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,15 +33,8 @@ DEBIAN_FRONTEND=noninteractive xargs -a ubuntu-packages.txt apt-get install -qq
 
 python3 -m venv venv
 . venv/bin/activate
+pip install --upgrade pip wheel
 pip install --upgrade --quiet -r requirements.txt
 
-wget http://doxygen.nl/files/doxygen-1.8.17.linux.bin.tar.gz
-tar zxf doxygen-1.8.17.linux.bin.tar.gz
-pushd doxygen-1.8.17
-./configure
-set +e
-make install
-set -e
-popd
 
 

--- a/ubuntu-packages.txt
+++ b/ubuntu-packages.txt
@@ -1,3 +1,4 @@
+doxygen
 enchant
 git
 graphviz


### PR DESCRIPTION
using doxygen from apt. In 20.04, it is 1.8.17 and recent enough to build our docs. Eliminates source forge download of binary, which is not working.
Fix some pip errors