### PR TITLE
[DAL] stylistic corrections in data management layer

### DIFF
--- a/source/elements/oneDAL/include/oneapi/dal/table/common.hpp
+++ b/source/elements/oneDAL/include/oneapi/dal/table/common.hpp
@@ -61,7 +61,7 @@ public:
 
     /// The metadata object that holds additional information
     /// about the data within the table.
-    /// @remark default = oneapi::dal::table_metadata{}
+    /// @remark default = table_metadata()
     const table_metadata& get_metadata() const;
 
     /// The runtime id of the table type.

--- a/source/elements/oneDAL/source/data_management/accessor/column.rst
+++ b/source/elements/oneDAL/source/data_management/accessor/column.rst
@@ -59,7 +59,8 @@ Usage example
 Programming interface
 ---------------------
 
-The following declarations are defined in ``oneapi/dal/table/column_accessor.hpp``
-within ``oneapi::dal`` namespace.
+All types and functions in this section shall be declared in the
+``oneapi::dal`` namespace and be available via inclusion of the
+``oneapi/dal/table/column_accessor.hpp`` header file.
 
 .. onedal_class:: oneapi::dal::column_accessor

--- a/source/elements/oneDAL/source/data_management/accessor/row.rst
+++ b/source/elements/oneDAL/source/data_management/accessor/row.rst
@@ -59,7 +59,8 @@ Usage example
 Programming interface
 ---------------------
 
-The following declarations are defined in ``oneapi/dal/table/row_accessor.hpp``
-within ``oneapi::dal`` namespace.
+All types and functions in this section shall be declared in the
+``oneapi::dal`` namespace and be available via inclusion of the
+``oneapi/dal/table/row_accessor.hpp`` header file.
 
 .. onedal_class:: oneapi::dal::row_accessor

--- a/source/elements/oneDAL/source/data_management/array.rst
+++ b/source/elements/oneDAL/source/data_management/array.rst
@@ -135,8 +135,9 @@ The array shall support the following requirements on the internal data manageme
 Programming interface
 ---------------------
 
-The following declarations are defined in ``oneapi/dal/array.hpp`` within
-``oneapi::dal`` namespace.
+All types and functions in this section shall be declared in the
+``oneapi::dal`` namespace and be available via inclusion of the
+``oneapi/dal/array.hpp`` header file.
 
 All the ``array`` class methods can be divided into several groups:
 

--- a/source/elements/oneDAL/source/data_management/csv_data_source.rst
+++ b/source/elements/oneDAL/source/data_management/csv_data_source.rst
@@ -14,7 +14,7 @@ transform it into numerical representation, and store it as an in-memory
 :txtref:`dataset` of a chosen type.
 
 Supported type of in-memory object for :expr:`read` operation with CSV data
-source is :txtref:`table`.
+source is :expr:`oneapi::dal::table`.
 
 CSV data source requires input file name to be set in the constructor, while the
 other parameters of the constructor such as delimiter and read options rely on
@@ -24,9 +24,11 @@ Usage example
 -------------
 ::
 
-   const auto data_source = onedal::csv::data_source("data.csv", ',');
+   using namespace oneapi;
 
-   const auto table = ondedal::read<onedal::table>(data_source);
+   const auto data_source = dal::csv::data_source("data.csv", ',');
+
+   const auto table = dal::read<dal::table>(data_source);
 
 
 Programming Interface
@@ -60,7 +62,7 @@ All types and functions in this section shall be declared in the
       read_options get_read_options() const;
    };
 
-.. namespace:: onedal::csv
+.. namespace:: oneapi::dal::csv
 .. class:: data_source
 
    .. function:: data_source(const char *file_name, char delimiter = default_delimiter, read_options opts = default_read_options)
@@ -98,7 +100,7 @@ All types and functions in this section shall be declared in the
          | ``read_options get_read_options() const``
 
 
-Reading :expr:`onedal::read<Object>(...)`
+Reading :expr:`oneapi::dal::read<Object>(...)`
 ------------------------------------------------
 
 Args
@@ -123,12 +125,13 @@ Args
 Operation
 ~~~~~~~~~
 
