### PR TITLE
oneVPL Spec update to version 2.4

### DIFF
--- a/oneapi-doc.json
+++ b/oneapi-doc.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1-provisional-draft",
-    "vpl_version": "2.3.1",
+    "version": "1.1-provisional-rev-1",
+    "vpl_version": "2.4.0",
     "art_version": "0.5-rev-1"
 }

--- a/source/elements/oneVPL/include/vpl/mfxcommon.h
+++ b/source/elements/oneVPL/include/vpl/mfxcommon.h
@@ -431,7 +431,10 @@ MFX_PACK_END()
 /* The mfxImplCapsDeliveryFormat enumerator specifies delivery format of the implementation capability. */
 typedef enum {
     MFX_IMPLCAPS_IMPLDESCSTRUCTURE       = 1,  /*!< Deliver capabilities as mfxImplDescription structure. */
-    MFX_IMPLCAPS_IMPLEMENTEDFUNCTIONS    = 2   /*!< Deliver capabilities as mfxImplementedFunctions structure. */
+    MFX_IMPLCAPS_IMPLEMENTEDFUNCTIONS    = 2,  /*!< Deliver capabilities as mfxImplementedFunctions structure. */
+    MFX_IMPLCAPS_IMPLPATH                = 3   /*!< Deliver pointer to the null-terminated string with the path to the
+                                                    implementation. String is delivered in a form of buffer of
+                                                    mfxChar type. */
 } mfxImplCapsDeliveryFormat;
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()

--- a/source/elements/oneVPL/include/vpl/mfxdefs.h
+++ b/source/elements/oneVPL/include/vpl/mfxdefs.h
@@ -1,5 +1,5 @@
 /*############################################################################
-  # Copyright (C) 2019-2020 Intel Corporation
+  # Copyright (C) 2019-2021 Intel Corporation
   #
   # SPDX-License-Identifier: MIT
   ############################################################################*/
@@ -8,7 +8,7 @@
 #define __MFXDEFS_H__
 
 #define MFX_VERSION_MAJOR 2
-#define MFX_VERSION_MINOR 3
+#define MFX_VERSION_MINOR 4
 
 // MFX_VERSION - version of API that 'assumed' by build may be provided externally
 // if it omitted then latest stable API derived from Major.Minor is assumed
@@ -176,20 +176,35 @@ MFX_PACK_END()
 
 #define MFX_VARIANT_VERSION MFX_STRUCT_VERSION(1, 0)
 
-/*! The mfxVariantType enumerator data types for mfxVarianf type. */
+/*! The mfxDataType enumerates data type for mfxDataType. */
 typedef enum {
-    MFX_VARIANT_TYPE_UNSET = 0, /*!< Undefined type. */
-    MFX_VARIANT_TYPE_U8 = 1,   /*!< 8-bit unsigned integer. */
-    MFX_VARIANT_TYPE_I8,       /*!< 8-bit signed integer. */
-    MFX_VARIANT_TYPE_U16,      /*!< 16-bit unsigned integer. */
-    MFX_VARIANT_TYPE_I16,      /*!< 16-bit signed integer. */
-    MFX_VARIANT_TYPE_U32,      /*!< 32-bit unsigned integer. */
-    MFX_VARIANT_TYPE_I32,      /*!< 32-bit signed integer. */
-    MFX_VARIANT_TYPE_U64,      /*!< 64-bit unsigned integer. */
-    MFX_VARIANT_TYPE_I64,      /*!< 64-bit signed integer. */
-    MFX_VARIANT_TYPE_F32,      /*!< 32-bit single precision floating point. */
-    MFX_VARIANT_TYPE_F64,      /*!< 64-bit double precision floating point. */
-    MFX_VARIANT_TYPE_PTR,      /*!< Generic type pointer. */
+    MFX_DATA_TYPE_UNSET   = 0,            /*!< Undefined type. */
+    MFX_DATA_TYPE_U8,                     /*!< 8-bit unsigned integer. */
+    MFX_DATA_TYPE_I8,                     /*!< 8-bit signed integer. */
+    MFX_DATA_TYPE_U16,                    /*!< 16-bit unsigned integer. */
+    MFX_DATA_TYPE_I16,                    /*!< 16-bit signed integer. */
+    MFX_DATA_TYPE_U32,                    /*!< 32-bit unsigned integer. */
+    MFX_DATA_TYPE_I32,                    /*!< 32-bit signed integer. */
+    MFX_DATA_TYPE_U64,                    /*!< 64-bit unsigned integer. */
+    MFX_DATA_TYPE_I64,                    /*!< 64-bit signed integer. */
+    MFX_DATA_TYPE_F32,                    /*!< 32-bit single precision floating point. */
+    MFX_DATA_TYPE_F64,                    /*!< 64-bit double precision floating point. */
+}mfxDataType;
+
+/*! The mfxVariantType enumerator data types for mfxVariantType. */
+typedef enum {
+    MFX_VARIANT_TYPE_UNSET = MFX_DATA_TYPE_UNSET,                        /*!< Undefined type. */
+    MFX_VARIANT_TYPE_U8    = MFX_DATA_TYPE_U8,                           /*!< 8-bit unsigned integer. */
+    MFX_VARIANT_TYPE_I8    = MFX_DATA_TYPE_I8,                           /*!< 8-bit signed integer. */
+    MFX_VARIANT_TYPE_U16   = MFX_DATA_TYPE_U16,                          /*!< 16-bit unsigned integer. */
+    MFX_VARIANT_TYPE_I16   = MFX_DATA_TYPE_I16,                          /*!< 16-bit signed integer. */
+    MFX_VARIANT_TYPE_U32   = MFX_DATA_TYPE_U32,                          /*!< 32-bit unsigned integer. */
+    MFX_VARIANT_TYPE_I32   = MFX_DATA_TYPE_I32,                          /*!< 32-bit signed integer. */
+    MFX_VARIANT_TYPE_U64   = MFX_DATA_TYPE_U64,                          /*!< 64-bit unsigned integer. */
+    MFX_VARIANT_TYPE_I64   = MFX_DATA_TYPE_I64,                          /*!< 64-bit signed integer. */
+    MFX_VARIANT_TYPE_F32   = MFX_DATA_TYPE_F32,                          /*!< 32-bit single precision floating point. */
+    MFX_VARIANT_TYPE_F64   = MFX_DATA_TYPE_F64,                          /*!< 64-bit double precision floating point. */
+    MFX_VARIANT_TYPE_PTR,                                                /*!< Generic type pointer. */
 } mfxVariantType;
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
@@ -292,6 +307,17 @@ typedef enum
     MFX_ERR_MORE_DATA_SUBMIT_TASK       = -10000, /*!< Return MFX_ERR_MORE_DATA but submit internal asynchronous task. */
 
 } mfxStatus;
+
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
+/*! Represents Globally Unique Identifier (GUID) with memory layout 
+    compliant to RFC 4122. See https://www.rfc-editor.org/info/rfc4122 for details. */
+typedef struct
+{
+    mfxU8 Data[16]; /*!< Array to keep GUID. */
+} mfxGUID;
+MFX_PACK_END()
+
 
 
 // Application

--- a/source/elements/oneVPL/include/vpl/mfxdispatcher.h
+++ b/source/elements/oneVPL/include/vpl/mfxdispatcher.h
@@ -27,7 +27,7 @@ typedef struct _mfxConfig *mfxConfig;
 
    @since This function is available since API version 2.0.
 */
-mfxLoader MFX_CDECL MFXLoad();
+mfxLoader MFX_CDECL MFXLoad(void);
 
 /*!
    @brief Destroys the dispatcher.
@@ -64,66 +64,6 @@ mfxConfig MFX_CDECL MFXCreateConfig(mfxLoader loader);
           One mfxConfig properties can hold only single filter property.
           @note Each new call with the same parameter name will overwrite the previously set value. This may invalidate other properties.
           @note Each new call with another parameter name will delete the previous property and create a new property based on new name's value.
-
-          Simple usage example:
-          @code
-             mfxLoader loader = MFXLoad();
-             mfxConfig cfg = MFXCreateConfig(loader);
-             mfxVariant ImplValue;
-             ImplValue.Type = MFX_VARIANT_TYPE_U32;
-             ImplValue.Data.U32 = MFX_IMPL_TYPE_HARDWARE;
-             MFXSetConfigFilterProperty(cfg,"mfxImplDescription.Impl",ImplValue);
-             MFXCreateSession(loader,0,&session);
-          @endcode
-
-          Usage example with two sessions (multiple loaders):
-          @code
-             // Create session with software based implementation
-             mfxLoader loader1 = MFXLoad();
-             mfxConfig cfg1 = MFXCreateConfig(loader1);
-             mfxVariant ImplValueSW;
-             ImplValueSW.Type = MFX_VARIANT_TYPE_U32;
-             ImplValueSW.Data.U32 = MFX_IMPL_TYPE_SOFTWARE;
-             MFXSetConfigFilterProperty(cfg1,"mfxImplDescription.Impl",ImplValueSW);
-             MFXCreateSession(loader1,0,&sessionSW);
-
-             // Create session with hardware based implementation
-             mfxLoader loader2 = MFXLoad();
-             mfxConfig cfg2 = MFXCreateConfig(loader2);
-             mfxVariant ImplValueHW;
-             ImplValueHW.Type = MFX_VARIANT_TYPE_U32;
-             ImplValueHW.Data.U32 = MFX_IMPL_TYPE_HARDWARE;
-             MFXSetConfigFilterProperty(cfg2,"mfxImplDescription.Impl",ImplValueHW);
-             MFXCreateSession(loader2,0,&sessionHW);
-
-             // use both sessionSW and sessionHW
-             // ...
-             // Close everything
-             MFXClose(sessionSW);
-             MFXClose(sessionHW);
-             MFXUnload(loader1); // cfg1 will be destroyed here.
-             MFXUnload(loader2); // cfg2 will be destroyed here.
-          @endcode
-
-          Usage example with two decoders (multiple config objects):
-          @code
-             mfxLoader loader = MFXLoad();
-
-             mfxConfig cfg1 = MFXCreateConfig(loader);
-             mfxVariant ImplValue;
-             val.Type = MFX_VARIANT_TYPE_U32;
-             val.Data.U32 = MFX_CODEC_AVC;
-             MFXSetConfigFilterProperty(cfg1,"mfxImplDescription.mfxDecoderDescription.decoder.CodecID",ImplValue);
-
-             mfxConfig cfg2 = MFXCreateConfig(loader);
-             mfxVariant ImplValue;
-             val.Type = MFX_VARIANT_TYPE_U32;
-             val.Data.U32 = MFX_CODEC_HEVC;
-             MFXSetConfigFilterProperty(cfg2,"mfxImplDescription.mfxDecoderDescription.decoder.CodecID",ImplValue);
-
-             MFXCreateSession(loader,0,&sessionAVC);
-             MFXCreateSession(loader,0,&sessionHEVC);
-          @endcode
 
    @param[in] config Config handle.
    @param[in] name Name of the parameter (see mfxImplDescription structure and example).

--- a/source/elements/oneVPL/include/vpl/mfxstructures.h
+++ b/source/elements/oneVPL/include/vpl/mfxstructures.h
@@ -166,6 +166,8 @@ enum {
     MFX_FOURCC_I010         = MFX_MAKEFOURCC('I', '0', '1', '0'), /*!< 10-bit YUV 4:2:0, each component has its own plane. */
     MFX_FOURCC_I420         = MFX_FOURCC_IYUV,                 /*!< Alias for the IYUV color format. */
     MFX_FOURCC_BGRA         = MFX_FOURCC_RGB4,                 /*!< Alias for the RGB4 color format. */
+    /*! BGR 24 bit planar layout (3 separate channels, 8-bits per sample each). This format should be mapped to VA_FOURCC_BGRP. */
+    MFX_FOURCC_BGRP         = MFX_MAKEFOURCC('B','G','R','P'),
 };
 
 /* PicStruct */
@@ -567,8 +569,27 @@ typedef struct mfxFrameSurfaceInterface {
 
     */
     void               (MFX_CDECL *OnComplete)(mfxStatus sts);
+    
+   /*! @brief
+    Returns an interface defined by the GUID. If the returned interface is a reference 
+    counted object the caller should release the obtained interface to avoid memory leaks.
 
-    mfxHDL              reserved2[3];
+    @param[in]  surface   Valid surface.
+    @param[in]  guid      GUID of the requested interface.
+    @param[out] iface     Interface.
+
+
+    @return
+     MFX_ERR_NONE               If no error. \n
+     MFX_ERR_NULL_PTR           If interface or surface is NULL. \n
+     MFX_ERR_UNSUPPORTED        If requested interface is not supported. \n
+     MFX_ERR_NOT_IMPLEMENTED    If requested interface is not implemented. \n
+     MFX_ERR_NOT_INITIALIZED    If requested interface is not available (not created or already deleted). \n
+     MFX_ERR_UNKNOWN            Any internal error.
+    */
+    mfxStatus           (MFX_CDECL *QueryInterface)(mfxFrameSurface1* surface, mfxGUID guid, mfxHDL* iface); 
+
+    mfxHDL              reserved2[2];
 } mfxFrameSurfaceInterface;
 MFX_PACK_END()
 
@@ -1663,12 +1684,16 @@ typedef struct {
        @note Not all codecs and implementations support this value. Use the Query API function to check if this feature is supported.
     */
     mfxU16      EnableNalUnitType;
-    /*!
-       Turn OFF to prevent Adaptive marking of Long Term Reference Frames when using ExtBRC. When set to ON and using ExtBRC, encoders will mark,
-       modify, or remove LTR frames based on encoding parameters and content properties. The application must set each input frame's
-       mfxFrameData::FrameOrder for correct operation of LTR.
-    */
-    mfxU16      ExtBrcAdaptiveLTR;         /* Tri-state option for ExtBRC. */
+
+    union {
+        mfxU16      ExtBrcAdaptiveLTR; /* Deprecated */
+        
+        /*!
+            If this flag is set to ON, encoder will mark, modify, or remove LTR frames based on encoding parameters and content          
+            properties. Turn OFF to prevent Adaptive marking of Long Term Reference Frames. 
+        */
+        mfxU16      AdaptiveLTR;
+    };
     /*!
        If this flag is set to ON, encoder adaptively selects one of implementation-defined quantization matrices for each frame.
        Non-default quantization matrices aim to improve subjective visual quality under certain conditions.
@@ -1677,8 +1702,13 @@ typedef struct {
        This parameter is valid only during initialization.
     */
     mfxU16      AdaptiveCQM;
-
-    mfxU16      reserved[162];
+    /*!
+       If this flag is set to ON, encoder adaptively selects list of reference frames to imrove encoding quality.
+       Enabling of the flag can increase computation complexity and introduce additional delay.
+       If this flag is set to OFF, regular reference frames are used for encoding.
+    */
+    mfxU16      AdaptiveRef;
+    mfxU16      reserved[161];
 } mfxExtCodingOption3;
 MFX_PACK_END()
 
