### PR TITLE
Add requirements for search algorithm comparator

### DIFF
--- a/source/elements/oneDPL/source/extensions.rst
+++ b/source/elements/oneDPL/source/extensions.rst
@@ -405,8 +405,10 @@ for each value in :code:`[value_first, value_last)`.  If the value exists in the
 the corresponding element in :code:`[result, result + distance(value_first, value_last))` is set to
 true, otherwise it is set to false.
 
-If no comparator is provided, :code:`operator<` is used to determine
-when the search value is less than an element in the range being searched.
+If no comparator is provided, :code:`operator<` is used to determine when the search value is less
+than an element in the range being searched. The elements e of [start, end) are partitioned with
+respect to the comparator used. For all elements e in [start, end) and a given search value v in
+[value_first, value_last) comp(e, v) implies !comp(v, e).
 
 .. code:: cpp
 
@@ -425,8 +427,10 @@ could be inserted in :code:`[start, end)` without violating the ordering defined
 provided. That lowest index is then assigned to the corresponding element in
 :code:`[result, result + distance(value_first, value_last))`.
 
-If no comparator is provided, :code:`operator<` is used to determine
-when the search value is less than an element in the range being searched.
+If no comparator is provided, :code:`operator<` is used to determine when the search value is less
+than an element in the range being searched. The elements e of [start, end) are partitioned with
+respect to the comparator used. For all elements e in [start, end) and a given search value v in
+[value_first, value_last) comp(e, v) implies !comp(v, e).
 
 .. code:: cpp
 
@@ -445,5 +449,7 @@ value could be inserted in :code:`[start, end)` without violating the ordering d
 comparator provided. That highest index is then assigned to the corresponding element in
 :code:`[result, result + distance(value_first, value_last))`.
 
-If no comparator is provided, :code:`operator<` is used to determine
-when the search value is less than an element in the range being searched.
+If no comparator is provided, :code:`operator<` is used to determine when the search value is less
+than an element in the range being searched. The elements e of [start, end) are partitioned with
+respect to the comparator used. For all elements e in [start, end) and a given search value v in
+[value_first, value_last) comp(e, v) implies !comp(v, e).

--- a/source/elements/oneDPL/source/extensions.rst
+++ b/source/elements/oneDPL/source/extensions.rst
@@ -406,9 +406,10 @@ the corresponding element in :code:`[result, result + distance(value_first, valu
 true, otherwise it is set to false.
 
 If no comparator is provided, :code:`operator<` is used to determine when the search value is less
-than an element in the range being searched. The elements e of [start, end) are partitioned with
-respect to the comparator used. For all elements e in [start, end) and a given search value v in
-[value_first, value_last) comp(e, v) implies !comp(v, e).
+than an element in the range being searched.
+
+The elements e of [start, end) must be partitioned with respect to the comparator used. For all
+elements e in [start, end) and a given search value v in [value_first, value_last) comp(e, v) implies !comp(v, e).
 
 .. code:: cpp
 
@@ -428,9 +429,9 @@ provided. That lowest index is then assigned to the corresponding element in
 :code:`[result, result + distance(value_first, value_last))`.
 
 If no comparator is provided, :code:`operator<` is used to determine when the search value is less
-than an element in the range being searched. The elements e of [start, end) are partitioned with
-respect to the comparator used. For all elements e in [start, end) and a given search value v in
-[value_first, value_last) comp(e, v) implies !comp(v, e).
+than an element in the range being searched.
+
+The elements e of [start, end) must be partitioned with respect to the comparator used.
 
 .. code:: cpp
 
@@ -450,6 +451,6 @@ comparator provided. That highest index is then assigned to the corresponding el
 :code:`[result, result + distance(value_first, value_last))`.
 
 If no comparator is provided, :code:`operator<` is used to determine when the search value is less
-than an element in the range being searched. The elements e of [start, end) are partitioned with
-respect to the comparator used. For all elements e in [start, end) and a given search value v in
-[value_first, value_last) comp(e, v) implies !comp(v, e).
+than an element in the range being searched.
+
+The elements e of [start, end) must be partitioned with respect to the comparator used.


### PR DESCRIPTION
The specification of the vectorized search algorithms in the oneDPL extension API did not include the requirements for the comparator provided to the algorithm, nor the related requirement on the partitioning of the data that will be searched.  Adding a sentence to each of `binary_search`, `lower_bound`, and `upper_bound` to resolve this.

Signed-off-by: Timmie Smith timmie.smith@intel.com