### PR TITLE
Disallow antidependencies between oneMKL APIs

### DIFF
--- a/source/elements/oneMKL/source/architecture/execution_model.inc.rst
+++ b/source/elements/oneMKL/source/architecture/execution_model.inc.rst
@@ -57,7 +57,7 @@ The oneMKL API is designed to allow asynchronous execution of computational rout
 
 Hence, it is the calling application's responsibility to ensure that any inputs are valid until computation is complete, and likewise to wait for computation completion before reading any outputs. This can be done automatically when using DPC++ buffers, or manually when using Unified Shared Memory (USM) pointers, as described in the sections below.
 
-Unless otherwise specified, asynchronous execution is *allowed*, but not *guaranteed*, by any oneMKL computational routine, and may vary between implementations and/or versions. oneMKL implementations must clearly document whether execution is guaranteed to be asynchronous for each supported routine.
+Unless otherwise specified, asynchronous execution is *allowed*, but not *guaranteed*, by any oneMKL computational routine, and may vary between implementations and/or versions. oneMKL implementations must clearly document whether execution is guaranteed to be asynchronous for each supported routine. Regardless, calling applications shall not launch any oneMKL computational routine with a dependency on a future oneMKL API call, even if this computational routine executes asynchronously (i.e. a oneMKL implementation may assume no antidependencies are present). This guarantee allows oneMKL implementations to reserve resources for execution without risking deadlock.
 
 .. _onemkl_synchronization_with_buffers:
 


### PR DESCRIPTION
Small clarification to disallow calling a oneMKL computational routine with a dependency on a future oneMKL API call (can be done in a few ways). This allows implementations to claim state and resources in an asynchronous routine at the time of the first call without worrying about deadlocks.