@@ -2033,7 +2063,12 @@ enum {
     /*!
        See the mfxExtHyperModeParam structure for more details.
     */
-    MFX_EXTBUFF_HYPER_MODE_PARAM = MFX_MAKEFOURCC('H', 'Y', 'P', 'M')
+    MFX_EXTBUFF_HYPER_MODE_PARAM = MFX_MAKEFOURCC('H', 'Y', 'P', 'M'),
+
+    /*!
+       See the mfxExtVPP3DLut structure for more details.
+    */
+    MFX_EXTBUFF_VPP_3DLUT = MFX_MAKEFOURCC('T','D','L','T'),
 };
 
 /* VPP Conf: Do not use certain algorithms  */
@@ -2089,6 +2124,94 @@ typedef struct {
                                  the larger the change is.  */
     mfxU16  reserved[15];
 } mfxExtVPPDenoise2;
+MFX_PACK_END()
+
+/*! The mfx3DLutChannelMapping enumerator specifies the channel mapping of 3DLUT. */
+typedef enum {
+    MFX_3DLUT_CHANNEL_MAPPING_DEFAULT            = 0,   /*!< Default 3DLUT channel mapping. The library selects the most appropriate 3DLUT channel mapping. */
+    MFX_3DLUT_CHANNEL_MAPPING_RGB_RGB            = 1,   /*!< 3DLUT RGB channels map to RGB channels. */
+    MFX_3DLUT_CHANNEL_MAPPING_YUV_RGB            = 2,   /*!< 3DLUT YUV channels map to RGB channels. */
+    MFX_3DLUT_CHANNEL_MAPPING_VUY_RGB            = 3,   /*!< 3DLUT VUY channels map to RGB channels. */
+} mfx3DLutChannelMapping;
+
+/*! The mfx3DLutMemoryLayout enumerator specifies the memory layout of 3DLUT. */
+typedef enum {
+    MFX_3DLUT_MEMORY_LAYOUT_DEFAULT                        = 0,          /*!< Default 3DLUT memory layout. The library selects the most appropriate 3DLUT memory layout.*/
+
+    MFX_3DLUT_MEMORY_LAYOUT_VENDOR                         = 0x1000,     /*!< The enumeration to separate default above and vendor specific.*/
+    /*!
+       Intel specific memory layout. The enumerator indicates the attributes and memory layout of 3DLUT.
+       3DLUT size is 17(the number of elements per dimension), 4 channels(3 valid channels, 1 channel is reserved), every channel must be 16-bit unsigned integer.
+       3DLUT contains 17x17x32 entries with holes that are not filled. Take RGB as example, the nodes RxGx17 to RxGx31 are not filled, are "don't care" bits, and not accessed for the 17x17x17 nodes.
+    */
+    MFX_3DLUT_MEMORY_LAYOUT_INTEL_17LUT                    = MFX_3DLUT_MEMORY_LAYOUT_VENDOR + 1,
+    /*!
+       Intel specific memory layout. The enumerator indicates the attributes and memory layout of 3DLUT.
+       3DLUT size is 33(the number of elements per dimension), 4 channels(3 valid channels, 1 channel is reserved), every channel must be 16-bit unsigned integer.
+       3DLUT contains 33x33x64 entries with holes that are not filled. Take RGB as example, the nodes RxGx33 to RxGx63 are not filled, are "don't care" bits, and not accessed for the 33x33x33 nodes.
+    */
+    MFX_3DLUT_MEMORY_LAYOUT_INTEL_33LUT                    = MFX_3DLUT_MEMORY_LAYOUT_VENDOR + 2,
+    /*!
+       Intel specific memory layout. The enumerator indicates the attributes and memory layout of 3DLUT.
+       3DLUT size is 65(the number of elements per dimension), 4 channels(3 valid channels, 1 channel is reserved), every channel must be 16-bit unsigned integer.
+       3DLUT contains 65x65x128 entries with holes that are not filled. Take RGB as example, the nodes RxGx65 to RxGx127 are not filled, are "don't care" bits, and not accessed for the 65x65x65 nodes.
+    */
+    MFX_3DLUT_MEMORY_LAYOUT_INTEL_65LUT                    = MFX_3DLUT_MEMORY_LAYOUT_VENDOR + 3,
+} mfx3DLutMemoryLayout;
+
+MFX_PACK_BEGIN_STRUCT_W_PTR()
+/*!
+    A hint structure that configures the data channel.
+*/
+typedef struct {
+    mfxDataType  DataType;                /*!< Data type, mfxDataType enumerator.*/
+    mfxU32       Size;                    /*!< Size of Look up table, the number of elements per dimension.*/
+    union
+    {
+        mfxU8*     Data;                  /*!< The pointer to 3DLUT data, 8 bit unsigned integer.*/
+        mfxU16*    Data16;                /*!< The pointer to 3DLUT data, 16 bit unsigned integer.*/
+    };
+    mfxU32       reserved[4];             /*!< Reserved for future extension.*/
+} mfxChannel;
+MFX_PACK_END()
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
+/*!
+    A hint structure that configures 3DLUT system buffer.
+*/
+typedef struct {
+    mfxChannel           Channel[3];        /*!< 3 Channels, can be RGB or YUV, mfxChannel structure.*/
+    mfxU32               reserved[8];       /*!< Reserved for future extension.*/
+} mfx3DLutSystemBuffer;
+MFX_PACK_END()
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
+/*!
+    A hint structure that configures 3DLUT video buffer.
+*/
+typedef struct {
+    mfxDataType                DataType;       /*!< Data type, mfxDataType enumerator.*/
+    mfx3DLutMemoryLayout       MemLayout;      /*!< Indicates 3DLUT memory layout. mfx3DLutMemoryLayout enumerator.*/
+    mfxMemId                   MemId;          /*!< Memory ID for holding the lookup table data. One MemID is dedicated for one instance of VPP.*/
+    mfxU32                     reserved[8];    /*!< Reserved for future extension.*/
+} mfx3DLutVideoBuffer;
+MFX_PACK_END()
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
+/*!
+    A hint structure that configures 3DLUT filter.
+*/
+typedef struct {
+    mfxExtBuffer             Header;           /*!< Extension buffer header. Header.BufferId must be equal to MFX_EXTBUFF_VPP_3DLUT..*/
+    mfx3DLutChannelMapping   ChannelMapping;   /*!< Indicates 3DLUT channel mapping. mfx3DLutChannelMapping enumerator.*/
+    mfxResourceType          BufferType;       /*!< Indicates 3DLUT buffer type. mfxResourceType enumerator, can be system memory, VA surface, DX11 texture/buffer etc.*/
+    union
+    {
+        mfx3DLutSystemBuffer SystemBuffer;     /*!< The 3DLUT system buffer. mfx3DLutSystemBuffer structure describes the details of the buffer.*/
+        mfx3DLutVideoBuffer  VideoBuffer;      /*!< The 3DLUT video buffer. mfx3DLutVideoBuffer describes the details of 3DLUT video buffer.*/
+    };
+    mfxU32                   reserved[4];      /*!< Reserved for future extension.*/
+} mfxExtVPP3DLut;
 MFX_PACK_END()
 
 MFX_PACK_BEGIN_USUAL_STRUCT()

--- a/source/elements/oneVPL/source/API_ref/VPL_enums.rst
+++ b/source/elements/oneVPL/source/API_ref/VPL_enums.rst
@@ -663,6 +663,9 @@ The ColorFourCC enumerator itemizes color formats.
 .. doxygenenumvalue:: MFX_FOURCC_Y416
    :project: oneVPL
 
+.. doxygenenumvalue:: MFX_FOURCC_BGRP
+   :project: oneVPL
+
 -----------
 ContentInfo
 -----------
@@ -808,6 +811,9 @@ extended buffers or video processing algorithm identifiers.
    :project: oneVPL
 
 .. doxygenenumvalue:: MFX_EXTBUFF_VPP_DENOISE2
+   :project: oneVPL
+
+.. doxygenenumvalue:: MFX_EXTBUFF_VPP_3DLUT
    :project: oneVPL
 
 .. doxygenenumvalue:: MFX_EXTBUFF_VPP_SCENE_ANALYSIS
@@ -1307,6 +1313,27 @@ VPP scaling filter.
    :project: oneVPL
 
 .. doxygenenumvalue:: MFX_INTERPOLATION_ADVANCED
+   :project: oneVPL
+
+--------
+DataType
+--------
+
+.. doxygenenum:: mfxDataType
+   :project: oneVPL
+
+-------------------
+3DLutChannelMapping
+-------------------
+
+.. doxygenenum:: mfx3DLutChannelMapping
+   :project: oneVPL
+
+-----------------
+3DLutMemoryLayout
+-----------------
+
+.. doxygenenum:: mfx3DLutMemoryLayout
    :project: oneVPL
 
 -------------------------------------
@@ -2263,4 +2290,11 @@ The FilmGrainFlags enumerator itemizes flags in AV1 film grain parameters.
    :project: oneVPL
    
 .. doxygenenumvalue:: MFX_FILM_GRAIN_CLIP_TO_RESTRICTED_RANGE
+   :project: oneVPL
+
+------------
+mfxHyperMode
+------------
+
+.. doxygenenum:: mfxHyperMode
    :project: oneVPL

--- a/source/elements/oneVPL/source/API_ref/VPL_structs_cross_component.rst
+++ b/source/elements/oneVPL/source/API_ref/VPL_structs_cross_component.rst
@@ -275,3 +275,12 @@ mfxExtHyperModeParam
    :project: oneVPL
    :members:
    :protected-members:
+
+mfxGUID
+-------
+
+.. doxygenstruct:: mfxGUID
+   :project: oneVPL
+   :members:
+   :protected-members:
+

--- a/source/elements/oneVPL/source/API_ref/VPL_structs_encode.rst
+++ b/source/elements/oneVPL/source/API_ref/VPL_structs_encode.rst
@@ -159,7 +159,6 @@ mfxExtCodingOption3
    :project: oneVPL
    :members:
    :protected-members:
-   :undoc-members:
 
 mfxExtCodingOptionSPSPPS
 ------------------------

--- a/source/elements/oneVPL/source/API_ref/VPL_structs_vpp.rst
+++ b/source/elements/oneVPL/source/API_ref/VPL_structs_vpp.rst
@@ -208,6 +208,38 @@ mfxExtVPPScaling
    :members:
    :protected-members:
 
+mfxChannel
+----------
+
+.. doxygenstruct:: mfxChannel
+   :project: oneVPL
+   :members:
+   :protected-members:
+
+mfx3DLutSystemBuffer
+--------------------
+
+.. doxygenstruct:: mfx3DLutSystemBuffer
+   :project: oneVPL
+   :members:
+   :protected-members:
+
+mfx3DLutVideoBuffer
+-------------------
+
+.. doxygenstruct:: mfx3DLutVideoBuffer
+   :project: oneVPL
+   :members:
+   :protected-members:
+
+mfxExtVPP3DLut
+--------------
+
+.. doxygenstruct:: mfxExtVPP3DLut
+   :project: oneVPL
+   :members:
+   :protected-members:
+
 mfxExtVPPVideoSignalInfo
 ------------------------
 

--- a/source/elements/oneVPL/source/VPL_change_log.rst
+++ b/source/elements/oneVPL/source/VPL_change_log.rst
@@ -13,6 +13,18 @@ This section describes the API evolution from version to version.
    :depth: 1
 
 -----------
+Version 2.4
+-----------
+
+* Added ability to retrieve path to the shared library with the implementation.
+* Added 3DLUT (Three-Dimensional Look Up Table) filter in VPP.
+* Added mfxGUID structure to specify Globally Unique Identifiers (GUIDs).
+* Added QueryInterface function to mfxFrameSurfaceInterface.
+* Added AdaptiveRef and alias for ExtBrcAdaptiveLTR.
+* Added MFX_FOURCC_BGRP FourCC for Planar BGR format.
+* Enviromental variables to control dispatcher's logger.
+
+-----------
 Version 2.3
 -----------
 

--- a/source/elements/oneVPL/source/appendix/VPL_apnds_e.rst
+++ b/source/elements/oneVPL/source/appendix/VPL_apnds_e.rst
@@ -14,27 +14,20 @@ This section describes basic memory management and synchronization techniques.
 To create the VA surface pool, the application should call the vaCreateSurfaces
 function:
 
-.. code-block:: c++
+.. literalinclude:: ../snippets/appnd_e.c
+   :language: c++
+   :start-after: /*beg1*/
+   :end-before: /*end1*/
    :lineno-start: 1
-
-   VASurfaceAttrib attrib;
-   attrib.type = VASurfaceAttribPixelFormat;
-   attrib.value.type = VAGenericValueTypeInteger;
-   attrib.value.value.i = VA_FOURCC_NV12;
-   attrib.flags = VA_SURFACE_ATTRIB_SETTABLE;
-
-   #define NUM_SURFACES 5;
-   VASurfaceID surfaces[NUMSURFACES];
-
-   vaCreateSurfaces(va_display, VA_RT_FORMAT_YUV420, width, height, surfaces, NUM_SURFACES, &attrib, 1);
 
 To destroy the surface pool, the application should call the vaDestroySurfaces
 function:
 
-.. code-block:: c++
+.. literalinclude:: ../snippets/appnd_e.c
+   :language: c++
+   :start-after: /*beg2*/
+   :end-before: /*end2*/
    :lineno-start: 1
-
-   vaDestroySurfaces(va_display, surfaces, NUM_SURFACES);
 
 If the application works with hardware acceleration through |msdk_full_name|, then it can
 access surface data immediately after successful completion of
@@ -55,59 +48,31 @@ plain in a mapped buffer and the VAImage.pitches[3] array holds color plain
 pitches in bytes. For packed data formats, only first entries in these
 arrays are valid. The following example shows how to access data in a NV12 surface:
 
-.. code-block:: c++
+.. literalinclude:: ../snippets/appnd_e.c
+   :language: c++
+   :start-after: /*beg3*/
+   :end-before: /*end3*/
    :lineno-start: 1
-
-   VAImage image;
-   unsigned char *buffer, Y, U, V;
-
-   vaDeriveImage(va_display, surface_id, &image);
-   vaMapBuffer(va_display, image.buf, &buffer);
-
-   /* NV12 */
-   Y = buffer + image.offsets[0];
-   U = buffer + image.offsets[1];
-   V = U + 1;
 
 
 After processing data in a VA surface, the application should release resources
 allocated for the mapped buffer and VAImage object:
 
