### PR TITLE
oneTBB: add the oneapi::tbb namespace description

### DIFF
--- a/source/elements/oneTBB/source/configuration/namespaces.rst
+++ b/source/elements/oneTBB/source/configuration/namespaces.rst
@@ -15,5 +15,16 @@ tbb::flow Namespace
 -------------------
 
 The ``tbb::flow`` namespace contains public identifiers defined by the
-library that you can reference in your program related to the flow graph feature. See 
+library that you can reference in your program related to the flow graph feature. See
 :doc:`Flow Graph <../flow_graph>` for more information.
+
+oneapi::tbb Namespace
+---------------------
+
+The ``tbb`` namespace is a part of the top level ``oneapi`` namespace. Therefore, all API from the ``tbb``
+namespace (incl. the ``tbb::flow`` namespace) are available in the ``oneapi::tbb`` namespace. The
+``oneapi::tbb`` namespace can be considered as an alias for the ``tbb`` namespace:
+
+.. code:: cpp
+
+    namespace oneapi { namespace tbb = ::tbb; }


### PR DESCRIPTION
Add a description of the oneapi top level namespace and its relation to the ::tbb namespace.