### PR TITLE
oneDNN: adjust memory allocation kind

### DIFF
--- a/source/elements/oneDNN/include/dnnl.hpp
+++ b/source/elements/oneDNN/include/dnnl.hpp
@@ -970,9 +970,9 @@ struct memory {
     ///       doesn't own the buffer.
     ///     - The #DNNL_MEMORY_ALLOCATE special value. Instructs the library to
     ///       allocate the buffer for the memory object. In this case the
-    ///       library owns the buffer. In this case, the memory allocation kind
-    ///       of the underlying buffer is
-    ///       #dnnl::sycl_interop::memory_kind::usm_device.
+    ///       library owns the buffer and the memory allocation kind of the
+    ///       underlying buffer is
+    ///       #dnnl::sycl_interop::memory_kind::usm.
     ///     - #DNNL_MEMORY_NONE to create dnnl::memory without an underlying
     ///       buffer.
     memory(const desc &md, const engine &aengine, void *handle);
@@ -981,7 +981,7 @@ struct memory {
     ///
     /// The underlying buffer for the memory will be allocated by the library.
     /// The memory allocation kind of the underlying buffer is
-    /// #dnnl::sycl_interop::memory_kind::usm_device.
+    /// #dnnl::sycl_interop::memory_kind::usm.
     ///
     /// @param md Memory descriptor.
     /// @param aengine Engine to store the data on.

--- a/source/elements/oneDNN/include/dnnl_sycl.hpp
+++ b/source/elements/oneDNN/include/dnnl_sycl.hpp
@@ -35,14 +35,9 @@ namespace sycl_interop {
 
 /// Memory allocation kinds.
 enum class memory_kind {
-    /// Device memory allocation kind. Such memory allocation is accessible by
-    /// the device, and is not accessible by the host.
-    usm_device,
-    /// Shared memory allocation kind. Such memory allocation is accessible by
-    /// both the host and the device.
-    usm_shared,
-    /// Buffer memory allocation kind. Such memory allocation is accessible in
-    /// global address space.
+    /// USM memory allocation kind.
+    usm,
+    /// Buffer memory allocation kind.
     buffer,
 };
 
@@ -113,7 +108,7 @@ cl::sycl::queue get_queue(const stream &astream);
 /// @param akind Memory allocation kind.
 /// @param ahandle Handle of the memory data to use. This parameter is optional.
 ///     By default, the underlying memory buffer is allocated internally, its
-///     memory allocation kind is #dnnl::sycl_interop::memory_kind::usm_device,
+///     memory allocation kind is #dnnl::sycl_interop::memory_kind::usm,
 ///     and the library owns the buffer. If @p handle is provided, the library
 ///     does not own the buffer.
 ///
@@ -136,7 +131,7 @@ memory make_memory(const memory::desc &adesc, const engine &aengine,
 /// @param akind Memory allocation kind.
 /// @param ahandle Handle of the memory data to use. This parameter is optional.
 ///     By default, the underlying memory buffer is allocated internally, its
-///     memory allocation kind is #dnnl::sycl_interop::memory_kind::usm_device,
+///     memory allocation kind is #dnnl::sycl_interop::memory_kind::usm,
 ///     and the library owns the buffer. If @p handle is provided, the library
 ///     does not own the buffer.
 ///

--- a/source/elements/oneDNN/source/example.cpp
+++ b/source/elements/oneDNN/source/example.cpp
@@ -33,7 +33,7 @@ struct memory {
     memory(memory::desc, engine, void *);
 };
 
-enum class memory_kind { usm_device };
+enum class memory_kind { usm };
 enum class prop_kind { forward_inference };
 enum class algorithm { eltwise_relu };
 


### PR DESCRIPTION
A minor fix before we release to aling the specs with the latest state of the oneDNN opensource project.