### PR TITLE
Update README AND CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,7 +3,7 @@
 .. SPDX-License-Identifier: CC-BY-4.0
 
 =================
-How to contribute
+How to Contribute
 =================
 
 This specification is a continuation of Intel’s decades-long history
@@ -21,43 +21,41 @@ prohibit you from also contributing your feedback directly to other
 standard bodies, including The Khronos Group under their respective
 submission policies.
 
-Contribute to the oneAPI Specification by opening issues in the oneAPI
-Specification `GitHub repository
-<https://github.com/oneapi-src/oneapi-spec>`__.
+.. contents::
+   :local:
+   :depth: 1
 
 ----------
 Governance
 ----------
 
-See `governance <doc/governance.rst>`__.
+See `governance <doc/governance.rst>`__ for more information.
 
-----------------
-General Feedback
-----------------
+---------------
+Submit a Change
+---------------
 
-Questions and feature requests can be submitted as issues in the `GitHub repository
-<https://github.com/oneapi-src/oneapi-spec>`__. Writing changes can be submitted as 
-an issue or a pull request. See the the next section on how to submit changes. If 
-none of these methods are appropriate, you may also email to 
+* For questions, feature requests, or to report a bug, submit an
+  `issue <https://github.com/oneapi-src/oneAPI-spec/issues>`__.
+* For changes to the document build infrastructure or minor editing of the text,
+  please submit a `pull request <https://github.com/oneapi-src/oneAPI-spec/pulls>`__.
+* For significant changes to the specification, submit an
+  `issue <https://github.com/oneapi-src/oneAPI-spec/issues>`__. Make sure to
+
+  * include "RFC" in the title,
+  * explain your proposed change and the motivation for the change.
+
+  You may also create a pull request as a way to explain the change.
+
+If none of these methods are appropriate, you may also email
 `oneapi@intel.com <mailto:oneapi@intel.com>`__.
 
-------------------
-Submitting changes
-------------------
-
-For changes to the infrastructure to build the document or minor
-editing/rewriting of the text, please submit a pull request. For
-significant changes to the specification, first submit an issue with
-RFC in the title. Explain what you want to change and the
-motivation. You may also create a pull request as a way to explain the
-change.
-
 --------------
-Sign your work
+Sign Your Work
 --------------
 
-Please include a signed-off-by tag in every contribution of 
-your feedback. By including a signed-off-by tag, you agree 
+Please include a signed-off-by tag in every contribution of
+your feedback. By including a signed-off-by tag, you agree
 that:
 
 1. You have a right to license your feedback to Intel.
@@ -69,8 +67,68 @@ that:
 3. Your feedback will be public and that a record of your feedback
    may be maintained indefinitely.
 
-If you agree to the above, every contribution of your feedback 
-must include the following line using your real name and email 
+If you agree to the above, every contribution of your feedback
+must include the following line using your real name and email
 address: Signed-off-by: Joe Smith joe.smith@email.com
 
+-----------
+Style Guide
+-----------
+
+See the `oneAPI Specification Style Guide <style-guide.rst>`_ for information.
+
+----------------------------------
+Edit with the GitHub Web Interface
+----------------------------------
+
+The simplest and quickest way to submit an edit is via the GitHub web
+interface. It provides an editor, change preview, and lets you submit the change
+as a pull request. You won't need to install any local tools. The preview will
+render ReST, but not the Sphinx directives, so it will not display exactly as the
+final document.
+
+----------------------
+Work with a Local Copy
+----------------------
+
+For bigger edits you will need a local version of the tools. See
+:ref:`Build the Specification <build_spec>` for instructions.
+
+-------------
+Editing Tools
+-------------
+
+For simple edits to individual files, you can use the GitHub web
+interface.
+
+**Emacs** has a built-in ReST mode. It does some syntax highlighting and
+helps with some of the tedious aspects of ReST. M-q will rejustify
+long lines to fit the recommended 80 character line. It understands
+ReST formatting and won't mess up lists. C-= is a Swiss army knife. It
+will cycle between different characters for a section break adornment
+(e.g. --, ===, ...) It will make the section break adornment match the
+size of the text. Probably a lot more.
+
+**Visual Studio Code** has extensions for previewers and automatic
+linting. I could not find any support for rejustifying paragraphs to
+80 characters, which makes it difficult to use.
+
+-----------------------------
+Create a New Version Number
+-----------------------------
+
+Change version in `<oneapi-doc.json>`__ and update the table in
+`<source/versions.rst>`__.
+
+------------
+More Reading
+------------
+
+* `Sphinx Documentation <http://www.sphinx-doc.org/en/master/>`_
+* `reStructuredText docs`_: User and reference manuals.
+* `Online editor/viewer`_: Web page that lets you type in some rst fragments
+  and view. Good for debugging.
+
+.. _`reStructuredText docs`: http://docutils.sourceforge.net/rst.html
+.. _`online editor/viewer`: http://rst.aaroniles.net/
 

