### PR TITLE
Extend tbb::task_group interfaces

### DIFF
--- a/source/elements/oneTBB/source/named_requirements/task_scheduler/task_group_func.rst
+++ b/source/elements/oneTBB/source/named_requirements/task_scheduler/task_group_func.rst
@@ -2,9 +2,9 @@
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 
-===========
+=============
 TaskGroupFunc
-===========
+=============
 **[req.task_group_func]**
 
 A type `Func` satisfies `TaskGroupFunc` if it meets `Function Objects` requirements from

--- a/source/elements/oneTBB/source/named_requirements/task_scheduler/task_group_func.rst
+++ b/source/elements/oneTBB/source/named_requirements/task_scheduler/task_group_func.rst
@@ -1,0 +1,28 @@
+.. SPDX-FileCopyrightText: 2021 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+===========
+TaskGroupFunc
+===========
+**[req.task_group_func]**
+
+A type `Func` satisfies `TaskGroupFunc` if it meets `Function Objects` requirements from
+[function.objects] ISO C++ Standard section and has at least one of the following methods:
+
+----------------------------------------------------------------------
+
+**TaskGroupFunc Requirements: Pseudo-Signature, Semantics**
+
+.. namespace:: TaskGroupFunc
+
+.. cpp:function:: void Func::operator()() const
+
+    Function call.
+
+.. cpp:function:: tbb::task_handle Func::operator()() const
+
+    Function call that returns ``tbb::task_handle``. See :doc:`task_handle
+    <../../task_scheduler/task_group/task_handle>`.
+
+

--- a/source/elements/oneTBB/source/task_scheduler/auxiliary_interfaces.rst
+++ b/source/elements/oneTBB/source/task_scheduler/auxiliary_interfaces.rst
@@ -26,4 +26,4 @@ Member functions
 .. cpp:function:: task_group_context* current_context()
 
     **Returns**: a pointer to the ``task_group_context`` associated with the task currently
-     running. If no task is running by the calling thread, ``nullptr` is returned.
+     running. If no task is running by the calling thread, ``nullptr`` is returned.

--- a/source/elements/oneTBB/source/task_scheduler/auxiliary_interfaces.rst
+++ b/source/elements/oneTBB/source/task_scheduler/auxiliary_interfaces.rst
@@ -1,0 +1,29 @@
+.. SPDX-FileCopyrightText: 2021 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+====================
+auxiliary_interfaces
+====================
+**[scheduler.auxiliary_interfaces]**
+
+A set of helpers that allows to query information about state of the task scheduler on the calling
+thread.
+
+.. code:: cpp
+
+    namespace tbb {
+        namespace task {
+            task_group_context* current_context();
+        }
+    }
+
+Member functions
+----------------
+
+.. namespace:: tbb::task
+
+.. cpp:function:: task_group_context* current_context()
+
+    **Returns**: a pointer to the ``task_group_context`` associated with the task currently
+     running. If no task is running by the calling thread, ``nullptr` is returned.

--- a/source/elements/oneTBB/source/task_scheduler/task_group/task_group_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_group/task_group_cls.rst
@@ -27,6 +27,12 @@ Tasks can be dynamically added to the group while it is executing.
             template<typename Func>
             task_group_status run_and_wait( const Func& f );
 
+            template<typename Func>
+            task_handle make_task( Func&& f );
+
+            void run( task_handle&& th );
+            task_group_status run_and_wait( task_handle&& th );
+
             task_group_status wait();
             void cancel();
         };
@@ -53,13 +59,33 @@ Member functions
 
 .. cpp:function:: template<typename Func> void run( Func&& f )
 
-    Adds a task to compute ``f()`` and returns immediately.
-    The ``Func`` type must meet the `Function Objects` requirements from [function.objects] ISO C++ Standard section.
+    Adds a task to compute ``f()`` and returns immediately. The ``Func`` type must meet the
+    :doc:`TaskGroupFunc requirements <../../named_requirements/task_scheduler/task_group_func>`.
 
 .. cpp:function:: template<typename Func> task_group_status run_and_wait( const Func& f )
 
