### PR TITLE
Amend and force-push to publish to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,5 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
-          git commit -m "Update from github actions"
-          git push
+          git commit --amend -m "Update from github actions"
+          git push --force origin gh-pages


### PR DESCRIPTION
This commit avoids making the repository grow in size too fast by
overwriting the gh-pages branch on every build. This commit is not
enough in itself. To decrease the repository size, we also need to do
something like cherry-pick the latest gh-pages into a new orphan branch,
then force-push this branch to gh-pages. Newly unreachable objects
should be slowly garbage-collected over time.

(Partially) Fixes #334.