-.. code-block:: c++
+.. literalinclude:: ../snippets/appnd_e.c
+   :language: c++
+   :start-after: /*beg4*/
+   :end-before: /*end4*/
    :lineno-start: 1
-
-   vaUnmapBuffer(va_display, image.buf);
-   vaDestroyImage(va_display, image.image_id);
 
 In some cases, in order to retrieve encoded bitstream data from video memory,
 the application must use the VABuffer to store data. The following example shows
 how to create, use, and destroy the VABuffer:
 
-.. code-block:: c++
+.. literalinclude:: ../snippets/appnd_e.c
+   :language: c++
+   :start-after: /*beg5*/
+   :end-before: /*end5*/
    :lineno-start: 1
-
-   /* create buffer */
-   VABufferID buf_id;
-   vaCreateBuffer(va_display, va_context, VAEncCodedBufferType, buf_size, 1, NULL, & buf_id);
-
-   /* encode frame */
-   // ...
-
-   /* map buffer */
-   VACodedBufferSegment *coded_buffer_segment;
-
-   vaMapBuffer(va_display, buf_id, (void **)(& coded_buffer_segment));
-
-   size   = coded_buffer_segment->size;
-   offset = coded_buffer_segment->bit_offset;
-   buf    = coded_buffer_segment->buf;
-
-   /* retrieve encoded data*/
-   // ...
-
-   /* unmap and destroy buffer */
-   vaUnmapBuffer(va_display, buf_id);
-   vaDestroyBuffer(va_display, buf_id);
 
 Note that the vaMapBuffer function returns pointers to different objects
 depending on the mapped buffer type. The VAImage is a plain data buffer and the

--- a/source/elements/oneVPL/source/index.rst
+++ b/source/elements/oneVPL/source/index.rst
@@ -18,7 +18,9 @@ changes.
 
 .. rubric:: oneVPL Specification Version
 
-Latest oneVPL specification version is |vpl_version|. 
+This document contains oneVPL specification version of |vpl_version|.
+
+Latest published version of oneVPL specification: `<https://spec.oneapi.com/onevpl/latest/index.html>`__.
 
 .. toctree::
    :titlesonly:

--- a/source/elements/oneVPL/source/programming_guide/VPL_prg_decoding.rst
+++ b/source/elements/oneVPL/source/programming_guide/VPL_prg_decoding.rst
@@ -20,8 +20,8 @@ the internal allocation mechanism presented here:
 Note the following key points about the example:
 
 - The application calls the :cpp:func:`MFXVideoDECODE_DecodeFrameAsync` function
-  for a decoding operation with the bitstream buffer (bits), frame surface is allocated 
-  internally by the library.
+  for a decoding operation with the bitstream buffer (bits), frame surface is
+  allocated internally by the library.
 
   .. attention:: As shown in the example above starting with API version 2.0, 
                  the application can provide NULL
@@ -31,27 +31,29 @@ Note the following key points about the example:
 - If decoding output is not available, the function returns a status code
   requesting additional bitstream input as follows:
 
-  - :cpp:enumerator:`mfxStatus::MFX_ERR_MORE_DATA`: The function needs additional
-    bitstream input. The existing buffer contains less than a frame's worth of
-    bitstream data.
+  - :cpp:enumerator:`mfxStatus::MFX_ERR_MORE_DATA`: The function needs
+    additional bitstream input. The existing buffer contains less than a frame's
+    worth of bitstream data.
 
 - Upon successful decoding, the :cpp:func:`MFXVideoDECODE_DecodeFrameAsync`
   function returns :cpp:enumerator:`mfxStatus::MFX_ERR_NONE`. However, the
-  decoded frame data (identified by the surface_out pointer) is not yet available
-  because the :cpp:func:`MFXVideoDECODE_DecodeFrameAsync` function is asynchronous.
-  The application must use the :cpp:func:`MFXVideoCORE_SyncOperation` or
-  :cpp:member:`mfxFrameSurfaceInterface::Synchronize`  to synchronize the decoding
-  operation before retrieving the decoded frame data.
+  decoded frame data (identified by the surface_out pointer) is not yet
+  available because the :cpp:func:`MFXVideoDECODE_DecodeFrameAsync` function is
+  asynchronous. The application must use the
+  :cpp:func:`MFXVideoCORE_SyncOperation` or
+  :cpp:member:`mfxFrameSurfaceInterface::Synchronize`  to synchronize the
+  decoding operation before retrieving the decoded frame data.
 
 - At the end of the bitstream, the application continuously calls the
   :cpp:func:`MFXVideoDECODE_DecodeFrameAsync` function with a NULL bitstream
   pointer to drain any remaining frames cached within the decoder until the
   function returns :cpp:enumerator:`mfxStatus::MFX_ERR_MORE_DATA`.
 
-- When application completes the work with frame surface, it must call release to avoid memory leaks.
+- When application completes the work with frame surface, it must call release
+  to avoid memory leaks.
 
-The next example demonstrates how applications can use internally pre-allocated chunk 
-of video surfaces:
+The next example demonstrates how applications can use internally pre-allocated
+chunk of video surfaces:
 
 .. literalinclude:: ../snippets/prg_decoding.c
    :language: c++
@@ -59,17 +61,17 @@ of video surfaces:
    :end-before: /*end2*/
    :lineno-start: 1
 
-Here the application should use the :cpp:func:`MFXVideoDECODE_QueryIOSurf` function to
-obtain the number of working frame surfaces required to reorder output frames.
-It is also required that :cpp:func:`MFXMemory_GetSurfaceForDecode` call is done after 
-decoder initialization. 
-In the :cpp:func:`MFXVideoDECODE_DecodeFrameAsync`
-the oneVPL library increments reference counter of incoming surface frame so it is required
+Here the application should use the :cpp:func:`MFXVideoDECODE_QueryIOSurf`
+function to obtain the number of working frame surfaces required to reorder
+output frames. It is also required that
+:cpp:func:`MFXMemory_GetSurfaceForDecode` call is done after decoder
+initialization. In the :cpp:func:`MFXVideoDECODE_DecodeFrameAsync` the oneVPL
+library increments reference counter of incoming surface frame so it is required
 that the application releases frame surface after the call.  
 
-Another approach to decode frames is to allocate video frames on-fly with help of 
-:cpp:func:`MFXMemory_GetSurfaceForDecode` function, feed the library and release
-working surface after :cpp:func:`MFXVideoDECODE_DecodeFrameAsync` call.
+Another approach to decode frames is to allocate video frames on-fly with help
+of :cpp:func:`MFXMemory_GetSurfaceForDecode` function, feed the library and
+release working surface after :cpp:func:`MFXVideoDECODE_DecodeFrameAsync` call.
 
   .. attention:: Please pay attention on two release calls for surfaces:
                  after :cpp:func:`MFXVideoDECODE_DecodeFrameAsync` to decrease
@@ -86,8 +88,8 @@ working surface after :cpp:func:`MFXVideoDECODE_DecodeFrameAsync` call.
    :lineno-start: 1
 
 
-The following pseudo code shows the decoding procedure according to the legacy mode 
-with external video frames allocation:
+The following pseudo code shows the decoding procedure according to the legacy
+mode with external video frames allocation:
 
 .. literalinclude:: ../snippets/prg_decoding.c
    :language: c++
@@ -103,8 +105,8 @@ Note the following key points about the example:
   is optional if the data is retrievable from other sources such as an
   audio/video splitter.
   
-- The :cpp:func:`MFXVideoDECODE_DecodeFrameAsync` function can return following status
-  codes in addition to the described above:
+- The :cpp:func:`MFXVideoDECODE_DecodeFrameAsync` function can return following
+  status codes in addition to the described above:
   
   - :cpp:enumerator:`mfxStatus::MFX_ERR_MORE_SURFACE`: The function needs one
     more frame surface to produce any output.
@@ -121,15 +123,16 @@ The following pseudo code shows the simplified decoding procedure:
 
 .. _simplified-decoding-procedure:
 
-oneVPL API version 2.0 introduces a new decoding approach. For simple use cases, when
-the user wants to decode a stream and does not want to set additional
+oneVPL API version 2.0 introduces a new decoding approach. For simple use cases,
+when the user wants to decode a stream and does not want to set additional
 parameters, a simplified procedure for the decoder's initialization has been
 proposed. In this scenario it is possible to skip explicit stages of a
 stream's header decoding and the decoder's initialization and instead to perform
 these steps implicitly during decoding of the first frame. This change also 
-requires setting the additional field :cpp:member:`mfxBitstream::CodecId` to indicate 
-codec type. In this mode the decoder allocates :cpp:struct:`mfxFrameSurface1`
-internally, so users should set the input surface to zero.
+requires setting the additional field :cpp:member:`mfxBitstream::CodecId` to
+indicate codec type. In this mode the decoder allocates
+:cpp:struct:`mfxFrameSurface1` internally, so users should set the input surface
+to zero.
 
 -----------------------
 Bitstream Repositioning
@@ -138,7 +141,8 @@ Bitstream Repositioning
 The application can use the following procedure for bitstream reposition during
 decoding:
 
-#. Use the :cpp:func:`MFXVideoDECODE_Reset` function to reset the oneVPL decoder.
+#. Use the :cpp:func:`MFXVideoDECODE_Reset` function to reset the oneVPL
+   decoder.
 #. Optional: If the application maintains a sequence header that correctly
    decodes the bitstream at the new position, the application may insert the
    sequence header to the bitstream buffer.
@@ -161,15 +165,16 @@ bitstream is considered invalid and the decoder tries to re-sync (find the next
 start code). Subsequent decoder behavior is dependent on which syntax element is
 broken:
 
-* SPS header is broken: return :cpp:enumerator:`mfxStatus::MFX_ERR_INCOMPATIBLE_VIDEO_PARAM`
-  (HEVC decoder only, AVC decoder uses last valid).
+* SPS header is broken: return
+  :cpp:enumerator:`mfxStatus::MFX_ERR_INCOMPATIBLE_VIDEO_PARAM` (HEVC decoder
+  only, AVC decoder uses last valid).
 * PPS header is broken: re-sync, use last valid PPS for decoding.
 * Slice header is broken: skip this slice, re-sync.
 * Slice data is broken: corruption flags are set on output surface.
 
-Many streams have IDR frames with ``frame_num != 0`` while the specification says
-that “If the current picture is an IDR picture, frame_num shall be equal to 0”
-(ITU-T H.265 7.4.3).
+Many streams have IDR frames with ``frame_num != 0`` while the specification
+says that “If the current picture is an IDR picture, frame_num shall be equal to
+0” (ITU-T H.265 7.4.3).
 
 VUI is also validated, but errors do not invalidate the whole SPS. The decoder
 either does not use the corrupted VUI (AVC) or resets incorrect values to
@@ -179,24 +184,25 @@ default (HEVC).
           violate the strict standard but can be decoded without errors.
 
 Corruption at the reference frame is spread over all inter-coded pictures that
-use the reference frame for prediction. To cope with this problem you must either
-periodically insert I-frames (intra-coded) or use the intra-refresh technique.
-The intra-refresh technique allows recovery from corruptions within a
+use the reference frame for prediction. To cope with this problem you must
+either periodically insert I-frames (intra-coded) or use the intra-refresh
+technique. The intra-refresh technique allows recovery from corruptions within a
 predefined time interval. The main point of intra-refresh is to insert a cyclic
-intra-coded pattern (usually a row) of macroblocks into the inter-coded pictures,
-restricting motion vectors accordingly. Intra-refresh is often used in combination
-with recovery point SEI, where the ``recovery_frame_cnt`` is derived from the
-intra-refresh interval. The recovery point SEI message is well described at
-ITU-T H.264 D.2.7 and ITU-T H.265 D.2.8. If decoding starts from AU associated
-with this SEI message, then the message can be used by the decoder to determine
-from which picture all subsequent pictures have no errors. In comparison to IDR,
-the recovery point message does not mark reference pictures as "unused for
-reference".
+intra-coded pattern (usually a row) of macroblocks into the inter-coded
+pictures, restricting motion vectors accordingly. Intra-refresh is often used in
+combination with recovery point SEI, where the ``recovery_frame_cnt`` is derived
+from the intra-refresh interval. The recovery point SEI message is well
+described at ITU-T H.264 D.2.7 and ITU-T H.265 D.2.8. If decoding starts from AU
+associated with this SEI message, then the message can be used by the decoder to
+determine from which picture all subsequent pictures have no errors. In
+comparison to IDR, the recovery point message does not mark reference pictures
+as "unused for reference".
 
-Besides validation of syntax elements and their constraints, the decoder also uses
-various hints to handle broken streams:
+Besides validation of syntax elements and their constraints, the decoder also
+uses various hints to handle broken streams:
 
-* If there are no valid slices for the current frame, then the whole frame is skipped.
+* If there are no valid slices for the current frame, then the whole frame is
+  skipped.
 * The slices which violate slice segment header semantics (ITU-T H.265 7.4.7.1)
   are skipped. Only the ``slice_temporal_mvp_enabled_flag`` is checked for now.
 * Since LTR (Long Term Reference) stays at DPB until it is explicitly
@@ -207,11 +213,11 @@ various hints to handle broken streams:
     marks the reference picture as LT, the operation is rolled back.
   * An IDR frame with ``frame_num != 0`` can’t be LTR.
 
-* If the decoder detects frame gapping, it inserts "fake"’" (marked as non-existing)
-  frames, updates FrameNumWrap (ITU-T H.264 8.2.4.1) for reference frames, and
-  applies the Sliding Window (ITU-T H.264 8.2.5.3) marking process. Fake frames
-  are marked as reference, but since they are marked as non-existing, they are
-  not used for inter-prediction.
+* If the decoder detects frame gapping, it inserts "fake"’" (marked as
+  non-existing) frames, updates FrameNumWrap (ITU-T H.264 8.2.4.1) for reference
+  frames, and applies the Sliding Window (ITU-T H.264 8.2.5.3) marking process.
+  Fake frames are marked as reference, but since they are marked as
+  non-existing, they are not used for inter-prediction.
 
 --------------------
 VP8 Specific Details
@@ -226,8 +232,8 @@ difference.
 JPEG
 ----
 
-The application can use the same decoding procedures for JPEG/motion JPEG decoding,
-as shown in the following pseudo code:
+The application can use the same decoding procedures for JPEG/motion JPEG
+decoding, as shown in the following pseudo code:
 
 .. code-block:: c++
 
@@ -253,14 +259,17 @@ conform to the ITU-T Recommendation T.81 with an EXIF or JFIF header. For
 motion JPEG decoding, the input can be any JPEG bitstreams that conform to the
 ITU-T Recommendation T.81.
 