-    Equivalent to ``{run(f); return wait();}``, but guarantees that ``f()`` runs on the current thread.
-    The ``Func`` type must meet the `Function Objects` requirements from the [function.objects] ISO C++ Standard section.
+    Equivalent to ``{run(f); return wait();}``, but guarantees that ``f()`` runs on the current
+    thread. The ``Func`` type must meet the :doc:`TaskGroupFunc requirements
+    <../../named_requirements/task_scheduler/task_group_func>`.
+
+    **Returns**: The status of ``task_group``. See :doc:`task_group_status <task_group_status_enum>`.
+
+.. cpp:function:: template<typename Func> task_handle make_task( Func&& f )
+
+    Creates a task that is associated with ``task_handle`` to compute ``f()``, but does not make it
+    available for execution. See the :doc:`task_handle <task_handle>`. The ``Func`` type must meet
+    the :doc:`TaskGroupFunc requirements <../../named_requirements/task_scheduler/task_group_func>`.
+
+    **Returns**: ``task_handle`` that must be passed to either method ``run`` or ``run_and_wait``.
+
+.. cpp:function:: void run( task_handle&& th )
+
+    Makes the task associated with ``th`` available for execution and returns immediately.
+
+.. cpp:function:: task_group_status run_and_wait( task_handle&& th )
+
+    Equivalent to ``{run(th); return wait();}``, but guarantees that the task associated with ``th``
+    runs on the current thread.
 
     **Returns**: The status of ``task_group``. See :doc:`task_group_status <task_group_status_enum>`.
 
@@ -78,5 +104,9 @@ Non-member functions
 
 .. cpp:function:: bool is_current_task_group_canceling()
 
-    Returns true if an innermost ``task_group`` executing on this thread is cancelling its tasks.
+    **Returns**: true if an innermost ``task_group`` executing on this thread is cancelling its tasks.
 
+See also:
+
+* :doc:`task_group_context <../scheduling_controls/task_group_context_cls>`
+* :doc:`task_handle <task_handle>`

--- a/source/elements/oneTBB/source/task_scheduler/task_group/task_group_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_group/task_group_cls.rst
@@ -18,7 +18,12 @@ Tasks can be dynamically added to the group while it is executing.
 
         class task_group {
         public:
+            struct traits {
+                bool ignore_outer_cancellation{false};
+            };
+
             task_group();
+            task_group(traits t);
             ~task_group();
 
             template<typename Func>
@@ -40,6 +45,19 @@ Tasks can be dynamically added to the group while it is executing.
         bool is_current_task_group_canceling();
 
     } // namespace tbb
+
+
+Member types and constants
+--------------------------
+
+.. cpp:struct:: traits
+
+    Represents properties of the ``task_group``.
+
+    .. cpp:bool:: ignore_outer_cancellation
+
+       If equals to ``true``, the created ``task_group`` object ignores cancellation requests from
+       outer context.
 
 Member functions
 ----------------

--- a/source/elements/oneTBB/source/task_scheduler/task_group/task_handle.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_group/task_handle.rst
@@ -1,0 +1,47 @@
+.. SPDX-FileCopyrightText: 2021 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+=================
+task_handle
+=================
+**[scheduler.task_handle]**
+
+A ``task_handle`` type is an implementation-defined type that represents the handle of an associated
+task. An instance of ``task_handle`` type can be default-constructed, move-constructed and
+move-assigned, but not copy-constructed, nor copy-assigned from another instance of the
+``task_handle`` type.
+
+.. code:: cpp
+
+    namespace tbb {
+        struct task_handle {
+            task_handle();
+
+            task_handle(const task_handle&) = delete;
+            task_handle& operator=(const task_handle&) = delete;
+
+            task_handle(task_handle&&);
+            task_handle& operator=(task_handle&&);
+
+            // implementation-defined
+        };
+    }
+
+Member functions
+----------------
+
+.. namespace:: tbb::task_handle
+
+.. cpp:function:: task_handle()
+
+    Constructs an empty ``task_handle``.
+
+.. cpp:function:: task_handle(task_handle&& th);
+
+    Constructs a ``task_handle``, which value is moved from ``th``. The value ``th`` is unspecified
+    after the call.
+
+.. cpp:function:: task_handle& operator=(task_handle&& th)
+
+    Assigns the value of ``th`` to ``this``. The value ``th`` is unspecified after the call.


### PR DESCRIPTION
A set of extensions for `tbb::task_group` is added that allows associating a task with `tbb::task_group` without immediate spawn, employ task bypassing, and isolating `tbb::task_group`'s context from the outer one.