### PR TITLE
oneVPL 2.3.1 release

### DIFF
--- a/source/elements/oneVPL/include/vpl/mfxcommon.h
+++ b/source/elements/oneVPL/include/vpl/mfxcommon.h
@@ -195,7 +195,8 @@ enum {
     MFX_PLATFORM_ROCKETLAKE     = 42, /*!< Code name Rocket Lake. */
     MFX_PLATFORM_ALDERLAKE_S    = 43, /*!< Code name Alder Lake S. */
     MFX_PLATFORM_ALDERLAKE_P    = 44, /*!< Code name Alder Lake P. */
-    MFX_PLATFORM_ARCTICSOUND_P  = 45, /*!< Code name Arctic Sound P. */
+    MFX_PLATFORM_ARCTICSOUND_P  = 45,
+    MFX_PLATFORM_XEHP           = 45, /*!< Code name Xe HP. */
     MFX_PLATFORM_KEEMBAY        = 50, /*!< Code name Keem Bay. */
 };
 

--- a/source/elements/oneVPL/source/API_ref/VPL_enums.rst
+++ b/source/elements/oneVPL/source/API_ref/VPL_enums.rst
@@ -1826,12 +1826,13 @@ PlatformCodeName
 .. doxygenenumvalue:: MFX_PLATFORM_ALDERLAKE_P 
    :project: oneVPL
 
-.. doxygenenumvalue:: MFX_PLATFORM_ARCTICSOUND_P
-   :project: oneVPL
+.. doxygenenumvalue:: MFX_PLATFORM_XEHP 
+    :project: oneVPL   
 
 .. doxygenenumvalue:: MFX_PLATFORM_KEEMBAY
    :project: oneVPL
 
+    
 
 --------
 PRefType

--- a/source/elements/oneVPL/source/VPL_change_log.rst
+++ b/source/elements/oneVPL/source/VPL_change_log.rst
@@ -22,7 +22,8 @@ Version 2.3
     * Code name Rocket Lake,
     * Code name Alder Lake S,
     * Code name Alder Lake P,
-    * Code name Arctic Sound P.
+    * Code name for Arctic Sound P.
+    * For spec version 2.3.1 MFX_PLATFORM_XEHP alias was added
 
 * mfx.h header file is added which includes all header files.
 * Added deprecation messages (deprecation macro) to the functions MFXInit and


### PR DESCRIPTION
Important: needs to merged after watermark turning off for prod env.

This release brings:

* Encoding in Hyper mode.
* New product names for platforms:

    * Code name Rocket Lake,
    * Code name Alder Lake S,
    * Code name Alder Lake P,
    * Code name for Arctic Sound P.
    * For spec version 2.3.1 MFX_PLATFORM_XEHP alias was added

* mfx.h header file is added which includes all header files.
* Added deprecation messages (deprecation macro) to the functions MFXInit and
  MFXInitEx functions definition.