-Unlike other oneVPL decoders, JPEG decoding supports three different output color
-formats: :term:`NV12`, :term:`YUY2`, and :term:`RGB32`. This support sometimes
-requires internal color conversion and more complicated initialization. The color
-format of the input bitstream is described by the
-:cpp:member:`mfxInfoMFX::JPEGChromaFormat` and :cpp:member:`mfxInfoMFX::JPEGColorFormat` fields.. The :cpp:func:`MFXVideoDECODE_DecodeHeader` function usually fills
-them in. If the JPEG bitstream does not contains color format information, the
-application should provide it. Output color format is described by general oneVPL
-parameters: the :cpp:member:`mfxFrameInfo::FourCC` and :cpp:member:`mfxFrameInfo::ChromaFormat` fields.
+Unlike other oneVPL decoders, JPEG decoding supports three different output
+color formats: :term:`NV12`, :term:`YUY2`, and :term:`RGB32`. This support
+sometimes requires internal color conversion and more complicated
+initialization. The color format of the input bitstream is described by the
+:cpp:member:`mfxInfoMFX::JPEGChromaFormat` and
+:cpp:member:`mfxInfoMFX::JPEGColorFormat` fields. The
+:cpp:func:`MFXVideoDECODE_DecodeHeader` function usually fills them in. If the
+JPEG bitstream does not contains color format information, the application
+should provide it. Output color format is described by general oneVPL
+parameters: the :cpp:member:`mfxFrameInfo::FourCC` and
+:cpp:member:`mfxFrameInfo::ChromaFormat` fields.
 
 Motion JPEG supports interlaced content by compressing each field (a half-height
 frame) individually. This behavior is incompatible with the rest of the oneVPL
@@ -269,19 +278,21 @@ of the same frame surface. The decoding procedure is modified as follows:
 
 - The application calls the :cpp:func:`MFXVideoDECODE_DecodeHeader` function
   with the first field JPEG bitstream to retrieve initialization parameters.
-- The application initializes the oneVPL JPEG decoder with the following settings:
+- The application initializes the oneVPL JPEG decoder with the following
+  settings:
 
-  - The ``PicStruct`` field of the :cpp:struct:`mfxVideoParam` structure set to the
-    correct interlaced type, :cpp:enumerator:`MFX_PICSTRUCT_FIELD_TFF` or
+  - The ``PicStruct`` field of the :cpp:struct:`mfxVideoParam` structure set to
+    the correct interlaced type, :cpp:enumerator:`MFX_PICSTRUCT_FIELD_TFF` or
     :cpp:enumerator:`MFX_PICSTRUCT_FIELD_BFF`, from the motion JPEG header.
-  - Double the ``Height`` field in the :cpp:struct:`mfxVideoParam` structure as the
-    value returned by the :cpp:func:`MFXVideoDECODE_DecodeHeader` function
+  - Double the ``Height`` field in the :cpp:struct:`mfxVideoParam` structure as
+    the value returned by the :cpp:func:`MFXVideoDECODE_DecodeHeader` function
     describes only the first field. The actual frame surface should contain both
     fields.
 
 - During decoding, the application sends both fields for decoding in the
-  same :cpp:struct:`mfxBitstream`. The application should also set :cpp:member:`mfxBitstream::DataFlag`
-  to :cpp:enumerator:`MFX_BITSTREAM_COMPLETE_FRAME`. oneVPL decodes both fields
+  same :cpp:struct:`mfxBitstream`. The application should also set
+  :cpp:member:`mfxBitstream::DataFlag` to
+  :cpp:enumerator:`MFX_BITSTREAM_COMPLETE_FRAME`. oneVPL decodes both fields
   and combines them into odd and even lines according to oneVPL convention.
 
 By default, the :cpp:func:`MFXVideoDECODE_DecodeHeader` function returns the
@@ -295,18 +306,18 @@ initialization by attaching :cpp:struct:`mfxExtJPEGQuantTables` and
 structure. In this case, the decoder ignores tables from bitstream and uses
 the tables specified by the application. The application can also retrieve these
 tables by attaching the same buffers to :cpp:struct:`mfxVideoParam` and calling
-:cpp:func:`MFXVideoDECODE_GetVideoParam` or :cpp:func:`MFXVideoDECODE_DecodeHeader`
-functions.
+:cpp:func:`MFXVideoDECODE_GetVideoParam` or
+:cpp:func:`MFXVideoDECODE_DecodeHeader` functions.
 
 -------------------------
 Multi-view Video Decoding
 -------------------------
 
 The oneVPL MVC decoder operates on complete MVC streams that contain all
-view and temporal configurations. The application can configure the oneVPL decoder
-to generate a subset at the decoding output. To do this, the application must
-understand the stream structure and use the stream information to configure the
-decoder for target views.
+view and temporal configurations. The application can configure the oneVPL
+decoder to generate a subset at the decoding output. To do this, the application
+must understand the stream structure and use the stream information to configure
+the decoder for target views.
 
 The decoder initialization procedure is as follows:
 
@@ -322,29 +333,32 @@ The decoder initialization procedure is as follows:
       function parses the bitstream and returns
       :cpp:enumerator:`mfxStatus::MFX_ERR_NOT_ENOUGH_BUFFER` with the correct
       values for ``NumView``, ``NumViewId``, and ``NumOP``. This step can be
-      skipped if the application is able to obtain the ``NumView``, ``NumViewId``,
-      and ``NumOP`` values from other sources.
+      skipped if the application is able to obtain the ``NumView``,
+      ``NumViewId``, and ``NumOP`` values from other sources.
    #. The application allocates memory for the ``View``, ``ViewId``, and ``OP``
-      arrays and calls the :cpp:func:`MFXVideoDECODE_DecodeHeader` function again.
-      The function returns the MVC structural information in the allocated arrays.
+      arrays and calls the :cpp:func:`MFXVideoDECODE_DecodeHeader` function
+      again. The function returns the MVC structural information in the
+      allocated arrays.
 
 #. The application fills the :cpp:struct:`mfxExtMVCTargetViews` structure to
    choose the target views, based on information described in the
    :cpp:struct:`mfxExtMVCSeqDesc` structure.
 #. The application initializes the oneVPL decoder using the
-   :cpp:func:`MFXVideoDECODE_Init` function. The application must attach both the
-   :cpp:struct:`mfxExtMVCSeqDesc` structure and the :cpp:struct:`mfxExtMVCTargetViews`
-   structure to the :cpp:struct:`mfxVideoParam` structure.
+   :cpp:func:`MFXVideoDECODE_Init` function. The application must attach both
+   the :cpp:struct:`mfxExtMVCSeqDesc` structure and the
+   :cpp:struct:`mfxExtMVCTargetViews` structure to the
+   :cpp:struct:`mfxVideoParam` structure.
 
-In the above steps, do not modify the values of the :cpp:struct:`mfxExtMVCSeqDesc`
-structure after the :cpp:func:`MFXVideoDECODE_DecodeHeader` function, as the oneVPL
-decoder uses the values in the structure for internal memory allocation. Once the
-application configures the oneVPL decoder, the rest of the decoding procedure remains
+In the above steps, do not modify the values of the
+:cpp:struct:`mfxExtMVCSeqDesc` structure after the
+:cpp:func:`MFXVideoDECODE_DecodeHeader` function, as the oneVPL decoder uses the
+values in the structure for internal memory allocation. Once the application
+configures the oneVPL decoder, the rest of the decoding procedure remains
 unchanged. As shown in the pseudo code below, the application calls the
-:cpp:func:`MFXVideoDECODE_DecodeFrameAsync` function multiple times to obtain all
-target views of the current frame picture, one target view at a time. The target
-view is identified by the ``FrameID`` field of the :cpp:struct:`mfxFrameInfo`
-structure.
+:cpp:func:`MFXVideoDECODE_DecodeFrameAsync` function multiple times to obtain
+all target views of the current frame picture, one target view at a time. The
+target view is identified by the ``FrameID`` field of the
+:cpp:struct:`mfxFrameInfo` structure.
 
 .. literalinclude:: ../snippets/prg_decoding.c
    :language: c++
@@ -356,10 +370,11 @@ structure.
 Combined Decode with Multi-channel Video Processing
 ---------------------------------------------------
 
-The oneVPL exposes interface for making decode and video processing operations in one call.
-Users can specify a number of output processing channels and multiple video filters per each channel.
-This interface supports only internal memory allocation model and returns array of processed frames
-through :cpp:struct:`mfxSurfaceArray` reference object as shown by the example:
+The oneVPL exposes interface for making decode and video processing operations
+in one call. Users can specify a number of output processing channels and
+multiple video filters per each channel. This interface supports only internal
+memory allocation model and returns array of processed frames through
+:cpp:struct:`mfxSurfaceArray` reference object as shown by the example:
 
 .. literalinclude:: ../snippets/prg_decoding_vpp.c
    :language: c++
@@ -367,7 +382,8 @@ through :cpp:struct:`mfxSurfaceArray` reference object as shown by the example:
    :end-before: /*end1*/
    :lineno-start: 1
 
-It's possible that different video processing channels may have diffrent latency:
+It's possible that different video processing channels may have diffrent
+latency:
 
 .. literalinclude:: ../snippets/prg_decoding_vpp.c
    :language: c++
@@ -375,10 +391,25 @@ It's possible that different video processing channels may have diffrent latency
    :end-before: /*end2*/
    :lineno-start: 1
 
-Application can match decoded frame w/ specific VPP channels using :cpp:member:`mfxFrameData::TimeStamp`, :cpp:member:mfxFrameData::FrameOrder` and :cpp:member:`mfxFrameInfo::ChannelId`.
+Application can match decoded frame w/ specific VPP channels using
+:cpp:member:`mfxFrameData::TimeStamp`, :cpp:member:mfxFrameData::FrameOrder` and
+:cpp:member:`mfxFrameInfo::ChannelId`.
 
