### PR TITLE
[DAL] Build warning fix

### DIFF
--- a/source/elements/oneDAL/dalapi/directives.py
+++ b/source/elements/oneDAL/dalapi/directives.py
@@ -156,7 +156,9 @@ class ClassDirective(DoxyDirective):
             self.add_property(property_def, x)
 
     def add_property(self, property_def, x: RstBuilder):
-        x.add_member(property_def.declaration, level=1)
+        x.add_property_member(property_def.declaration, 
+                              property_def.parent_fully_qualified_name, 
+                              level=1)
         if property_def.doc and property_def.doc.description:
             desc = self.format_description(property_def.doc.description)
             if desc:

--- a/source/elements/oneDAL/dalapi/generator.py
+++ b/source/elements/oneDAL/dalapi/generator.py
@@ -28,6 +28,14 @@ class RstBuilder(object):
         self(f'.. cpp:member:: {declaration}', level)
         self.add_blank_line()
 
+    def add_property_member(self, declaration: str, parent_fully_qualified_name: str, level=0):
+        assert declaration
+        assert parent_fully_qualified_name
+        fake_parent_namespace = '_'.join(parent_fully_qualified_name.split('::'))
+        self(f'.. cpp:namespace:: {fake_parent_namespace}_properties', level)
+        self(f'.. cpp:member:: {declaration}', level)
+        self.add_blank_line()
+
     def add_doc(self, doc_text: str, level=0):
         assert doc_text
         self(self._format_text(doc_text), level)


### PR DESCRIPTION
Fix of #218 

The issue is that dalapi generates fake class member for properties, which can conflict with other names in the class.
For example, in the ``homogen_table``:

```cpp
class homogen_table {
public:
   static int64_t kind();
public:
   int64_t get_kind();
};
```

For ``get_kind()`` the ``kind`` property is generated, which conflicts with static function.

Here I implemented a fix proposed by @rscohn2 by placing generated property symbol inside fake namespace. It does not affect the doc rendering, but affect the reference name of the symbol in html file.