### PR TITLE
oneVPL 2.3.1 (u) release

### DIFF
--- a/oneapi-doc.json
+++ b/oneapi-doc.json
@@ -1,5 +1,5 @@
 {
     "version": "1.1-provisional-draft",
-    "vpl_version": "2.3.0",
+    "vpl_version": "2.3.1",
     "art_version": "0.5-rev-1"
 }

--- a/source/elements/oneVPL/include/vpl/mfxcommon.h
+++ b/source/elements/oneVPL/include/vpl/mfxcommon.h
@@ -196,7 +196,7 @@ enum {
     MFX_PLATFORM_ALDERLAKE_S    = 43, /*!< Code name Alder Lake S. */
     MFX_PLATFORM_ALDERLAKE_P    = 44, /*!< Code name Alder Lake P. */
     MFX_PLATFORM_ARCTICSOUND_P  = 45,
-    MFX_PLATFORM_XEHP           = 45, /*!< Code name Xe HP. */
+    MFX_PLATFORM_XEHP_SDV       = 45, /*!< Code name XeHP SDV. */
     MFX_PLATFORM_KEEMBAY        = 50, /*!< Code name Keem Bay. */
 };
 

--- a/source/elements/oneVPL/source/API_ref/VPL_enums.rst
+++ b/source/elements/oneVPL/source/API_ref/VPL_enums.rst
@@ -1826,7 +1826,7 @@ PlatformCodeName
 .. doxygenenumvalue:: MFX_PLATFORM_ALDERLAKE_P 
    :project: oneVPL
 
-.. doxygenenumvalue:: MFX_PLATFORM_XEHP 
+.. doxygenenumvalue:: MFX_PLATFORM_XEHP_SDV
     :project: oneVPL   
 
 .. doxygenenumvalue:: MFX_PLATFORM_KEEMBAY

--- a/source/elements/oneVPL/source/VPL_change_log.rst
+++ b/source/elements/oneVPL/source/VPL_change_log.rst
@@ -23,7 +23,7 @@ Version 2.3
     * Code name Alder Lake S,
     * Code name Alder Lake P,
     * Code name for Arctic Sound P.
-    * For spec version 2.3.1 MFX_PLATFORM_XEHP alias was added
+    * For spec version 2.3.1 MFX_PLATFORM_XEHP_SDV alias was added
 
 * mfx.h header file is added which includes all header files.
 * Added deprecation messages (deprecation macro) to the functions MFXInit and


### PR DESCRIPTION
* Encoding in Hyper mode.
* New product names for platforms:

    * Code name Rocket Lake,
    * Code name Alder Lake S,
    * Code name Alder Lake P,
    * Code name for Arctic Sound P.
    * For spec version 2.3.1 MFX_PLATFORM_XEHP_SDV alias was added

* mfx.h header file is added which includes all header files.
* Added deprecation messages (deprecation macro) to the functions MFXInit and
  MFXInitEx functions definition.