--- a/README.rst
+++ b/README.rst
@@ -9,45 +9,54 @@ oneAPI Specifications
 .. image:: https://github.com/oneapi-src/oneapi-spec/workflows/CI/badge.svg
    :target: https://github.com/oneapi-src/oneapi-spec/actions?query=workflow%3ACI
 
-This repo contains the sources for the `oneAPI Specification`_.
+This repository contains the sources for the `oneAPI Specification`_. For the
+latest build from main branch, see
+`HTML <https://oneapi-src.github.io/oneAPI-spec>`__ and
+`PDF <https://rscohn2.github.io/oneAPI-spec/oneAPI-spec.pdf>`__.
 
-For the latest build from main branch, see `HTML
-<https://oneapi-src.github.io/oneAPI-spec>`__ and `PDF
-<https://rscohn2.github.io/oneAPI-spec/oneAPI-spec.pdf>`__.
+For more information about oneAPI, see
+`oneapi.com <https://oneapi.com>`__. For information about future releases of the
+oneAPI specification, see the `oneAPI Specification Roadmap <roadmap.rst>`__.
+To be notified about new releases, become a release-only watcher of this
+repo.
 
-For more information about oneAPI, see `oneapi.com
-<https://oneapi.com>`__. For information about future releases of the
-oneAPI specification, see the `roadmap <roadmap.rst>`__. To be
-notified about new releases, become a release-only watcher of this
-repo. See `contribute <CONTRIBUTING.rst>`__ for information about
-contributing.
+The document is written using `reStructuredText`_ and built with `Sphinx`_ using
+a theme provided by `Read the Docs`_.
 
-The document is built with `Sphinx`_ using a theme provided by `Read
-the Docs`_.
+.. contents::
+   :local:
+   :depth: 1
 
----------------------------------
-Editing with GitHub Web Interface
----------------------------------
+-------
+License
+-------
 
-The simplest and quickest way to edit is directly in the GitHub web
-interface. It has an editor, previewer, and lets you commit
-changes. You won't need to install any local tools. The previewer
-knows how to render RST, but not the sphinx directives so it will not
-display exactly as the real document.
+The oneAPI specification is licensed under the Creative Commons Attribution 4.0
+International License.
 
--------------------------
-Working with a Local Copy
--------------------------
+See `LICENSE <LICENSE.rst>`__ for more information.
 
-For bigger edits, you will need a local version of the tools. Clone
-this repo to your local system. scripts/oneapi.py is a helper script
-for the maintenance tasks. You can also look at the source if you want
-to do the same task manually.
+----------
+Contribute
+----------
+
+See `CONTRIBUTING <CONTRIBUTING.rst>`__ for more information.
+
+.. _build_spec:
+
+-----------------------
+Build the Specification
+-----------------------
+
+To build the specification document locally, clone this repository to your local
+system and follow the setup and build instructions. The setup and build steps
+make use of scripts/oneapi.py, a helper script for maintenance tasks. You can
+also look at the source if you want to see how to do the same task manually.
 
 Setup
 -----
 
-Install Python 3, doxygen (>= 1.8.17), latex, etc.  To install on **Ubuntu**::
+Install Python 3, Doxygen (>= 1.8.17), LaTeX, etc.  To install on **Ubuntu**::
 
    sudo scripts/install.sh
 
@@ -55,76 +64,49 @@ Create and activate a Python virtual environment with all required tools::
 
   python scripts/oneapi.py spec-venv
   source spec-venv/bin/activate
-  
+
 To install directly with pip::
 
   pip install -r requirements.txt
 
-On Windows::
+To install on Windows::
 
   python scripts\oneapi.py spec-venv
   spec-venv\Scripts\activate