-:code:`onedal::table` is the only supported value of the :code:`Object` template parameter for :expr:`read` operation with CSV data source.
+:expr:`oneapi::dal::table` is the only supported value of the :code:`Object`
+template parameter for :expr:`read` operation with CSV data source.
 
-.. namespace:: onedal
+.. namespace:: oneapi::dal
 .. function:: template <typename Object, typename DataSource> \
               Object read(const DataSource& ds)
 
-   :tparam Object: oneDAL object type that shall be produced as a result of
+   :tparam Object: |dal_short_name| object type that shall be produced as a result of
                    reading from the data source.
    :tparam DataSource: CSV data source :expr:`csv::data_source`.

--- a/source/elements/oneDAL/source/data_management/data_sources.rst
+++ b/source/elements/oneDAL/source/data_management/data_sources.rst
@@ -65,7 +65,7 @@ Each operation shall satisfy the following requirements:
 ------------------------
 Read operation shortcuts
 ------------------------
-In order to make the code on user side less verbose, oneDAL defines the
+In order to make the code on user side less verbose, |dal_short_name| defines the
 following overloaded functions called *shortcuts* for a read operation in addition
 to the general one described in section `Read operation definition
 <read_operation_definition_>`_.

--- a/source/elements/oneDAL/source/data_management/index.rst
+++ b/source/elements/oneDAL/source/data_management/index.rst
@@ -243,4 +243,4 @@ This section includes the detailed descriptions of all data management objects i
    array.rst
    accessors.rst
    data_sources.rst
-   table.rst
+   tables.rst

--- a/source/elements/oneDAL/source/data_management/table/homogen.rst
+++ b/source/elements/oneDAL/source/data_management/table/homogen.rst
@@ -14,7 +14,8 @@ for which the following is true:
 Programming interface
 ---------------------
 
-The following declarations are defined in ``oneapi/dal/table/homogen.hpp``
-within ``oneapi::dal`` namespace.
+All types and functions in this section shall be declared in the
+``oneapi::dal`` namespace and be available via inclusion of the
+``oneapi/dal/table/homogen.hpp`` header file.
 
 .. onedal_class:: oneapi::dal::homogen_table

--- a/source/elements/oneDAL/source/data_management/tables.rst
+++ b/source/elements/oneDAL/source/data_management/tables.rst
@@ -2,9 +2,9 @@
 
 .. _tables:
 
-=====
-Table
-=====
+======
+Tables
+======
 
 This section describes the types related to the :txtref:`table` concept.
 
@@ -36,7 +36,7 @@ Requirements on table types
 
 Each implementation of :txtref:`table` concept shall:
 
-1. Follow definition of the :txtref:`table concept <table>` and its restrictions
+1. Follow definition of the :txtref:`table` concept and its restrictions
    (e.g., :capterm:`immutability`).
 
 2. Be derived from the :expr:`oneapi::dal::table` class. The behavior of this class can be
@@ -95,8 +95,9 @@ Table types
 Programming interface
 ---------------------
 
-The following declarations are defined in ``oneapi/dal/table/common.hpp`` within
-``oneapi::dal`` namespace.
+All types and functions in this section shall be declared in the
+``oneapi::dal`` namespace and be available via inclusion of the
+``oneapi/dal/table/common.hpp`` header file.
 
 Table
 -----

--- a/source/elements/oneDAL/source/data_management/tables.rst
+++ b/source/elements/oneDAL/source/data_management/tables.rst
@@ -36,7 +36,7 @@ Requirements on table types
 
 Each implementation of :txtref:`table` concept shall:
 
-1. Follow definition of the :txtref:`table` concept and its restrictions
+1. Follow the definition of the :txtref:`table` concept and its restrictions
    (e.g., :capterm:`immutability`).
 
 2. Be derived from the :expr:`oneapi::dal::table` class. The behavior of this class can be


### PR DESCRIPTION
* Common section with table declarations renamed to "tables". It has a section "table" describing common table interface, that's why I decided to rename the parent topic. 

* Some references to table types fixed

* Managed how to make default metadata property value to appear

* Data sources: namespace fixes

* Common phrase in programming interface sections is used.