### PR TITLE
Important fix of opaque memory support removal and couple of editoria…

### DIFF
--- a/source/elements/oneVPL/include/onevpl/mfxdefs.h
+++ b/source/elements/oneVPL/include/onevpl/mfxdefs.h
@@ -135,7 +135,7 @@ typedef union {
         mfxU8  Major; /*!< Major number of the correspondent structure. */
       /*! @} */
     };
-    mfxU16  Version;   /*!< Structure version number */
+    mfxU16  Version;   /*!< Structure version number. */
 } mfxStructVersion;
 MFX_PACK_END()
 

--- a/source/elements/oneVPL/include/onevpl/mfxstructures.h
+++ b/source/elements/oneVPL/include/onevpl/mfxstructures.h
@@ -1329,7 +1329,7 @@ typedef struct {
     */
     mfxU16      DisableDeblockingIdc;
     /*!
-       Completely disables VUI in output bitstream.
+       Completely disables VUI in the output bitstream.
        @note Not all codecs and implementations support this value. Use the Query API function to check if this feature is supported.
     */
     mfxU16      DisableVUI;
@@ -1650,17 +1650,17 @@ Values are in the 1 to 51 range,
        modify, or remove LTR frames based on encoding parameters and content properties. The application must set each input frame's
        mfxFrameData::FrameOrder for correct operation of LTR.
     */
-    mfxU16      ExtBrcAdaptiveLTR;         /* tri-state option for ExtBRC */
+    mfxU16      ExtBrcAdaptiveLTR;         /* Tri-state option for ExtBRC. */
     mfxU16      reserved[163];
 } mfxExtCodingOption3;
 MFX_PACK_END()
 
-/*! IntraPredBlockSize/InterPredBlockSize specifies minimum block size of inter-prediction. */
+/*! IntraPredBlockSize/InterPredBlockSize specifies the minimum block size of inter-prediction. */
 enum {
     MFX_BLOCKSIZE_UNKNOWN   = 0, /*!< Unspecified. */
-    MFX_BLOCKSIZE_MIN_16X16 = 1, /*!< 16x16              */
-    MFX_BLOCKSIZE_MIN_8X8   = 2, /*!< 16x16, 8x8         */
-    MFX_BLOCKSIZE_MIN_4X4   = 3  /*!< 16x16, 8x8, 4x4    */
+    MFX_BLOCKSIZE_MIN_16X16 = 1, /*!< 16x16 minimum block size.              */
+    MFX_BLOCKSIZE_MIN_8X8   = 2, /*!< 8x8 minimum block size. May be 16x16 or 8x8.         */
+    MFX_BLOCKSIZE_MIN_4X4   = 3  /*!< 4x4 minimum block size. May be 16x16, 8x8, or 4x4.    */
 };
 
 /*! The MVPrecision enumerator specifies the motion estimation precision. */
@@ -1676,7 +1676,7 @@ enum {
     MFX_CODINGOPTION_UNKNOWN    =0,    /*!< Unspecified. */
     MFX_CODINGOPTION_ON         =0x10, /*!< Coding option set. */
     MFX_CODINGOPTION_OFF        =0x20, /*!< Coding option not set. */
-    MFX_CODINGOPTION_ADAPTIVE   =0x30  /*!< Reserved */
+    MFX_CODINGOPTION_ADAPTIVE   =0x30  /*!< Reserved. */
 };
 
 /*! The BitstreamDataFlag enumerator uses bit-ORed values to itemize additional information about the bitstream buffer. */
@@ -4216,8 +4216,8 @@ MFX_PACK_BEGIN_STRUCT_W_PTR()
    The mfxExtDeviceAffinityMask structure is used by the application to specify
    affinity mask for the device with given device ID. See mfxDeviceDescription
    for the device ID definition and sub device indexes. If the implementation
-   manages CPU threads for some purposes, user can set CPU threads affinity
-   mask as well by using this structure with deviceID equals to the "CPU". 
+   manages CPU threads for some purpose, the user can set the CPU thread affinity
+   mask by using this structure with DeviceID set to "CPU".
 */
 typedef struct {
     /*! Extension buffer header. Header.BufferId must be equal to

--- a/source/elements/oneVPL/source/appendix/VPL_intel_media_sdk.rst
+++ b/source/elements/oneVPL/source/appendix/VPL_intel_media_sdk.rst
@@ -88,6 +88,9 @@ included in oneVPL:
   into one encoding call. This feature was removed because it is device specific
   and not commonly used.
 
+- **Surface Type Neutral Transcoding.** Opaque memory support is removed and 
+  replaced with internal memory allocation concept.   
+
 -----------------------------------------
 |msdk_full_name| API Removals
 -----------------------------------------
@@ -151,6 +154,12 @@ The following |msdk_full_name| functions are not included in oneVPL:
 - **Video processing functions**
 
   - MFXVideoVPP_RunFrameVPPAsyncEx()
+
+- **Memory type and IOPattern enumerations**
+  
+  - MFX_IOPATTERN_IN_OPAQUE_MEMORY
+  - MFX_IOPATTERN_OUT_OPAQUE_MEMORY
+  - MFX_MEMTYPE_OPAQUE_FRAME
 
 .. important:: Corresponding extension buffers are also removed.
 


### PR DESCRIPTION
Added statement that opaque memory (legacy MSDK feature) is not and will not be supported by oneVPL.