-  
 
-Building the docs
------------------
+Build the Docs
+--------------
 
-To build the html document::
+To build the HTML document, use the following command::
 
   python scripts/oneapi.py html
 
 The document is organized as a book with chapters. Each element of
 oneAPI is its own chapter and can be built separately. For example, to
-build the oneVPL chapter, do::
+build the oneVPL chapter, use the following command::
 
   python scripts/oneapi.py html source/elements/oneVPL
-  
-To see the docs, visit build/html/index.html in your browser using a
-file:// URL. Build the pdf version with::
+
+To view the HTML docs, visit build/html/index.html in your browser using a
+file:// URL.
+
+Build the pdf version wit the following command::
 
   python scripts/oneapi.py latexpdf
 
-And then view build/latexpdf/oneAPI-spec.pdf
+The generated PDF will be located at build/latexpdf/oneAPI-spec.pdf.
 
-Editing Tools
--------------
-
-For simple edits to individual files, you can use the GitHub web
-interface.
-
-**Emacs** has a built-in ReST mode. It does some syntax highlighting and
-helps with some of the tedious aspects of ReST. M-q will rejustify
-long lines to fit the recommended 80 character line. It understands
-ReST formatting and won't mess up lists. C-= is a Swiss army knife. It
-will cycle between different characters for a section break adornment
-(e.g. --, ===,...)  It will make the section break adornment match the
-size of the text. Probably a lot more.
-
-**Visual Studio Code** has extensions for previewers and automatic
-linting. I could not find any support for rejustifying paragraphs to
-80 characters, which makes it difficult to use.
-
-------------------
-Submitting changes
-------------------
-
-Changes are submitted as PR's to this repo. PR's and push trigger the
-CI to build the doc and save it as an artifact. If you are working in
-a fork on github, commits to the main branch will build and publish
-the doc in the github pages associated with the repo.
-
-------
 Docker
 ------
 
-You can build a **Docker container** image with::
+You can build a **Docker container** image with the following command::
 
    python scripts/oneapi.py dockerbuild
 
 The tag will be rscohn2/oneapi-spec.  The script copies your proxy settings in
 the invoking shell so it will work inside the firewall.
 
-You can run a docker container with::
+You can run a docker container with the following command::
 
     python scripts/oneapi.py dockerrun
 
@@ -132,30 +114,14 @@ You can run a docker container with::
 CI
 --
 
-We use GitHub actions. See `<.github/workflows/ci.yml>`_
+We use GitHub actions. See `<.github/workflows/ci.yml>`_.
+
+PR's trigger the CI to build the document and save it as an artifact. If you are
+working in a fork on GitHub, commits to the main branch will build and publish
+the document in the GitHub pages associated with the repository.
 
 
------------------------------
-Creating a new version number
------------------------------
-
-Change version in `<oneapi-doc.json>`__ and update the table in
-`<source/versions.rst>`__.
-
-------------
-More Reading
-------------
-
-* `oneAPI Specification Roadmap <roadmap.rst>`__
-* `oneAPI Specification Style Guide <style-guide.rst>`_
-* `Sphinx Documentation <http://www.sphinx-doc.org/en/master/>`_
-* `rst docs`_: User and reference manuals.
-* `online editor/viewer`_: Web page that lets you type in some rst fragments
-  and view. Good for debugging.
-
-.. _`rst tutorial`: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
-.. _`rst docs`: http://docutils.sourceforge.net/rst.html
-.. _`online editor/viewer`: http://rst.aaroniles.net/
-.. _`oneAPI Specification`: https://spec.oneapi.com
+.. _`reStructuredText`: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 .. _`Sphinx`: http://www.sphinx-doc.org/en/master/
 .. _`Read the Docs`: https://readthedocs.org/
+.. _`oneAPI Specification`: https://spec.oneapi.com


### PR DESCRIPTION
- General editorial/capitalization/readability edits
- Standardize capitalization in section headings
- Add local TOC for easier navigation
- Add contribute and license section to README
- Consolidate guidance for contributing (re editing, etc) to
  CONTRIBUTING
- Move build instructions into 'Build the Specification'
  section
- Some reorganization of content for consistency and
  readability

Signed-off-by: Kristal Dale <kristal.dale@intel.com>