-Application can skip some or all channels including decoding output with help of `skip_channels` and `num_skip_channels` parameters as follows: application fills `skip_channels` array with `ChannelId`s to disable output of correspondent channels. In that case  :cpp:member:`surf_array_out` would contain only surfaces for the remaining channels. If the decoder's channel and/or impacted VPP channels don't have output frame(s) for the current call (for instance, input bitstream doesn't contain complete frame or deinterlacing/FRC filter have delay) `skip_channels` parameter is ignored for this channel. 
-If application disables all channels the SDK returns NULL as  :cpp:struct:`mfxSurfaceArray`. 
-If application doesn't need to disable any channels it sets `num_skip_channels` to zero, `skip_channels` is ignored when `num_skip_channels` is zero.
+Application can skip some or all channels including decoding output with help of
+`skip_channels` and `num_skip_channels` parameters as follows: application fills
+`skip_channels` array with `ChannelId`s to disable output of correspondent
+channels. In that case  :cpp:member:`surf_array_out` would contain only surfaces
+for the remaining channels. If the decoder's channel and/or impacted VPP
+channels don't have output frame(s) for the current call (for instance, input
+bitstream doesn't contain complete frame or deinterlacing/FRC filter have delay)
+`skip_channels` parameter is ignored for this channel. 
 
-.. note:: Even if more than one input compressed frame is consumed, the :cpp:func:`MFXVideoDECODE_VPP_DecodeFrameAsync` produces only           one decoded frame and correspondent frames from VPP channels.
+If application disables all channels the SDK returns NULL as
+:cpp:struct:`mfxSurfaceArray`.
+
+If application doesn't need to disable any channels it sets `num_skip_channels`
+to zero, `skip_channels` is ignored when `num_skip_channels` is zero.
+
+.. note:: Even if more than one input compressed frame is consumed, the
+  :cpp:func:`MFXVideoDECODE_VPP_DecodeFrameAsync` produces only one decoded
+  frame and correspondent frames from VPP channels.

--- a/source/elements/oneVPL/source/programming_guide/VPL_prg_encoding.rst
+++ b/source/elements/oneVPL/source/programming_guide/VPL_prg_encoding.rst
@@ -30,8 +30,8 @@ Note the following key points about the example:
 - The application calls the :cpp:func:`MFXVideoENCODE_EncodeFrameAsync` function
   for the encoding operation. The input frame must be in an unlocked frame
   surface from the frame surface pool. If the encoding output is not available,
-  the function returns the :cpp:enumerator:`mfxStatus::MFX_ERR_MORE_DATA` status code
-  to request additional input frames.
+  the function returns the :cpp:enumerator:`mfxStatus::MFX_ERR_MORE_DATA` status
+  code to request additional input frames.
 - Upon successful encoding, the :cpp:func:`MFXVideoENCODE_EncodeFrameAsync`
   function returns :cpp:enumerator:`mfxStatus::MFX_ERR_NONE`. At this point, the
   encoded bitstream is not yet available because the
@@ -44,9 +44,9 @@ Note the following key points about the example:
   until the function returns :cpp:enumerator:`mfxStatus::MFX_ERR_MORE_DATA`.
 
 .. note:: It is the application's responsibility to fill pixels outside of the
-          crop window when it is smaller than the frame to be encoded, especially
-          in cases when crops are not aligned to minimum coding block size (16
-          for AVC and 8 for HEVC and VP9).
+          crop window when it is smaller than the frame to be encoded,
+          especially in cases when crops are not aligned to minimum coding block
+          size (16 for AVC and 8 for HEVC and VP9).
 
 ---------------
 Internal Memory
@@ -63,9 +63,9 @@ The following pseudo code shows the encoding procedure with internal memory:
 There are several key differences in this example, compared to external memory
 (legacy mode):
 
-- The application does not need to call the :cpp:func:`MFXVideoENCODE_QueryIOSurf`
-  function to obtain the number of working frame surfaces since allocation is
-  done by oneVPL.
+- The application does not need to call the
+  :cpp:func:`MFXVideoENCODE_QueryIOSurf` function to obtain the number of
+  working frame surfaces since allocation is done by oneVPL.
 - The application calls the :cpp:func:`MFXMemory_GetSurfaceForEncode` function
   to get a free surface for the subsequent encode operation.
 - The application must call the
@@ -88,20 +88,22 @@ new sequence, it completely resets internal state and begins a new sequence with
 the IDR frame.
 
 The application controls encoder behavior during parameter change by attaching
-the :cpp:struct:`mfxExtEncoderResetOption` structure to the :cpp:struct:`mfxVideoParam`
-structure during reset. By using this structure, the application instructs the
-encoder to start or not start a new sequence after reset. In some cases, the
-request to continue the current sequence cannot be satisfied and the encoder will
-fail during reset. To avoid this scenario, the application may query the reset
-outcome before the actual reset by calling the :cpp:func:`MFXVideoENCODE_Query` function
-with the :cpp:struct:`mfxExtEncoderResetOption` attached to the
+the :cpp:struct:`mfxExtEncoderResetOption` structure to the
+:cpp:struct:`mfxVideoParam` structure during reset. By using this structure, the
+application instructs the encoder to start or not start a new sequence after
+reset. In some cases, the request to continue the current sequence cannot be
+satisfied and the encoder will fail during reset. To avoid this scenario, the
+application may query the reset outcome before the actual reset by calling the
+:cpp:func:`MFXVideoENCODE_Query` function with the
+:cpp:struct:`mfxExtEncoderResetOption` attached to the
 :cpp:struct:`mfxVideoParam` structure.
 
 The application uses the following procedure to change encoding configurations:
 
-#. The application retrieves any cached frames in the oneVPL encoder by calling the
-   :cpp:func:`MFXVideoENCODE_EncodeFrameAsync` function with a NULL input frame
-   pointer until the function returns :cpp:enumerator:`mfxStatus::MFX_ERR_MORE_DATA`.
+#. The application retrieves any cached frames in the oneVPL encoder by calling
+   the :cpp:func:`MFXVideoENCODE_EncodeFrameAsync` function with a NULL input
+   frame pointer until the function returns
+   :cpp:enumerator:`mfxStatus::MFX_ERR_MORE_DATA`.
 
 #. The application calls the :cpp:func:`MFXVideoENCODE_Reset` function with the
    new configuration:
@@ -119,11 +121,11 @@ External Bitrate Control
 
 The application can make the encoder use the external Bitrate Control (BRC)
 instead of the native bitrate control. To make the encoder use the external BRC,
-the application should attach the :cpp:struct:`mfxExtCodingOption2` structure with
-``ExtBRC = MFX_CODINGOPTION_ON`` and the :cpp:struct:`mfxExtBRC` callback structure
-to the :cpp:struct:`mfxVideoParam` structure during encoder initialization.
-The **Init**, **Reset**, and **Close** callbacks will be invoked inside their
-corresponding functions: :cpp:func:`MFXVideoENCODE_Init`,
+the application should attach the :cpp:struct:`mfxExtCodingOption2` structure
+with ``ExtBRC = MFX_CODINGOPTION_ON`` and the :cpp:struct:`mfxExtBRC` callback
+structure to the :cpp:struct:`mfxVideoParam` structure during encoder
+initialization. The **Init**, **Reset**, and **Close** callbacks will be invoked
+inside their corresponding functions: :cpp:func:`MFXVideoENCODE_Init`,
 :cpp:func:`MFXVideoENCODE_Reset`, and :cpp:func:`MFXVideoENCODE_Close`. The
 following figure shows asynchronous encoding flow with external BRC (using
 ``GetFrameCtrl`` and ``Update``):
@@ -133,8 +135,9 @@ following figure shows asynchronous encoding flow with external BRC (using
 
    Asynchronous encoding flow with external BRC
 
-.. note:: ``IntAsyncDepth`` is the oneVPL max internal asynchronous encoding queue
-   size. It is always less than or equal to :cpp:member:`mfxVideoParam::AsyncDepth`.
+.. note:: ``IntAsyncDepth`` is the oneVPL max internal asynchronous encoding
+   queue size. It is always less than or equal to
+   :cpp:member:`mfxVideoParam::AsyncDepth`.
 
 The following pseudo code shows use of the external BRC:
 
@@ -164,35 +167,38 @@ encoding, as shown in the following pseudo code:
 The application may specify Huffman and quantization tables during encoder
 initialization by attaching :cpp:struct:`mfxExtJPEGQuantTables` and
 :cpp:struct:`mfxExtJPEGHuffmanTables` buffers to the :cpp:struct:`mfxVideoParam`
-structure. If the application does not define tables, then the oneVPL encoder uses
-tables recommended in ITU-T\* Recommendation T.81. If the application does not
-define a quantization table it must specify the :cpp:member:`mfxInfoMFX::Quality`
-parameter. In this case, the oneVPL encoder scales the default quantization table
-according to the specified :cpp:member:`mfxInfoMFX::Quality` parameter value.
+structure. If the application does not define tables, then the oneVPL encoder
+uses tables recommended in ITU-T\* Recommendation T.81. If the application does
+not define a quantization table it must specify the
+:cpp:member:`mfxInfoMFX::Quality` parameter. In this case, the oneVPL encoder
+scales the default quantization table according to the specified
+:cpp:member:`mfxInfoMFX::Quality` parameter value.
 
 The application should properly configure chroma sampling format and color
 format using the :cpp:member:`mfxFrameInfo::FourCC` and
 :cpp:member:`mfxFrameInfo::ChromaFormat` fields. For example, to encode a 4:2:2
 vertically sampled YCbCr picture, the application should set
 :cpp:member:`mfxFrameInfo::FourCC` to :cpp:enumerator:`MFX_FOURCC_YUY2` and
-:cpp:member:`mfxFrameInfo::ChromaFormat` to :cpp:enumerator:`MFX_CHROMAFORMAT_YUV422V`.
-To encode a 4:4:4 sampled RGB picture, the application should set
-:cpp:member:`mfxFrameInfo::FourCC` to :cpp:enumerator:`MFX_FOURCC_RGB4` and
-:cpp:member:`mfxFrameInfo::ChromaFormat` to :cpp:enumerator:`MFX_CHROMAFORMAT_YUV444`.
+:cpp:member:`mfxFrameInfo::ChromaFormat` to
+:cpp:enumerator:`MFX_CHROMAFORMAT_YUV422V`. To encode a 4:4:4 sampled RGB
+picture, the application should set :cpp:member:`mfxFrameInfo::FourCC` to
+:cpp:enumerator:`MFX_FOURCC_RGB4` and :cpp:member:`mfxFrameInfo::ChromaFormat`
+to :cpp:enumerator:`MFX_CHROMAFORMAT_YUV444`.
 
-The oneVPL encoder supports different sets of chroma sampling and color formats on
-different platforms. The application must call the :cpp:func:`MFXVideoENCODE_Query`
-function to check if the required color format is supported on a given platform
-and then initialize the encoder with proper values of :cpp:member:`mfxFrameInfo::FourCC`
-and :cpp:member:`mfxFrameInfo::ChromaFormat`.
+The oneVPL encoder supports different sets of chroma sampling and color formats
+on different platforms. The application must call the
+:cpp:func:`MFXVideoENCODE_Query` function to check if the required color format
+is supported on a given platform and then initialize the encoder with proper
+values of :cpp:member:`mfxFrameInfo::FourCC` and
+:cpp:member:`mfxFrameInfo::ChromaFormat`.
 
 The application should not define the number of scans and number of components.
 These numbers are derived by the oneVPL encoder from the
 :cpp:member:`mfxInfoMFx::Interleaved` flag and from chroma type. If interleaved
-coding is specified, then one scan is encoded that contains all image components.
-Otherwise, the number of scans is equal to number of components. The encoder
-uses the following component IDs:
-“1” for luma (Y), “2” for chroma Cb (U), and “3” for chroma Cr (V).
+coding is specified, then one scan is encoded that contains all image
+components. Otherwise, the number of scans is equal to number of components.
+The encoder uses the following component IDs: “1” for luma (Y), “2” for chroma
+Cb (U), and “3” for chroma Cr (V).
 
 The application should allocate a buffer that is big enough to hold the encoded
 picture. A rough upper limit may be calculated using the following equation
@@ -214,43 +220,44 @@ Multi-view Video Encoding
 Similar to the decoding and video processing initialization procedures, the
 application attaches the :cpp:struct:`mfxExtMVCSeqDesc` structure to the
 :cpp:struct:`mfxVideoParam` structure for encoding initialization. The
-:cpp:struct:`mfxExtMVCSeqDesc` structure configures the oneVPL MVC encoder to work
-in three modes:
+:cpp:struct:`mfxExtMVCSeqDesc` structure configures the oneVPL MVC encoder to
+work in three modes:
 
 - **Default dependency mode:** The application specifies
-  :cpp:member:`mfxExtMVCSeqDesc::NumView` and all other fields to zero. The oneVPL
-  encoder creates a single operation point with all views (view identifier 0 :
-  NumView-1) as target views. The first view (view identifier 0) is the base view.
-  Other views depend on the base view.
+  :cpp:member:`mfxExtMVCSeqDesc::NumView` and all other fields to zero. The
+  oneVPL encoder creates a single operation point with all views (view
+  identifier 0 : NumView-1) as target views. The first view (view identifier 0)
+  is the base view. Other views depend on the base view.
 
 - **Explicit dependency mode:** The application specifies
-  :cpp:member:`mfxExtMVCSeqDesc::NumView` and the view dependency array, and sets
-  all other fields to zero. The oneVPL encoder creates a single operation point with
-  all views (view identifier View[0 : NumView-1].ViewId) as target views. The
-  first view (view identifier View[0].ViewId) is the base view. View dependencies
-  are defined as :cpp:struct:`mfxMVCViewDependency` structures.
+  :cpp:member:`mfxExtMVCSeqDesc::NumView` and the view dependency array, and
+  sets all other fields to zero. The oneVPL encoder creates a single operation
+  point with all views (view identifier View[0 : NumView-1].ViewId) as target
+  views. The first view (view identifier View[0].ViewId) is the base view. View
+  dependencies are defined as :cpp:struct:`mfxMVCViewDependency` structures.
 
 - **Complete mode:** The application fully specifies the views and their
-  dependencies. The oneVPL encoder generates a bitstream with corresponding stream
-  structures.
+  dependencies. The oneVPL encoder generates a bitstream with corresponding
+  stream structures.
 
-During encoding, the oneVPL encoding function :cpp:func:`MFXVideoENCODE_EncodeFrameAsync`
-accumulates input frames until encoding of a picture is possible. The function
-returns :cpp:enumerator:`mfxStatus::MFX_ERR_MORE_DATA` for more data at input or
-:cpp:enumerator:`mfxStatus::MFX_ERR_NONE` if it successfully accumulated enough data for
-encoding a picture. The generated bitstream contains the complete picture
-(multiple views). The application can change this behavior and instruct the
-encoder to output each view in a separate bitstream buffer. To do so, the
+During encoding, the oneVPL encoding function
+:cpp:func:`MFXVideoENCODE_EncodeFrameAsync` accumulates input frames until
+encoding of a picture is possible. The function returns
+:cpp:enumerator:`mfxStatus::MFX_ERR_MORE_DATA` for more data at input or
+:cpp:enumerator:`mfxStatus::MFX_ERR_NONE` if it successfully accumulated enough
+data for encoding a picture. The generated bitstream contains the complete
+picture (multiple views). The application can change this behavior and instruct
+the encoder to output each view in a separate bitstream buffer. To do so, the
 application must turn on the :cpp:member:`mfxExtCodingOption::ViewOutput` flag.
-In this case, the encoder returns :cpp:enumerator:`mfxStatus::MFX_ERR_MORE_BITSTREAM`
-if it needs more bitstream buffers at output and
-:cpp:enumerator:`mfxStatus::MFX_ERR_NONE` when processing of the
-picture (multiple views) has been finished. It is recommended that the application
-provide a new input frame each time the oneVPL encoder requests a new bitstream buffer.
-The application must submit view data for encoding in the order they are
-described in the :cpp:struct:`mfxExtMVCSeqDesc` structure. Particular view data
-can be submitted for encoding only when all views that it depends upon have
-already been submitted.
+In this case, the encoder returns
+:cpp:enumerator:`mfxStatus::MFX_ERR_MORE_BITSTREAM` if it needs more bitstream
+buffers at output and :cpp:enumerator:`mfxStatus::MFX_ERR_NONE` when processing
+of the picture (multiple views) has been finished. It is recommended that the
+application provide a new input frame each time the oneVPL encoder requests a
+new bitstream buffer. The application must submit view data for encoding in the
+order they are described in the :cpp:struct:`mfxExtMVCSeqDesc` structure.
+Particular view data can be submitted for encoding only when all views that it
+depends upon have already been submitted.
 
 The following pseudo code shows the encoding procedure:
 

--- a/source/elements/oneVPL/source/programming_guide/VPL_prg_session.rst
+++ b/source/elements/oneVPL/source/programming_guide/VPL_prg_session.rst
@@ -229,8 +229,8 @@ left to right from column to column and concatenate strings by using `.` (dot) a
    | :cpp:struct:`mfxImplDescription`      | | mfxImplDescription       | MFX_VARIANT_TYPE_U32 |                           |
    |                                       | | .Impl                    |                      |                           |
    |                                       +----------------------------+----------------------+---------------------------+
-   |                                       | | mfxImplDescription       | MFX_VARIANT_TYPE_U32 |                           |
-   |                                       | | .AccelerationMode        |                      |                           |
+   |                                       | | mfxImplDescription       | MFX_VARIANT_TYPE_U32 | The mode will be used for |
+   |                                       | | .AccelerationMode        |                      | session initilization     |
    |                                       +----------------------------+----------------------+---------------------------+
    |                                       | | mfxImplDescription       | MFX_VARIANT_TYPE_U32 |                           |
    |                                       | | .ApiVersion              |                      |                           |
@@ -254,13 +254,13 @@ left to right from column to column and concatenate strings by using `.` (dot) a
    |                                       | | .Keywords                |                      | null-terminated string.   |
    |                                       +----------------------------+----------------------+---------------------------+
    |                                       | | mfxImplDescription       | MFX_VARIANT_TYPE_U32 |                           |
-   |                                       | | .VendorImplID            |                      |                           |
+   |                                       | | .VendorID                |                      |                           |
    |                                       +----------------------------+----------------------+---------------------------+
    |                                       | | mfxImplDescription       | MFX_VARIANT_TYPE_U32 |                           |
-   |                                       | | .AccelerationMode        |                      |                           |
+   |                                       | | .VendorImplID            |                      |                           |
    |                                       +----------------------------+----------------------+---------------------------+
-   |                                       | | mfxImplDescription       | MFX_VARIANT_TYPE_U16 |                           |
-   |                                       | | .mfxDeviceDescription    |                      |                           |
+   |                                       | | mfxImplDescription       | MFX_VARIANT_TYPE_PTR | Pointer to the            |
+   |                                       | | .mfxDeviceDescription    |                      | null-terminated string.   |
    |                                       | | .device                  |                      |                           |
    |                                       | | .DeviceID                |                      |                           |
    |                                       +----------------------------+----------------------+---------------------------+
@@ -365,43 +365,43 @@ left to right from column to column and concatenate strings by using `.` (dot) a
    |                                       | | .encmemdesc              |                      |                           |
    |                                       | | .ColorFormats            |                      |                           |
    |                                       +----------------------------+----------------------+---------------------------+
-   |                                       | | mfxVPPDescription        | MFX_VARIANT_TYPE_U32 |                           |
-   |                                       | | .mfxDecoderDescription   |                      |                           |
+   |                                       | | mfxImplDescription       | MFX_VARIANT_TYPE_U32 |                           |
+   |                                       | | .mfxVPPDescription       |                      |                           |
    |                                       | | .filter                  |                      |                           |
    |                                       | | .FilterFourCC            |                      |                           |
    |                                       +----------------------------+----------------------+---------------------------+
-   |                                       | | mfxVPPDescription        | MFX_VARIANT_TYPE_U16 |                           |
-   |                                       | | .mfxDecoderDescription   |                      |                           |
+   |                                       | | mfxImplDescription       | MFX_VARIANT_TYPE_U16 |                           |
+   |                                       | | .mfxVPPDescription       |                      |                           |
    |                                       | | .filter                  |                      |                           |
    |                                       | | .MaxDelayInFrames        |                      |                           |
    |                                       +----------------------------+----------------------+---------------------------+
-   |                                       | | mfxVPPDescription        | MFX_VARIANT_TYPE_U32 |                           |
-   |                                       | | .mfxDecoderDescription   |                      |                           |
+   |                                       | | mfxImplDescription       | MFX_VARIANT_TYPE_U32 |                           |
+   |                                       | | .mfxVPPDescription       |                      |                           |
    |                                       | | .filter                  |                      |                           |
    |                                       | | .memdesc                 |                      |                           |
    |                                       | | .MemHandleType           |                      |                           |
    |                                       +----------------------------+----------------------+---------------------------+
-   |                                       | | mfxVPPDescription        | MFX_VARIANT_TYPE_PTR | Pointer to the            |
-   |                                       | | .mfxDecoderDescription   |                      | :cpp:struct:`mfxRange32U` |
+   |                                       | | mfxImplDescription       | MFX_VARIANT_TYPE_PTR | Pointer to the            |
+   |                                       | | .mfxVPPDescription       |                      | :cpp:struct:`mfxRange32U` |
    |                                       | | .filter                  |                      | object                    |
    |                                       | | .memdesc                 |                      |                           |
    |                                       | | .Width                   |                      |                           |
    |                                       +----------------------------+----------------------+---------------------------+
-   |                                       | | mfxVPPDescription        | MFX_VARIANT_TYPE_PTR | Pointer to the            |
-   |                                       | | .mfxDecoderDescription   |                      | :cpp:struct:`mfxRange32U` |
+   |                                       | | mfxImplDescription       | MFX_VARIANT_TYPE_PTR | Pointer to the            |
+   |                                       | | .mfxVPPDescription       |                      | :cpp:struct:`mfxRange32U` |
    |                                       | | .filter                  |                      | object                    |
    |                                       | | .memdesc                 |                      |                           |
    |                                       | | .Height                  |                      |                           |
    |                                       +----------------------------+----------------------+---------------------------+
-   |                                       | | mfxVPPDescription        | MFX_VARIANT_TYPE_U32 |                           |
-   |                                       | | .mfxDecoderDescription   |                      |                           |
+   |                                       | | mfxImplDescription       | MFX_VARIANT_TYPE_U32 |                           |
+   |                                       | | .mfxVPPDescription       |                      |                           |
    |                                       | | .filter                  |                      |                           |
    |                                       | | .memdesc                 |                      |                           |
    |                                       | | .format                  |                      |                           |
    |                                       | | .InFormat                |                      |                           |
    |                                       +----------------------------+----------------------+---------------------------+
-   |                                       | | mfxVPPDescription        | MFX_VARIANT_TYPE_U32 |                           |
-   |                                       | | .mfxDecoderDescription   |                      |                           |
+   |                                       | | mfxImplDescription       | MFX_VARIANT_TYPE_U32 |                           |
+   |                                       | | .mfxVPPDescription       |                      |                           |
    |                                       | | .filter                  |                      |                           |
    |                                       | | .memdesc                 |                      |                           |
    |                                       | | .format                  |                      |                           |
@@ -410,6 +410,12 @@ left to right from column to column and concatenate strings by using `.` (dot) a
    | :cpp:struct:`mfxImplementedFunctions` | | mfxImplementedFunctions  | MFX_VARIANT_TYPE_PTR | Pointer to the buffer     |
    |                                       | | .FunctionsName           |                      | with string               |
    +---------------------------------------+----------------------------+----------------------+---------------------------+
+   | N/A                                   | | DXGIAdapterIndex         | MFX_VARIANT_TYPE_U32 | Adapter index according   |
+   |                                       | |                          |                      | to                        |
+   |                                       | |                          |                      | IDXGIFactory::EnumAdapters|
+   +---------------------------------------+----------------------------+----------------------+---------------------------+
+
+.. important:: DXGIAdapterNum property is available for Windows only and filters only hardware implementations.
 
 Examples of the property name strings:
 
@@ -616,7 +622,59 @@ library. The sequence diagram below demonstrates the approach.
                :cpp:struct:`mfxVPPDescription` when enumerates or creates
                |msdk_full_name| implementation. Once |msdk_full_name| is loaded
                applications have to use legacy approach to query capabilities.
-   
+
+---------------------------
+oneVPL Dispatcher Debug Log
+---------------------------
+
+The debug output of the dispatcher is controlled with the `ONEVPL_DISPATCHER_LOG`
+environment variable. To enable log output, set the `ONEVPL_DISPATCHER_LOG`
+environment variable value equals to "ON".
+
+By default, oneVPL dispatcher prints all log messages to the console.
+To redirect log output to the desired file, set the `ONEVPL_DISPATCHER_LOG_FILE`
+environmental variable with the file name of the log file.
+
+------------------------------
+Examples of Dispathcer's Usage
+------------------------------
+
+This code illustrates simple usage of dispathcer to load first avialable
+library:
+
+.. literalinclude:: ../snippets/prg_disp.c
+   :language: c++
+   :start-after: /*beg1*/
+   :end-before: /*end1*/
+   :lineno-start: 1
+
+This code illustrates simple usage of dispathcer to load first avialable HW
+accelerated library:
+
+.. literalinclude:: ../snippets/prg_disp.c
+   :language: c++
+   :start-after: /*beg2*/
+   :end-before: /*end2*/
+   :lineno-start: 1
+
+This code illustrates how multiple sessions from multiple loaders can be
+created:
+
+.. literalinclude:: ../snippets/prg_disp.c
+   :language: c++
+   :start-after: /*beg3*/
+   :end-before: /*end3*/
+   :lineno-start: 1
+
+This code illustrates how multiple decoders from single loader can be
+created:
+
+.. literalinclude:: ../snippets/prg_disp.c
+   :language: c++
+   :start-after: /*beg4*/
+   :end-before: /*end4*/
+   :lineno-start: 1
+
 ---------------------------------------
 How To Check If Function is Implemented
 ---------------------------------------
@@ -712,12 +770,31 @@ VPP filter.
    * - :cpp:enumerator:`MFX_EXTBUFF_VPP_COLORFILL`
      - ColorFill filter
 
-This code illustrate VPP mirror filter implementation search procedure:
+This code illustrates VPP mirror filter implementation search procedure:
 
 .. literalinclude:: ../snippets/prg_session.cpp
    :language: c++
    :start-after: /*beg4*/
    :end-before: /*end4*/
+   :lineno-start: 1
+
+-------------------------------------------------------------
+How To Get Path to the Shared Library With the Implementation
+-------------------------------------------------------------
+
+Sessions can be created from different implementations, each implementations can
+be located in different shared libraries. To get path of the shared library with
+the implementation from which session can be or was created, application can use
+:cpp:func:`MFXEnumImplementations` and pass :cpp:enumerator:`MFX_IMPLCAPS_IMPLPATH`
+value as the outpt data request.
+
+This code illustrates collection and print out path of implementations's
+shared library:
+
+.. literalinclude:: ../snippets/prg_session.cpp
+   :language: c++
+   :start-after: /*beg5*/
+   :end-before: /*end5*/
    :lineno-start: 1
 
 -----------------------------------------------------------------------------------------------------------

--- a/source/elements/oneVPL/source/programming_guide/VPL_prg_transcoding.rst
+++ b/source/elements/oneVPL/source/programming_guide/VPL_prg_transcoding.rst
@@ -119,8 +119,8 @@ on :cpp:member:`mfxFrameAllocRequest::NumFrameSuggested` values:
 
 .. literalinclude:: ../snippets/prg_transcoding.c
    :language: c++
-   :start-after: /*beg3*/
-   :end-before: /*end3*/
+   :start-after: /*beg2*/
+   :end-before: /*end2*/
    :lineno-start: 1
 
 ------------------------

--- a/source/elements/oneVPL/source/programming_guide/VPL_prg_vpp.rst
+++ b/source/elements/oneVPL/source/programming_guide/VPL_prg_vpp.rst
@@ -109,6 +109,8 @@ list of configurable filters.
      - :cpp:struct:`mfxExtVPPProcAmp`
    * - :cpp:enumerator:`MFX_EXTBUFF_VPP_FIELD_PROCESSING`
      - :cpp:struct:`mfxExtVPPFieldProcessing`
+   * - :cpp:enumerator:`MFX_EXTBUFF_VPP_3DLUT`
+     - :cpp:struct:`mfxExtVPP3DLut`
 
 The following example shows video processing configuration:
 
@@ -206,4 +208,25 @@ function. This is shown in the following pseudo code:
    :language: c++
    :start-after: /*beg3*/
    :end-before: /*end3*/
+   :lineno-start: 1
+
+----------------------
+Video Processing 3DLUT
+----------------------
+
+oneVPL video processing supports 3DLUT with Intel HW specific memory layout. The following pseudo code
+shows how to create a :cpp:enumerator:`MFX_3DLUT_MEMORY_LAYOUT_INTEL_65LUT` 3DLUT surface.
+
+.. literalinclude:: ../snippets/prg_vpp.c
+   :language: c++
+   :start-after: /*beg4*/
+   :end-before: /*end4*/
+   :lineno-start: 1
+   
+The following pseudo code shows how to create a system memory :cpp:struct:`mfx3DLutSystemBuffer` 3DLUT surface.
+
+.. literalinclude:: ../snippets/prg_vpp.c
+   :language: c++
+   :start-after: /*beg5*/
+   :end-before: /*end5*/
    :lineno-start: 1

--- a/source/elements/oneVPL/source/snippets/appnd_b.c
+++ b/source/elements/oneVPL/source/snippets/appnd_b.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 
-/* these macro requires code complilation*/
+/* These macro required for code compilation. */
 #define sps_buffer NULL
 #define sps_buffer_length 0
 #define pps_buffer NULL

--- a/source/elements/oneVPL/source/snippets/appnd_e.c
+++ b/source/elements/oneVPL/source/snippets/appnd_e.c
@@ -1,0 +1,89 @@
+/*############################################################################
+  # Copyright (C) 2021 Intel Corporation
+  #
+  # SPDX-License-Identifier: MIT
+  ############################################################################*/
+  
+#include "va/va.h"
+
+/* These macro required for code compilation. */
+
+/* end of internal stuff */
+
+void appnd_e1(VADisplay va_display, int width, int height) {
+/*beg1*/
+const int num_surfaces = 5;
+VASurfaceID surfaces[num_surfaces];
+VASurfaceAttrib attrib;
+
+attrib.type = VASurfaceAttribPixelFormat;
+attrib.value.type = VAGenericValueTypeInteger;
+attrib.value.value.i = VA_FOURCC_NV12;
+attrib.flags = VA_SURFACE_ATTRIB_SETTABLE;
+
+vaCreateSurfaces(va_display, VA_RT_FORMAT_YUV420, width, height,
+                 surfaces, num_surfaces, &attrib, 1);
+/*end1*/
+
+/*beg2*/
+vaDestroySurfaces(va_display, surfaces, num_surfaces);
+/*end2*/
+}
+
+
+void appnd_e2(VADisplay va_display, VASurfaceID surfaceToMap) {
+/*beg3*/
+VAImage image;
+unsigned char *Y, *U, *V;
+void* buffer;
+
+vaDeriveImage(va_display, surfaceToMap, &image);
+vaMapBuffer(va_display, image.buf, &buffer);
+
+/* NV12 */
+Y = (unsigned char*)buffer + image.offsets[0];
+U = (unsigned char*)buffer + image.offsets[1];
+V = U + 1;
+/*end3*/
+Y = Y;
+V = V;
+/*beg4*/
+vaUnmapBuffer(va_display, image.buf);
+vaDestroyImage(va_display, image.image_id);
+/*end4*/
+}
+
+void appnd_e3(VADisplay va_display, VAContextID va_context, unsigned int buf_size) {
+/*beg5*/
+VABufferID buf_id;
+size_t size;
+uint32_t offset;
+void *buf;
+
+/* create buffer */
+vaCreateBuffer(va_display, va_context, VAEncCodedBufferType, buf_size, 1, NULL, & buf_id);
+
+/* encode frame */
+// ...
+
+/* map buffer */
+VACodedBufferSegment *coded_buffer_segment;
+
+vaMapBuffer(va_display, buf_id, (void **)(&coded_buffer_segment));
+
+size   = coded_buffer_segment->size;
+offset = coded_buffer_segment->bit_offset;
+buf    = coded_buffer_segment->buf;
+
+/* retrieve encoded data*/
+// ...
+
+/* unmap and destroy buffer */
+vaUnmapBuffer(va_display, buf_id);
+vaDestroyBuffer(va_display, buf_id);
+/*end5*/
+
+size = size;
+offset = offset;
+buf = buf;
+}

--- a/source/elements/oneVPL/source/snippets/appnd_f.c
+++ b/source/elements/oneVPL/source/snippets/appnd_f.c
@@ -9,7 +9,7 @@
 #include "mfxdefs.h"
 #include "mfxvideo.h"
 
-/* these macro requires code complilation*/
+/* These macro required for code compilation. */
 mfxSession session;
 #define valid_non_zero_value 1
 #define frame_qp 4

--- a/source/elements/oneVPL/source/snippets/prg_decoding.c
+++ b/source/elements/oneVPL/source/snippets/prg_decoding.c
@@ -11,8 +11,9 @@
 #include "mfxvideo.h"
 #include "mfxmvc.h"
 
-/* these macro requires code complilation*/
-#define INFINITE 0
+/* These macro required for code compilation. */
+#define INFINITE 0x7FFFFFFF
+#define UNUSED_PARAM(x) (void)(x)
 
 mfxSession session;
 mfxBitstream *bitstream, *bits;
@@ -25,6 +26,7 @@ mfxSyncPoint syncp;
 
 static void allocate_pool_of_frame_surfaces(int nFrames)
 {
+    UNUSED_PARAM(nFrames);
     return;
 }
 
@@ -35,21 +37,26 @@ static int end_of_stream()
 
 static void append_more_bitstream(mfxBitstream *bs)
 {
+    UNUSED_PARAM(bs);
     return;
 }
 
 static void find_free_surface_from_the_pool(mfxFrameSurface1 **pool)
 {
+    UNUSED_PARAM(pool);
     return;
 }
 
 static void realloc_surface(mfxFrameSurface1* work, mfxFrameInfo FrameInfo)
 {
+    UNUSED_PARAM(work);
+    UNUSED_PARAM(FrameInfo);
     return;
 }
 
 static void do_something_with_decoded_frame(mfxFrameSurface1* disp)
 {
+    UNUSED_PARAM(disp);
     return;
 }
 
@@ -60,11 +67,13 @@ static void free_pool_of_frame_surfaces()
 
 static void add_surface_to_pool(mfxFrameSurface1* surf)
 {
+    UNUSED_PARAM(surf);
     return;
 }
 
 static void get_next_surface_from_pool(mfxFrameSurface1 **surface)
 {
+    UNUSED_PARAM(surface);
     return;
 }
 /* end of internal stuff */

--- a/source/elements/oneVPL/source/snippets/prg_decoding_vpp.c
+++ b/source/elements/oneVPL/source/snippets/prg_decoding_vpp.c
@@ -10,6 +10,7 @@
 #include "mfxdefs.h"
 #include "mfxvideo.h"
 
+#define UNUSED_PARAM(x) (void)(x)
 
 mfxSession session;
 mfxBitstream *bitstream;
@@ -18,6 +19,10 @@ mfxVideoParam* decode_par;
 mfxVideoChannelParam** vpp_par_array;
 mfxU32 num_channel_par;
 mfxStatus sts;
+
+static void do_smth(mfxFrameSurface1* surf) {
+  UNUSED_PARAM(surf);
+}
 
 static void prg_decoding_vpp1 () {
 /*beg1*/
@@ -34,9 +39,9 @@ sts = MFXVideoDECODE_VPP_Init(session, decode_par, vpp_par_array, num_channel_pa
 sts = MFXVideoDECODE_VPP_DecodeFrameAsync(session, bitstream, NULL, 0, &surf_array_out);
 
 //surf_array_out layout is
-surf_array_out->Surfaces[0]; //The first channel which contains original decoded frames
-surf_array_out->Surfaces[1]; //The second channel contains resized processed frames after decode. 
-surf_array_out->Surfaces[2]; //The third  channel contains color converted frames after decode. 
+do_smth(surf_array_out->Surfaces[0]); //The first channel contains decoded frames.
+do_smth(surf_array_out->Surfaces[1]); //The second channel contains resized frames after decode. 
+do_smth(surf_array_out->Surfaces[2]); //The third channel contains color converted frames after decode. 
 /*end1*/
 }
 
@@ -47,15 +52,15 @@ static void prg_decoding_vpp2 () {
 //1st call
 sts = MFXVideoDECODE_VPP_DecodeFrameAsync(session, bitstream, NULL, 0, &surf_array_out);
 //surf_array_out layout is
-surf_array_out->Surfaces[0]; //decoded frame
-surf_array_out->Surfaces[1]; //resized frame (ChannelId = 1). The first frame from channel wit resize availble 
+do_smth(surf_array_out->Surfaces[0]); //decoded frame
+do_smth(surf_array_out->Surfaces[1]); //resized frame (ChannelId = 1). The first frame from channel with resize avialable 
 // no output from channel with ADI output since it has one frame delay
 
 //2nd call
 sts = MFXVideoDECODE_VPP_DecodeFrameAsync(session, bitstream, NULL, 0, &surf_array_out);
 //surf_array_out layout is
-surf_array_out->Surfaces[0]; //decoded frame
-surf_array_out->Surfaces[1]; //resized frame (ChannelId = 1)
-surf_array_out->Surfaces[2]; //ADI output (ChannelId = 2). The first frame from ADI channel 
+do_smth(surf_array_out->Surfaces[0]); //decoded frame
+do_smth(surf_array_out->Surfaces[1]); //resized frame (ChannelId = 1)
+do_smth(surf_array_out->Surfaces[2]); //ADI output (ChannelId = 2). The first frame from ADI channel 
 /*end2*/
 }

--- a/source/elements/oneVPL/source/snippets/prg_disp.c
+++ b/source/elements/oneVPL/source/snippets/prg_disp.c
@@ -1,0 +1,90 @@
+
+/*############################################################################
+  # Copyright (C) 2021 Intel Corporation
+  #
+  # SPDX-License-Identifier: MIT
+  ############################################################################*/
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "mfx.h"
+
+/* These macro required for code compilation. */
+#define INFINITE 0x7FFFFFFF
+#define UNUSED_PARAM(x) (void)(x)
+
+mfxSession session, sessionSW, sessionHW;
+
+void prg_dispatcher1 () {
+/*beg1*/
+mfxLoader loader = MFXLoad();
+MFXCreateSession(loader,0,&session);
+/*end1*/
+}
+
+void prg_dispatcher2 () {
+/*beg2*/
+mfxLoader loader = MFXLoad();
+mfxConfig cfg = MFXCreateConfig(loader);
+mfxVariant ImplValue;
+ImplValue.Type = MFX_VARIANT_TYPE_U32;
+ImplValue.Data.U32 = MFX_IMPL_TYPE_HARDWARE;
+MFXSetConfigFilterProperty(cfg,(const mfxU8 *)"mfxImplDescription.Impl",ImplValue);
+MFXCreateSession(loader,0,&session);
+/*end2*/
+}
+
+void prg_dispatcher3 () {
+/*beg3*/
+// Create session with software based implementation
+mfxLoader loader1 = MFXLoad();
+mfxConfig cfg1 = MFXCreateConfig(loader1);
+mfxVariant ImplValueSW;
+ImplValueSW.Type = MFX_VARIANT_TYPE_U32;
+ImplValueSW.Data.U32 = MFX_IMPL_TYPE_SOFTWARE;
+MFXSetConfigFilterProperty(cfg1,(const mfxU8 *)"mfxImplDescription.Impl",ImplValueSW);
+MFXCreateSession(loader1,0,&sessionSW);
+
+// Create session with hardware based implementation
+mfxLoader loader2 = MFXLoad();
+mfxConfig cfg2 = MFXCreateConfig(loader2);
+mfxVariant ImplValueHW;
+ImplValueHW.Type = MFX_VARIANT_TYPE_U32;
+ImplValueHW.Data.U32 = MFX_IMPL_TYPE_HARDWARE;
+MFXSetConfigFilterProperty(cfg2,(const mfxU8 *)"mfxImplDescription.Impl",ImplValueHW);
+MFXCreateSession(loader2,0,&sessionHW);
+
+// use both sessionSW and sessionHW
+// ...
+// Close everything
+MFXClose(sessionSW);
+MFXClose(sessionHW);
+MFXUnload(loader1); // cfg1 will be destroyed here.
+MFXUnload(loader2); // cfg2 will be destroyed here.
+/*end3*/
+}
+
+void prg_dispatcher4 () {
+/*beg4*/
+mfxLoader loader = MFXLoad();
+
+// We want to have AVC decoder supported.
+mfxConfig cfg1 = MFXCreateConfig(loader);
+mfxVariant ImplValue;
+ImplValue.Type = MFX_VARIANT_TYPE_U32;
+ImplValue.Data.U32 = MFX_CODEC_AVC;
+MFXSetConfigFilterProperty(cfg1,
+            (const mfxU8 *)"mfxImplDescription.mfxDecoderDescription.decoder.CodecID",ImplValue);
+
+// And we want to have HEVC encoder supported by the same implementation.
+mfxConfig cfg2 = MFXCreateConfig(loader);
+ImplValue.Type = MFX_VARIANT_TYPE_U32;
+ImplValue.Data.U32 = MFX_CODEC_HEVC;
+MFXSetConfigFilterProperty(cfg2,
+            (const mfxU8 *)"mfxImplDescription.mfxEncoderDescription.encoder.CodecID",ImplValue);
+
+// To create single session with both capabilities.
+MFXCreateSession(loader,0,&session);
+/*end4*/
+}

--- a/source/elements/oneVPL/source/snippets/prg_encoding.c
+++ b/source/elements/oneVPL/source/snippets/prg_encoding.c
@@ -13,8 +13,9 @@
 #include "mfxvideo.h"
 #include "mfxmvc.h"
 
-/* these macro requires code complilation*/
-#define INFINITE 0
+/* These macro required for code compilation. */
+#define INFINITE 0x7FFFFFFF
+#define UNUSED_PARAM(x) (void)(x)
 
 mfxVideoParam init_param;
 mfxFrameAllocRequest request;
@@ -26,6 +27,7 @@ mfxSyncPoint syncp;
 
 static void allocate_pool_of_frame_surfaces(int nFrames)
 {
+    UNUSED_PARAM(nFrames);
     return;
 }
 
@@ -36,16 +38,19 @@ static int end_of_stream()
 
 static void find_unlocked_surface_from_the_pool(mfxFrameSurface1 **pool)
 {
+    UNUSED_PARAM(pool);
     return;
 }
 
 static void fill_content_for_encoding(mfxFrameSurface1 *surface)
 {
+    UNUSED_PARAM(surface);
     return;
 }
 
 static void do_something_with_encoded_bits(mfxBitstream *bits)
 {
+    UNUSED_PARAM(bits);
     return;
 }
 
@@ -138,18 +143,22 @@ MFXVideoENCODE_Close(session);
 
    static int IsParametersSupported(mfxVideoParam *par)
    {
+       UNUSED_PARAM(par);
        // do some checks
        return 1;
    }
 
    static int IsResetPossible(MyBrcContext* ctx, mfxVideoParam *par)
    {
+       UNUSED_PARAM(ctx);
+       UNUSED_PARAM(par);
        // do some checks
        return 1;
    }
 
    static MyBrcFrame* GetFrame(MyBrcFrame *frame_queue, mfxU32 frame_queue_size, mfxU32 EncodedOrder)
    {
+       UNUSED_PARAM(EncodedOrder);
        //do some logic
        if(frame_queue_size) return &frame_queue[0];
        return NULL;
@@ -157,46 +166,62 @@ MFXVideoENCODE_Close(session);
 
    static mfxU32 GetFrameCost(mfxU16 FrameType, mfxU16 PyramidLayer)
    {
+       UNUSED_PARAM(FrameType);
+       UNUSED_PARAM(PyramidLayer);
        // calculate cost
        return 1;
    }
 
    static mfxU32 GetMinSize(MyBrcContext *ctx, mfxU32 cost)
    {
+       UNUSED_PARAM(ctx);
+       UNUSED_PARAM(cost);
        // do some logic
        return 1;
    }
 
    static mfxU32 GetMaxSize(MyBrcContext *ctx, mfxU32 cost)
    {
+       UNUSED_PARAM(ctx);
+       UNUSED_PARAM(cost);
        // do some logic
        return 1;
    }
 
    static mfxI32 GetInitQP(MyBrcContext *ctx, mfxU32 MinSize, mfxU32 MaxSize, mfxU32 cost)
    {
+       UNUSED_PARAM(ctx);
+       UNUSED_PARAM(MinSize);
+       UNUSED_PARAM(MaxSize);
+       UNUSED_PARAM(cost);
        // do some logic
        return 1;
    }
 
    static mfxU64 GetTime()
    {
-       mfxU64 wallClock;
+       mfxU64 wallClock = 0xFFFF;
        return wallClock;
    }
 
    static void UpdateBRCState(mfxU32 CodedFrameSize, MyBrcContext *ctx)
    {
+       UNUSED_PARAM(CodedFrameSize);
+       UNUSED_PARAM(ctx);
        return;
    }
 
    static void RemoveFromQueue(MyBrcFrame* frame_queue, mfxU32 frame_queue_size, MyBrcFrame* frame)
    {
+       UNUSED_PARAM(frame_queue);
+       UNUSED_PARAM(frame_queue_size);
+       UNUSED_PARAM(frame);
        return;
    }
 
    static mfxU64 GetMaxFrameEncodingTime(MyBrcContext *ctx)
    {
+       UNUSED_PARAM(ctx);
        return 2;
    }
 
@@ -204,7 +229,7 @@ MFXVideoENCODE_Close(session);
       MyBrcContext* ctx = (MyBrcContext*)pthis;
       mfxI32 QpBdOffset;
       mfxExtCodingOption2* co2;
-      mfxI32 defaultQP;
+      mfxI32 defaultQP = 4;
 
       if (!pthis || !par)
          return MFX_ERR_NULL_PTR;

--- a/source/elements/oneVPL/source/snippets/prg_err.c
+++ b/source/elements/oneVPL/source/snippets/prg_err.c
@@ -11,7 +11,7 @@
 #include "mfxdefs.h"
 #include "mfxvideo.h"
 
-/* these macro requires code complilation*/
+/* These macro required for code compilation. */
 #define INFINITE 0
 
 mfxSession session;
@@ -21,7 +21,11 @@ mfxSyncPoint buffered_syncp, syncp;
 /* end of internal stuff */
 
 static void prg_handle_device_busy (mfxSession session, mfxSyncPoint sp) {
-    sp ? MFXVideoCORE_SyncOperation(session, sp, INFINITE) : sleep(5);
+    if (sp) {
+        MFXVideoCORE_SyncOperation(session, sp, INFINITE);
+    } else {
+        sleep(5);
+    }
 }
 
 

--- a/source/elements/oneVPL/source/snippets/prg_hw.cpp
+++ b/source/elements/oneVPL/source/snippets/prg_hw.cpp
@@ -15,7 +15,7 @@
 #include "mfxadapter.h"
 #include "mfxdispatcher.h"
 
-/* these macro requires code complilation*/
+/* These macro required for code compilation. */
 
 #define MSDK_CHECK_STATUS(X, MSG)                {if ((X) < MFX_ERR_NONE) {printf("%s\n",MSG);}}
 
@@ -36,7 +36,7 @@ MSDK_CHECK_STATUS(sts, "MFXQueryAdaptersNumber failed");
 
 // Allocate memory for response
 std::vector<mfxAdapterInfo> displays_data(num_adapters_available);
-mfxAdaptersInfo adapters = { displays_data.data(), mfxU32(displays_data.size()), 0u };
+mfxAdaptersInfo adapters = { displays_data.data(), mfxU32(displays_data.size()), 0u, {0} };
 
 // Query information about all adapters (mind that first parameter is NULL)
 sts = MFXQueryAdapters(nullptr, &adapters);
@@ -79,8 +79,8 @@ default:
    impl = MFX_IMPL_HARDWARE_ANY;
    break;
 }
-
-// Initialize mfxSession in regular way with obtained implementation
+printf("Choosen implementation: %d\n", impl);
+// Initialize mfxSession in regular way with obtained implementation.
 /*end1*/
 return 0;
 }
@@ -97,10 +97,10 @@ MSDK_CHECK_STATUS(sts, "MFXQueryAdaptersNumber failed");
 
 // Allocate memory for response
 std::vector<mfxAdapterInfo> displays_data(num_adapters_available);
-mfxAdaptersInfo adapters = { displays_data.data(), mfxU32(displays_data.size()), 0u };
+mfxAdaptersInfo adapters = { displays_data.data(), mfxU32(displays_data.size()), 0u, {0} };
 
 // Fill description of Encode workload
-mfxComponentInfo interface_request = { MFX_COMPONENT_ENCODE, Encode_mfxVideoParam };
+mfxComponentInfo interface_request = { MFX_COMPONENT_ENCODE, Encode_mfxVideoParam, {0} };
 
 // Query information about suitable adapters for Encode workload described by Encode_mfxVideoParam
 sts = MFXQueryAdapters(&interface_request, &adapters);
@@ -134,6 +134,8 @@ default:
    impl = MFX_IMPL_HARDWARE_ANY;
    break;
 }
+
+printf("Choosen implementation: %d\n", impl);
 
 // Initialize mfxSession in regular way with obtained implementation
 /*end2*/

--- a/source/elements/oneVPL/source/snippets/prg_mem.c
+++ b/source/elements/oneVPL/source/snippets/prg_mem.c
@@ -5,7 +5,8 @@
 #include "mfxsession.h"
 #include "mfxvideo.h"
 
-/* these macro requires code complilation*/
+/* These macro required for code compilation. */
+#define UNUSED_PARAM(x) (void)(x)
 
 mfxSession session;
 mfxStatus sts;
@@ -17,26 +18,31 @@ mfxResourceType resource_type;
 
 static int isDeviceTypeCompatible(mfxHandleType device_type)
 {
+    UNUSED_PARAM(device_type);
     return 1;
 }
 
 static int isPossibleForMemorySharing(mfxHDL device_handle)
 {
+    UNUSED_PARAM(device_handle);
     return 1;
 }
 
 static int isResourceTypeCompatible(mfxResourceType resource_type)
 {
+    UNUSED_PARAM(resource_type);
     return 1;
 }
 
 static void ProcessNativeMemory(mfxHDL hdl)
 {
+    UNUSED_PARAM(hdl);
     return;
 }
 
 static void ProcessSystemMemory(mfxFrameSurface1 *surf)
 {
+    UNUSED_PARAM(surf);
     return;
 }
 /* end of internal stuff */
@@ -51,6 +57,7 @@ typedef struct {
 } mid_struct;
 
 mfxStatus fa_alloc(mfxHDL pthis, mfxFrameAllocRequest *request, mfxFrameAllocResponse *response) {
+   UNUSED_PARAM(pthis);
    if (!(request->Type&MFX_MEMTYPE_SYSTEM_MEMORY))
       return MFX_ERR_UNSUPPORTED;
    if (request->Info.FourCC!=MFX_FOURCC_NV12)
@@ -67,6 +74,7 @@ mfxStatus fa_alloc(mfxHDL pthis, mfxFrameAllocRequest *request, mfxFrameAllocRes
 }
 
 mfxStatus fa_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr) {
+   UNUSED_PARAM(pthis);
    mid_struct *mmid=(mid_struct *)mid;
    ptr->Pitch=mmid->width;
    ptr->Y=mmid->base;
@@ -76,15 +84,21 @@ mfxStatus fa_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr) {
 }
 
 mfxStatus fa_unlock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr) {
+   UNUSED_PARAM(pthis);
+   UNUSED_PARAM(mid);
    if (ptr) ptr->Y=ptr->U=ptr->V=ptr->A=0;
    return MFX_ERR_NONE;
 }
 
 mfxStatus fa_gethdl(mfxHDL pthis, mfxMemId mid, mfxHDL *handle) {
+   UNUSED_PARAM(pthis);
+   UNUSED_PARAM(mid);
+   UNUSED_PARAM(handle);
    return MFX_ERR_UNSUPPORTED;
 }
 
 mfxStatus fa_free(mfxHDL pthis, mfxFrameAllocResponse *response) {
+   UNUSED_PARAM(pthis);
    for (int i=0;i<response->NumFrameActual;i++) {
       mid_struct *mmid=(mid_struct *)response->mids[i];
       free(mmid->base); free(mmid);
@@ -93,9 +107,9 @@ mfxStatus fa_free(mfxHDL pthis, mfxFrameAllocResponse *response) {
 }
 /*end1*/
 
-static int prg_mem2 () {
+static void prg_mem2 () {
 /*beg2*/
-// lets decode frame and try to access output in a an optimal way.
+// lets decode frame and try to access output in an optimal way.
 sts = MFXVideoDECODE_DecodeFrameAsync(session, NULL, NULL, &outsurface, &syncp);
 if (MFX_ERR_NONE == sts)
 {

--- a/source/elements/oneVPL/source/snippets/prg_session.cpp
+++ b/source/elements/oneVPL/source/snippets/prg_session.cpp
@@ -108,3 +108,31 @@ MFXSetConfigFilterProperty(mirror_flt_config
 MFXCreateSession(loader, 0, &mirror_session_handle);
 /*end4*/
 }
+
+static void prg_session5 () {
+/*beg5*/
+mfxHDL h;
+mfxSession def_session;
+
+loader = mfxLoader();
+
+// Create session from the first avialable implementation.
+// That's why we no any filters need to be set.
+// First avialable implementation has index equal to the 0.
+MFXCreateSession(loader, 0, &def_session);
+
+// Get and print out OS path to the loaded shared library
+// with the implementation. It is absolutely OK to call
+// MFXEnumImplementations after session creation just need to make
+// sure that the same index of implementation is provided to the
+// function call.
+MFXEnumImplementations(loader, 0, MFX_IMPLCAPS_IMPLPATH, &h);
+mfxChar* path = reinterpret_cast<mfxChar*>(h);
+
+// Print out the path
+std::cout << "Loaded shared library: " << path << std::endl;
+
+// Release the memory for the string with path.
+MFXDispReleaseImplDescription(loader, h);
+/*end5*/
+}

--- a/source/elements/oneVPL/source/snippets/prg_transcoding.c
+++ b/source/elements/oneVPL/source/snippets/prg_transcoding.c
@@ -5,17 +5,22 @@
 #include "mfxsession.h"
 #include "mfxvideo.h"
 
-/* these macro requires code complilation*/
+/* These macro required for code compilation. */
 #define INFINITE 0
+#define UNUSED_PARAM(x) (void)(x)
 
 mfxSession session;
 mfxBitstream *bs, *bits2;
 mfxFrameSurface1 *work, *vin, *vout;
 int going_through_vpp=1;
 
+static void allocate_surfaces(mfxU32 num_surfaces) {
+   UNUSED_PARAM(num_surfaces);
+}
+
 /* end of internal stuff */
 
-static int prg_transcoding1 () {
+static void prg_transcoding1 () {
 /*beg1*/
 mfxSyncPoint sp_d, sp_e;
 MFXVideoDECODE_DecodeFrameAsync(session,bs,work,&vin, &sp_d);
@@ -29,8 +34,8 @@ MFXVideoCORE_SyncOperation(session,sp_e,INFINITE);
 /*end1*/
 }
 
-static int prg_transcoding2 () {
-/*beg3*/
+static void prg_transcoding2 () {
+/*beg2*/
 mfxVideoParam init_param_v, init_param_e;
 mfxFrameAllocRequest response_v[2], response_e;
 
@@ -41,8 +46,10 @@ init_param_v.AsyncDepth=async_depth;
 MFXVideoVPP_QueryIOSurf(session, &init_param_v, response_v);
 init_param_e.AsyncDepth=async_depth;
 MFXVideoENCODE_QueryIOSurf(session, &init_param_e, &response_e);
-mfxU32 num_surfaces=    response_v[1].NumFrameSuggested
-         +response_e.NumFrameSuggested
-         -async_depth; /* double counted in ENCODE & VPP */
-/*end3*/
+mfxU32 num_surfaces = response_v[1].NumFrameSuggested
+         + response_e.NumFrameSuggested
+         - async_depth; /* double counted in ENCODE & VPP */
+
+allocate_surfaces(num_surfaces);
+/*end2*/
 }

--- a/source/elements/oneVPL/source/snippets/prg_vpp.c
+++ b/source/elements/oneVPL/source/snippets/prg_vpp.c
@@ -1,4 +1,3 @@
-
 /*############################################################################
   # Copyright (C) 2020 Intel Corporation
   #
@@ -9,12 +8,15 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "va/va.h"
+
 #include "mfxdefs.h"
 #include "mfxvideo.h"
 #include "mfxmvc.h"
 
-/* these macro requires code complilation*/
-#define INFINITE 0
+/* These macro required for code compilation. */
+#define INFINITE 0x7FFFFFFF
+#define UNUSED_PARAM(x) (void)(x)
 
 mfxSession session;
 mfxVideoParam init_param;
@@ -28,26 +30,32 @@ mfxFrameSurface1 *in, *out;
 
 static void allocate_pool_of_surfaces(mfxFrameSurface1 **pool, int nFrames)
 {
+    UNUSED_PARAM(pool);
+    UNUSED_PARAM(nFrames);
     return;
 }
 
 static mfxFrameSurface1* find_unlocked_surface_and_fill_content(mfxFrameSurface1 **pool)
 {
+    UNUSED_PARAM(pool);
     return pool[0];
 }
 
 static mfxFrameSurface1* find_unlocked_surface_from_the_pool(mfxFrameSurface1 **pool)
 {
+    UNUSED_PARAM(pool);
     return pool[0];
 }
 
 static void process_output_frame(mfxFrameSurface1 *surf)
 {
+    UNUSED_PARAM(surf);
     return;
 }
 
 static void fill_content_for_video_processing(mfxFrameSurface1 *surf)
 {
+    UNUSED_PARAM(surf);
     return;
 }
 
@@ -56,8 +64,9 @@ static int end_of_stream()
     return 1;
 }
 
-static void free_pool_of_surfaces()
+static void free_pool_of_surfaces(mfxFrameSurface1 **in_pool)
 {
+    UNUSED_PARAM(in_pool);
     return;
 }
 /* end of internal stuff */
@@ -145,4 +154,79 @@ for (;;) {
 /* close VPP */
 MFXVideoVPP_Close(session);
 /*end3*/
+}
+
+static void prg_vpp4 () {
+/*beg4*/
+VADisplay va_dpy = 0;
+VASurfaceID surface_id = 0;
+
+vaInitialize(va_dpy, NULL, NULL);
+
+// MFX_3DLUT_MEMORY_LAYOUT_INTEL_65LUT indicate 65*65*128*8bytes.
+mfxU32 seg_size = 65, mul_size = 128;
+mfxMemId memId = 0;
+
+// create 3DLUT surface (MFX_3DLUT_MEMORY_LAYOUT_INTEL_65LUT)
+VASurfaceAttrib    surface_attrib = {};
+surface_attrib.type =  VASurfaceAttribPixelFormat;
+surface_attrib.flags = VA_SURFACE_ATTRIB_SETTABLE;
+surface_attrib.value.type = VAGenericValueTypeInteger;
+surface_attrib.value.value.i = VA_FOURCC_RGBA;
+
+vaCreateSurfaces(va_dpy,
+                 VA_RT_FORMAT_RGB32,   // 4 bytes
+                 seg_size * mul_size,  // 65*128
+                 seg_size * 2,         // 65*2
+                 &surface_id,
+                 1,
+                 &surface_attrib,
+                 1);
+
+*((VASurfaceID*)memId) = surface_id;
+
+// configure 3DLUT parameters
+mfxExtVPP3DLut lut3DConfig;
+memset(&lut3DConfig, 0, sizeof(lut3DConfig));
+lut3DConfig.Header.BufferId         = MFX_EXTBUFF_VPP_3DLUT;
+lut3DConfig.Header.BufferSz         = sizeof(mfxExtVPP3DLut);
+lut3DConfig.ChannelMapping          = MFX_3DLUT_CHANNEL_MAPPING_RGB_RGB;    
+lut3DConfig.BufferType              = MFX_RESOURCE_VA_SURFACE;
+lut3DConfig.VideoBuffer.DataType    = MFX_DATA_TYPE_U16;
+lut3DConfig.VideoBuffer.MemLayout   = MFX_3DLUT_MEMORY_LAYOUT_INTEL_65LUT;
+lut3DConfig.VideoBuffer.MemId       = memId;
+
+// release 3DLUT surface
+vaDestroySurfaces(va_dpy, &surface_id, 1);
+/*end4*/
+}
+
+static void prg_vpp5 () {
+/*beg5*/
+
+// 64 size 3DLUT
+mfxU8 dataR[64], dataG[64], dataB[64];
+mfxChannel channelR, channelG, channelB;
+channelR.DataType = MFX_DATA_TYPE_U8;
+channelR.Size = 64;
+channelR.Data = dataR;
+channelG.DataType = MFX_DATA_TYPE_U8;
+channelG.Size = 64;
+channelG.Data = dataG;
+channelB.DataType = MFX_DATA_TYPE_U8;
+channelB.Size = 64;
+channelB.Data = dataB;
+
+// configure 3DLUT parameters
+mfxExtVPP3DLut lut3DConfig;
+memset(&lut3DConfig, 0, sizeof(lut3DConfig));
+lut3DConfig.Header.BufferId         = MFX_EXTBUFF_VPP_3DLUT;
+lut3DConfig.Header.BufferSz         = sizeof(mfxExtVPP3DLut);
+lut3DConfig.ChannelMapping          = MFX_3DLUT_CHANNEL_MAPPING_RGB_RGB;    
+lut3DConfig.BufferType              = MFX_RESOURCE_SYSTEM_SURFACE;
+lut3DConfig.SystemBuffer.Channel[0] = channelR;
+lut3DConfig.SystemBuffer.Channel[1] = channelG;
+lut3DConfig.SystemBuffer.Channel[2] = channelB;
+
+/*end5*/
 }


### PR DESCRIPTION
* Added ability to retrieve path to the shared library with the implementation.
* Added 3DLUT (Three-Dimensional Look Up Table) filter in VPP.
* Added mfxGUID structure to specify Globally Unique Identifiers (GUIDs).
* Added QueryInterface function to mfxFrameSurfaceInterface.
* Added AdaptiveRef and alias for ExtBrcAdaptiveLTR.
* Added MFX_FOURCC_BGRP FourCC for Planar BGR format.
* Environmental variables to control dispatcher's logger.