### PR TITLE
Remove namespace oneapi::std from oneDPL

### DIFF
--- a/source/elements/oneDPL/source/common.rst
+++ b/source/elements/oneDPL/source/common.rst
@@ -5,7 +5,7 @@
 Namespaces
 ----------
 
-oneDPL uses :code:`namespace oneapi::std` for the subset of the standard C++ library for kernels,
-and uses :code:`namespace oneapi::dpl` for other functionality including Parallel STL algorithms,
-oneDPL execution policies, and extensions.
+oneDPL uses :code:`namespace oneapi::dpl` for all its functionality including Parallel STL algorithms,
+oneDPL execution policies, etc. For the subset of the standard C++ library for kernels, the standard class
+and function names aer also aliased in :code:`namespace oneapi::dpl`.
 

--- a/source/elements/oneDPL/source/common.rst
+++ b/source/elements/oneDPL/source/common.rst
@@ -7,5 +7,4 @@ Namespaces
 
 oneDPL uses :code:`namespace oneapi::dpl` for all its functionality including Parallel STL algorithms,
 oneDPL execution policies, etc. For the subset of the standard C++ library for kernels, the standard class
-and function names aer also aliased in :code:`namespace oneapi::dpl`.
-
+and function names are also aliased in :code:`namespace oneapi::dpl`.


### PR DESCRIPTION
A specification patch that fixes https://github.com/oneapi-src/oneAPI-spec/issues/304