### PR TITLE
add reference to info_namespace for tbb

### DIFF
--- a/source/elements/oneTBB/source/nested-aux-interfaces.rst
+++ b/source/elements/oneTBB/source/nested-aux-interfaces.rst
@@ -12,3 +12,4 @@
    memory_allocation.rst
    mutual_exclusion.rst
    timing.rst
+   info_namespace.rst


### PR DESCRIPTION
@ivankochin: Please check this
standalone tbb spec (aux-interfaces.rst) and integrated (nested-aux-interfaces.rst) have separate top-level TOC. Add a missing file.