### PR TITLE
[oneMKL][DFT] switch template arguments order and add descriptor -> descriptor_type

### DIFF
--- a/source/elements/oneMKL/source/domains/dft/compute_backward.rst
+++ b/source/elements/oneMKL/source/domains/dft/compute_backward.rst
@@ -32,8 +32,8 @@ compute_backward (Buffer version)
 
    namespace oneapi::mkl::dft {
 
-      template <typename data_type, typename descriptor>
-      void compute_backward( descriptor                 &desc,
+      template <typename descriptor_type, typename data_type>
+      void compute_backward( descriptor_type            &desc,
                              sycl::buffer<data_type, 1> &inout );
 
    }
@@ -44,8 +44,8 @@ compute_backward (Buffer version)
 
    namespace oneapi::mkl::dft {
 
-      template <typename data_type, typename descriptor>
-      void compute_backward( descriptor                 &desc, 
+      template <typename descriptor_type, typename data_type>
+      void compute_backward( descriptor_type            &desc, 
                              sycl::buffer<data_type, 1> &inout_re,
                              sycl::buffer<data_type, 1> &inout_im);
    }
@@ -57,8 +57,8 @@ compute_backward (Buffer version)
 
    namespace oneapi::mkl::dft {
    
-      template <typename input_type, typename output_type, typename descriptor>
-      void compute_backward( descriptor                   &desc,
+      template <typename descriptor_type, typename input_type, typename output_type>
+      void compute_backward( descriptor_type              &desc,
                              sycl::buffer<input_type, 1>  &in, 
                              sycl::buffer<output_type, 1> &out);
    }
@@ -69,8 +69,8 @@ compute_backward (Buffer version)
 
    namespace oneapi::mkl::dft {
 
-      template <typename input_type, typename output_type, typename descriptor>
-      void compute_backward( descriptor                   &desc,
+      template <typename descriptor_type, typename input_type, typename output_type>
+      void compute_backward( descriptor_type              &desc,
                              sycl::buffer<input_type, 1>  &in_re,
                              sycl::buffer<input_type, 1>  &in_im,
                              sycl::buffer<output_type, 1> &out_re,
@@ -151,8 +151,8 @@ compute_backward (USM version)
 
    namespace oneapi::mkl::dft {
    
-      template <typename data_type, typename descriptor>
-      sycl::event compute_backward( descriptor                                    &desc,
+      template <typename descriptor_type, typename data_type>
+      sycl::event compute_backward( descriptor_type                               &desc,
                                     data_type                                     *inout,
                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
    }
@@ -163,8 +163,8 @@ compute_backward (USM version)
 
    namespace oneapi::mkl::dft {
       
-      template <typename data_type, typename descriptor>
-      sycl::event compute_backward(descriptor                                    &desc,
+      template <typename descriptor_type, typename data_type>
+      sycl::event compute_backward(descriptor_type                               &desc,
                                    data_type                                     *inout_re,
                                    data_type                                     *inout_im,
                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
@@ -178,8 +178,8 @@ compute_backward (USM version)
 
    namespace oneapi::mkl::dft {
       
-      template <typename input_type, typename output_type, typename descriptor>
-      sycl::event compute_backward( descriptor                                    &desc,
+      template <typename descriptor_type, typename input_type, typename output_type>
+      sycl::event compute_backward( descriptor_type                               &desc,
                                     input_type                                    *in,
                                     output_type                                   *out,
                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
@@ -193,8 +193,8 @@ compute_backward (USM version)
 
    namespace oneapi::mkl::dft {
       
-      template <typename input_type, typename output_type, typename descriptor>
-      sycl::event compute_backward( descriptor                                    &desc,
+      template <typename descriptor_type, typename input_type, typename output_type>
+      sycl::event compute_backward( descriptor_type                               &desc,
                                     input_type                                    *in_re,
                                     input_type                                    *in_im,
                                     output_type                                   *out_re,

--- a/source/elements/oneMKL/source/domains/dft/compute_forward.rst
+++ b/source/elements/oneMKL/source/domains/dft/compute_forward.rst
@@ -32,8 +32,8 @@ compute_forward (Buffer version)
 
    namespace oneapi::mkl::dft {
 
-      template <typename data_type, typename descriptor>
-      void compute_forward( descriptor                 &desc,
+      template <typename descriptor_type, typename data_type>
+      void compute_forward( descriptor_type            &desc,
                             sycl::buffer<data_type, 1> &inout);
 
    }
@@ -45,8 +45,8 @@ compute_forward (Buffer version)
 
    namespace oneapi::mkl::dft {
 
-      template <typename data_type, typename descriptor>
-      void compute_forward( descriptor                 &desc,
+      template <typename descriptor_type typename data_type>
+      void compute_forward( descriptor_type            &desc,
                             sycl::buffer<data_type, 1> &inout_re,
                             sycl::buffer<data_type, 1> &inout_im);
    }
@@ -58,8 +58,8 @@ compute_forward (Buffer version)
 
    namespace oneapi::mkl::dft {
    
-      template <typename input_type, typename output_type, typename descriptor>
-      void compute_forward( descriptor                   &desc,
+      template <typename descriptor_type, typename input_type, typename output_type>
+      void compute_forward( descriptor_type              &desc,
                             sycl::buffer<input_type, 1>  &in,
                             sycl::buffer<output_type, 1> &out);
    }
@@ -70,8 +70,8 @@ compute_forward (Buffer version)
 
    namespace oneapi::mkl::dft {
 
-      template <typename input_type, typename output_type, typename descriptor>
-      void compute_forward( descriptor                   &desc,
+      template <typename descriptor_type, typename input_type, typename output_type>
+      void compute_forward( descriptor_type              &desc,
                             sycl::buffer<input_type, 1>  &in_re,
                             sycl::buffer<input_type, 1>  &in_im,
                             sycl::buffer<output_type, 1> &out_re,
@@ -155,8 +155,8 @@ compute_forward (USM version)
 
    namespace oneapi::mkl::dft {
    
-      template <typename data_type, typename descriptor>
-      sycl::event compute_forward( descriptor                                    &desc,
+      template <typename descriptor_type, typename data_type>
+      sycl::event compute_forward( descriptor_type                               &desc,
                                    data_type                                     *inout,
                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
    }
@@ -168,8 +168,8 @@ compute_forward (USM version)
 
    namespace oneapi::mkl::dft {
       
-      template <typename data_type, typename descriptor>
-      sycl::event compute_forward(descriptor                                    &desc,
+      template <typename descriptor_type, typename data_type>
+      sycl::event compute_forward(descriptor_type                               &desc,
                                   data_type                                     *inout_re,
                                   data_type                                     *inout_im,
                                   const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
@@ -186,8 +186,8 @@ compute_forward (USM version)
 
    namespace oneapi::mkl::dft {
       
-      template <typename input_type, typename output_type, typename descriptor>
-      sycl::event compute_forward( descriptor                                    &desc,
+      template <typename descriptor_type, typename input_type, typename output_type>
+      sycl::event compute_forward( descriptor_type                               &desc,
                                    input_type                                    *in,
                                    output_type                                   *out,
                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
@@ -201,8 +201,8 @@ compute_forward (USM version)
 
    namespace oneapi::mkl::dft {
       
-      template <typename input_type, typename output_type, typename descriptor>
-      sycl::event compute_forward( descriptor                                    &desc,
+      template <typename descriptor_type, typename input_type, typename output_type>
+      sycl::event compute_forward( descriptor_type                               &desc,
                                    input_type                                    *in_re,
                                    input_type                                    *in_im,
                                    output_type                                   *out_re,


### PR DESCRIPTION
updates template argument order in compute_forward and compute_backward apis.