### PR TITLE
[oneMKL][LAPACK] correct documentation for [or/un]mqr

### DIFF
--- a/source/elements/oneMKL/source/domains/lapack/gesvd.rst
+++ b/source/elements/oneMKL/source/domains/lapack/gesvd.rst
@@ -55,7 +55,7 @@ are returned in descending order. The first :math:`\min(m, n)` columns of
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void gesvd(cl::sycl::queue &queue, onemkl::job jobu, onemkl::job jobvt, std::int64_t m, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<realT,1> &s, cl::sycl::buffer<T,1> &u, std::int64_t ldu, cl::sycl::buffer<T,1> &vt, std::int64_t ldvt, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void gesvd(cl::sycl::queue &queue, oneapi::mkl::job jobu, oneapi::mkl::job jobvt, std::int64_t m, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<realT,1> &s, cl::sycl::buffer<T,1> &u, std::int64_t ldu, cl::sycl::buffer<T,1> &vt, std::int64_t ldvt, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -240,7 +240,7 @@ are returned in descending order. The first :math:`\min(m, n)` columns of
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event gesvd(cl::sycl::queue &queue, onemkl::job jobu, onemkl::job jobvt, std::int64_t m, std::int64_t n, T *a, std::int64_t lda, RealT *s, T *u, std::int64_t ldu, T *vt, std::int64_t ldvt, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event gesvd(cl::sycl::queue &queue, oneapi::mkl::job jobu, oneapi::mkl::job jobvt, std::int64_t m, std::int64_t n, T *a, std::int64_t lda, RealT *s, T *u, std::int64_t ldu, T *vt, std::int64_t ldvt, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/gesvd_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/gesvd_scratchpad_size.rst
@@ -38,7 +38,7 @@ gesvd_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t gesvd_scratchpad_size(cl::sycl::queue &queue, onemkl::job jobu, onemkl::job jobvt, std::int64_t m, std::int64_t n, std::int64_t lda, std::int64_t ldu, std::int64_t ldvt) 
+      std::int64_t gesvd_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::job jobu, oneapi::mkl::job jobvt, std::int64_t m, std::int64_t n, std::int64_t lda, std::int64_t ldu, std::int64_t ldvt) 
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/getrs.rst
+++ b/source/elements/oneMKL/source/domains/lapack/getrs.rst
@@ -32,11 +32,11 @@ equations:
        :header-rows: 1
     
        * -     \ :math:`AX = B`\     
-         -     if ``trans``\ =\ ``onemkl::transpose::nontrans``\     
+         -     if ``trans``\ =\ ``oneapi::mkl::transpose::nontrans``\     
        * -     \ :math:`A^TX = B`\     
-         -     if ``trans``\ =\ ``onemkl::transpose::trans``\     
+         -     if ``trans``\ =\ ``oneapi::mkl::transpose::trans``\     
        * -     \ :math:`A^HX = B`\     
-         -     if ``trans``\ =\ ``onemkl::transpose::conjtrans``\     
+         -     if ``trans``\ =\ ``oneapi::mkl::transpose::conjtrans``\     
 
 Before calling this routine, you must call
 :ref:`onemkl_lapack_getrf`
@@ -52,7 +52,7 @@ getrs (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void getrs(cl::sycl::queue &queue, onemkl::transpose trans, std::int64_t n, std::int64_t nrhs, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<std::int64_t,1> &ipiv, cl::sycl::buffer<T,1> &b, std::int64_t ldb, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void getrs(cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n, std::int64_t nrhs, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<std::int64_t,1> &ipiv, cl::sycl::buffer<T,1> &b, std::int64_t ldb, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -65,13 +65,13 @@ queue
 trans
    Indicates the form of the equations:
 
-   If ``trans=onemkl::transpose::nontrans``, then :math:`AX = B` is solved
+   If ``trans=oneapi::mkl::transpose::nontrans``, then :math:`AX = B` is solved
    for :math:`X`.
 
-   If ``trans=onemkl::transpose::trans``, then :math:`A^TX = B` is solved
+   If ``trans=oneapi::mkl::transpose::trans``, then :math:`A^TX = B` is solved
    for :math:`X`.
 
-   If ``trans=onemkl::transpose::conjtrans``, then :math:`A^HX = B` is
+   If ``trans=oneapi::mkl::transpose::conjtrans``, then :math:`A^HX = B` is
    solved for :math:`X`.
 
 n
@@ -152,7 +152,7 @@ getrs (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event getrs(cl::sycl::queue &queue, onemkl::transpose trans, std::int64_t n, std::int64_t nrhs, T *a, std::int64_t lda, std::int64_t *ipiv, T *b, std::int64_t ldb, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event getrs(cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n, std::int64_t nrhs, T *a, std::int64_t lda, std::int64_t *ipiv, T *b, std::int64_t ldb, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section
@@ -165,13 +165,13 @@ queue
 trans
    Indicates the form of the equations:
 
-   If ``trans=onemkl::transpose::nontrans``, then :math:`AX = B` is solved
+   If ``trans=oneapi::mkl::transpose::nontrans``, then :math:`AX = B` is solved
    for :math:`X`.
 
-   If ``trans=onemkl::transpose::trans``, then :math:`A^TX = B` is solved
+   If ``trans=oneapi::mkl::transpose::trans``, then :math:`A^TX = B` is solved
    for :math:`X`.
 
-   If ``trans=onemkl::transpose::conjtrans``, then :math:`A^HX = B` is
+   If ``trans=oneapi::mkl::transpose::conjtrans``, then :math:`A^HX = B` is
    solved for :math:`X`.
 
 n

--- a/source/elements/oneMKL/source/domains/lapack/getrs_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/getrs_scratchpad_size.rst
@@ -39,7 +39,7 @@ getrs_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t getrs_scratchpad_size(cl::sycl::queue &queue, onemkl::transpose trans, std::int64_t n, std::int64_t nrhs, std::int64_t lda, std::int64_t ldb) 
+      std::int64_t getrs_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n, std::int64_t nrhs, std::int64_t lda, std::int64_t ldb) 
     }
 
 .. container:: section
@@ -52,13 +52,13 @@ queue
 trans
    Indicates the form of the equations:
 
-   If ``trans=onemkl::transpose::nontrans``, then :math:`AX = B` is solved
+   If ``trans=oneapi::mkl::transpose::nontrans``, then :math:`AX = B` is solved
    for :math:`X`.
 
-   If ``trans=onemkl::transpose::trans``, then :math:`A^TX = B` is solved
+   If ``trans=oneapi::mkl::transpose::trans``, then :math:`A^TX = B` is solved
    for :math:`X`.
 
-   If ``trans=onemkl::transpose::conjtrans``, then :math:`A^HX = B` is
+   If ``trans=oneapi::mkl::transpose::conjtrans``, then :math:`A^HX = B` is
    solved for :math:`X`.
 
 n

--- a/source/elements/oneMKL/source/domains/lapack/heevd.rst
+++ b/source/elements/oneMKL/source/domains/lapack/heevd.rst
@@ -48,7 +48,7 @@ heevd (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void heevd(cl::sycl::queue &queue, onemkl::job jobz, onemkl::uplo upper_lower, std::int64_t n, butter<T,1> &a, std::int64_t lda, cl::sycl::buffer<realT,1> &w, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void heevd(cl::sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo upper_lower, std::int64_t n, butter<T,1> &a, std::int64_t lda, cl::sycl::buffer<realT,1> &w, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -127,12 +127,12 @@ This routine shall throw the following exceptions if the associated condition is
 
    If ``info=-i``, the :math:`i`-th parameter had an illegal value.
 
-   If ``info=i``, and ``jobz = onemkl::job::novec``, then the algorithm
+   If ``info=i``, and ``jobz = oneapi::mkl::job::novec``, then the algorithm
    failed to converge; :math:`i` indicates the number of off-diagonal
    elements of an intermediate tridiagonal form which did not
    converge to zero.
 
-   If ``info=i``, and ``jobz = onemkl::job::vec``, then the algorithm failed
+   If ``info=i``, and ``jobz = oneapi::mkl::job::vec``, then the algorithm failed
    to compute an eigenvalue while working on the submatrix lying in
    rows and columns :math:`\text{info}/(n+1)` through :math:`\text{mod}(\text{info},n+1)`.
 
@@ -148,7 +148,7 @@ heevd (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event heevd(cl::sycl::queue &queue, onemkl::job jobz, onemkl::uplo upper_lower, std::int64_t n, butter<T,1> &a, std::int64_t lda, RealT *w, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event heevd(cl::sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo upper_lower, std::int64_t n, butter<T,1> &a, std::int64_t lda, RealT *w, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section
@@ -228,12 +228,12 @@ This routine shall throw the following exceptions if the associated condition is
 
    If ``info=-i``, the :math:`i`-th parameter had an illegal value.
 
-   If ``info=i``, and ``jobz = onemkl::job::novec``, then the algorithm
+   If ``info=i``, and ``jobz = oneapi::mkl::job::novec``, then the algorithm
    failed to converge; :math:`i` indicates the number of off-diagonal
    elements of an intermediate tridiagonal form which did not
    converge to zero.
 
-   If ``info=i``, and ``jobz = onemkl::job::vec``, then the algorithm failed
+   If ``info=i``, and ``jobz = oneapi::mkl::job::vec``, then the algorithm failed
    to compute an eigenvalue while working on the submatrix lying in
    rows and columns :math:`\text{info}/(n+1)` through :math:`\text{mod}(\text{info},n+1)`.
 

--- a/source/elements/oneMKL/source/domains/lapack/heevd_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/heevd_scratchpad_size.rst
@@ -37,7 +37,7 @@ heevd_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t heevd_scratchpad_size(cl::sycl::queue &queue, onemkl::job jobz, onemkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
+      std::int64_t heevd_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/hegvd.rst
+++ b/source/elements/oneMKL/source/domains/lapack/hegvd.rst
@@ -45,7 +45,7 @@ hegvd (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void hegvd(cl::sycl::queue &queue, std::int64_t itype, onemkl::job jobz, onemkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &b, std::int64_t ldb, cl::sycl::buffer<realT,1> &w, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void hegvd(cl::sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz, oneapi::mkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &b, std::int64_t ldb, cl::sycl::buffer<realT,1> &w, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -160,11 +160,11 @@ This routine shall throw the following exceptions if the associated condition is
 
    For :math:`\text{info} \le n`:
 
-      If :math:`\text{info}=i`, and ``jobz = onemkl::job::novec``, then the algorithm
+      If :math:`\text{info}=i`, and ``jobz = oneapi::mkl::job::novec``, then the algorithm
       failed to converge; :math:`i` indicates the number of off-diagonal elements
       of an intermediate tridiagonal form which did not converge to zero;
 
-      If :math:`\text{info}=i`, and ``jobz = onemkl::job::vec``, then the algorithm
+      If :math:`\text{info}=i`, and ``jobz = oneapi::mkl::job::vec``, then the algorithm
       failed to compute an eigenvalue while working on the submatrix
       lying in rows and columns :math:`\text{info}/(n+1)`` through
       :math:`\text{mod}(\text{info}, n+1)`.
@@ -188,7 +188,7 @@ hegvd (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event hegvd(cl::sycl::queue &queue, std::int64_t itype, onemkl::job jobz, onemkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *b, std::int64_t ldb, RealT *w, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event hegvd(cl::sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz, oneapi::mkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *b, std::int64_t ldb, RealT *w, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section
@@ -305,11 +305,11 @@ This routine shall throw the following exceptions if the associated condition is
 
    For :math:`\text{info} \le n`:
 
-      If :math:`\text{info}=i`, and ``jobz = onemkl::job::novec``, then the algorithm
+      If :math:`\text{info}=i`, and ``jobz = oneapi::mkl::job::novec``, then the algorithm
       failed to converge; :math:`i` indicates the number of off-diagonal elements
       of an intermediate tridiagonal form which did not converge to zero;
 
-      If :math:`\text{info}=i`, and ``jobz = onemkl::job::vec``, then the algorithm
+      If :math:`\text{info}=i`, and ``jobz = oneapi::mkl::job::vec``, then the algorithm
       failed to compute an eigenvalue while working on the submatrix
       lying in rows and columns :math:`\text{info}/(n+1)` through
       :math:`\text{mod}(\text{info},n+1)`.

--- a/source/elements/oneMKL/source/domains/lapack/hegvd_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/hegvd_scratchpad_size.rst
@@ -37,7 +37,7 @@ hegvd_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t hegvd_scratchpad_size(cl::sycl::queue &queue, std::int64_t itype, onemkl::job jobz, onemkl::uplo upper_lower, std::int64_t n, std::int64_t lda, std::int64_t ldb) 
+      std::int64_t hegvd_scratchpad_size(cl::sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t lda, std::int64_t ldb) 
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/hetrd.rst
+++ b/source/elements/oneMKL/source/domains/lapack/hetrd.rst
@@ -41,7 +41,7 @@ hetrd (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void hetrd(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<realT,1> &d, cl::sycl::buffer<realT,1> &e, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void hetrd(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<realT,1> &d, cl::sycl::buffer<realT,1> &e, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -146,7 +146,7 @@ hetrd (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event hetrd(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, RealT *d, RealT *e, T *tau, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event hetrd(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, RealT *d, RealT *e, T *tau, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/hetrd_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/hetrd_scratchpad_size.rst
@@ -37,7 +37,7 @@ hetrd_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t hetrd_scratchpad_size(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
+      std::int64_t hetrd_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/orgbr.rst
+++ b/source/elements/oneMKL/source/domains/lapack/orgbr.rst
@@ -67,7 +67,7 @@ orgbr (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void orgbr(cl::sycl::queue &queue, onemkl::generate gen, std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void orgbr(cl::sycl::queue &queue, oneapi::mkl::generate gen, std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -169,7 +169,7 @@ orgbr (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event orgbr(cl::sycl::queue &queue, onemkl::generate gen, std::int64_t m, std::int64_t n, std::int64_t k, T *a, std::int64_t lda, T *tau, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event orgbr(cl::sycl::queue &queue, oneapi::mkl::generate gen, std::int64_t m, std::int64_t n, std::int64_t k, T *a, std::int64_t lda, T *tau, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/orgbr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/orgbr_scratchpad_size.rst
@@ -36,7 +36,7 @@ orgbr_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t orgbr_scratchpad_size(cl::sycl::queue &queue, onemkl::generate gen, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t &scratchpad_size) 
+      std::int64_t orgbr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::generate gen, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t &scratchpad_size) 
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/orgtr.rst
+++ b/source/elements/oneMKL/source/domains/lapack/orgtr.rst
@@ -39,7 +39,7 @@ orgtr (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void orgtr(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void orgtr(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -115,7 +115,7 @@ orgtr (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event orgtr(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *tau, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event orgtr(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *tau, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/orgtr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/orgtr_scratchpad_size.rst
@@ -36,7 +36,7 @@ orgtr_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t orgtr_scratchpad_size(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
+      std::int64_t orgtr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/ormqr.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ormqr.rst
@@ -13,26 +13,25 @@ factorization formed by :ref:`onemkl_lapack_geqrf`.
 .. container:: section
 
   .. rubric:: Description
-      
+
 ``ormqr`` supports the following precisions.
 
-    .. list-table:: 
+    .. list-table::
        :header-rows: 1
- 
-       * -  T 
-       * -  ``float`` 
-       * -  ``double`` 
-       * -  ``std::complex<float>`` 
-       * -  ``std::complex<double>`` 
 
-The routine multiplies a real matrix :math:`C` by :math:`Q` or
-:math:`Q^{T}`, where :math:`Q` is the orthogonal matrix :math:`Q` of the
-QR factorization formed by the routine
-:ref:`onemkl_lapack_geqrf`.
+       * -  T
+       * -  ``float``
+       * -  ``double``
 
-Depending on the parameters ``left_right`` and ``trans``, the routine
-can form one of the matrix products :math:`QC`, :math:`Q^TC`, :math:`CQ`, or
-:math:`CQ^T` (overwriting the result on :math:`C`).
+The routine multiplies a rectangular real :math:`m \times n` matrix :math:`C` by
+:math:`Q` or :math:`Q^T`, where :math:`Q` is the complex unitary matrix defined
+as a product of :math:`k` elementary reflectors :math:`H(i)` of order :math:`n`:
+:math:`Q = H(1)^TH(2)^T ... H(k)^T` as returned by the RQ factorization routine
+:ref:`onemkl_lapack_gerqf`.
+
+Depending on the parameters ``side`` and ``trans``, the routine can form one of
+the matrix products :math:`QC`, :math:`Q^TC`, :math:`CQ`, or :math:`CQ^T`
+(overwriting the result over :math:`C`).
 
 ormqr (Buffer Version)
 ----------------------
@@ -40,11 +39,11 @@ ormqr (Buffer Version)
 .. container:: section
 
   .. rubric:: Syntax
-         
+
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void ormqr(cl::sycl::queue &queue, onemkl::side left_right, onemkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &c, std::int64_t ldc, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void ormqr(cl::sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &c, std::int64_t ldc, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -52,69 +51,73 @@ ormqr (Buffer Version)
   .. rubric:: Input Parameters
 
 queue
-   The queue where the routine should be executed.
+    The queue where the routine should be executed.
 
-left_right
-   If ``left_right=onemkl::side::left``, :math:`Q` or :math:`Q^{T}` is
-   applied to :math:`C` from the left.
+side
+    If ``side = oneapi::mkl::side::left``, :math:`Q` or :math:`Q^{T}` is applied
+    to :math:`C` from the left.
 
-   If ``left_right=onemkl::side::right``, :math:`Q` or :math:`Q^{T}` is
-   applied to :math:`C` from the right.
+    If ``side = oneapi::mkl::side::right``, :math:`Q` or :math:`Q^{T}` is
+    applied to :math:`C` from the right.
 
 trans
-   If ``trans=onemkl::transpose::trans``, the routine multiplies :math:`C`
-   by :math:`Q`.
+    If ``trans = oneapi::mkl::transpose::nontrans``, the routine multiplies
+    :math:`C` by :math:`Q`.
 
-   If ``trans=onemkl::transpose::nontrans``, the routine multiplies
-   :math:`C` by :math:`Q^{T}`.
+    If ``trans = oneapi::mkl::transpose::trans``, the routine multiplies :math:`C`
+    by :math:`Q^{T}`.
 
 m
-   The number of rows in the matrix :math:`A` (:math:`0 \le m`).
+    The number of rows in the matrix :math:`C` (:math:`0 \le m`).
 
 n
-   The number of columns in the matrix :math:`A` (:math:`0 \le n \le m`).
+    The number of columns in the matrix :math:`C` (:math:`0 \le n`).
 
 k
-   The number of elementary reflectors whose product defines the
-   matrix :math:`Q` (:math:`0 \le k \le n`).
+    The number of elementary reflectors whose product defines the
+    matrix :math:`Q` 
+
+    If ``side = oneapi::mkl::side::left``, :math:`0 \le k \le m`
+
+    If ``side = oneapi::mkl::side::right``, :math:`0 \le k \le n`
 
 a
-   The buffer ``a`` as returned by :ref:`onemkl_lapack_geqrf`.
-   The second dimension of ``a`` must be at least :math:`\max(1,k)`.
+    The buffer ``a`` as returned by :ref:`onemkl_lapack_geqrf`.
+    The second dimension of ``a`` must be at least :math:`\max(1,k)`.
 
 lda
-   The leading dimension of ``a``.
+    The leading dimension of ``a``.
 
 tau
-   The buffer ``tau`` as returned by :ref:`onemkl_lapack_geqrf`.
-   The second dimension of ``a`` must be at least :math:`\max(1,k)`.
+    The buffer ``tau`` as returned by :ref:`onemkl_lapack_geqrf`.
 
 c
-   The buffer ``c`` contains the matrix :math:`C`. The second dimension of ``c``
-   must be at least :math:`\max(1,n)`.
+    The buffer ``c`` contains the matrix :math:`C`. The second dimension of
+    ``c`` must be at least :math:`\max(1,n)`.
 
 ldc
-   The leading dimension of ``c``.
+    The leading dimension of ``c``.
 
 scratchpad_size
-   Size of scratchpad memory as a number of floating point elements of type ``T``.
-   Size should not be less than the value returned by :ref:`onemkl_lapack_ormqr_scratchpad_size` function.
+    Size of scratchpad memory as a number of floating point elements of type
+    ``T``. Size should not be less than the value returned by the
+    :ref:`onemkl_lapack_ormqr_scratchpad_size` function.
 
 .. container:: section
 
   .. rubric:: Output Parameters
-      
+
 c
-   Overwritten by the product :math:`QC`, :math:`Q^{T}C`, :math:`CQ`, or
-   :math:`CQ^{T}` (as specified by left_right and trans).
+    Overwritten by the product :math:`QC`, :math:`Q^{T}C`, :math:`CQ`, or
+    :math:`CQ^{T}` (as specified by ``side`` and ``trans``).
 
 scratchpad
-   Buffer holding scratchpad memory to be used by routine for storing intermediate results.
+    Buffer holding scratchpad memory to be used by routine for storing intermediate results.
 
 .. container:: section
 
   .. rubric:: Throws
-         
+
 This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
 
 :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
@@ -129,11 +132,11 @@ This routine shall throw the following exceptions if the associated condition is
 
 :ref:`oneapi::mkl::lapack::computation_error<onemkl_lapack_exception_computation_error>`
 
-   Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
+    Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
 
-   If :math:`\text{info}=-i`, the :math:`i`-th parameter had an illegal value.
+    If :math:`\text{info}=-i`, the :math:`i`-th parameter had an illegal value.
 
-   If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
+    If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
 
 ormqr (USM Version)
 ----------------------
@@ -141,11 +144,11 @@ ormqr (USM Version)
 .. container:: section
 
   .. rubric:: Syntax
-         
+
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event ormqr(cl::sycl::queue &queue, onemkl::side left_right, onemkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, T *a, std::int64_t lda, T *tau, T *c, std::int64_t ldc, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event ormqr(cl::sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, T *a, std::int64_t lda, T *tau, T *c, std::int64_t ldc, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section
@@ -153,72 +156,76 @@ ormqr (USM Version)
   .. rubric:: Input Parameters
 
 queue
-   The queue where the routine should be executed.
+    The queue where the routine should be executed.
 
-left_right
-   If ``left_right=onemkl::side::left``, :math:`Q` or :math:`Q^{T}` is
-   applied to :math:`C` from the left.
+side
+    If ``side = oneapi::mkl::side::left``, :math:`Q` or :math:`Q^{T}` is applied
+    to :math:`C` from the left.
 
-   If ``left_right=onemkl::side::right``, :math:`Q` or :math:`Q^{T}` is
-   applied to :math:`C` from the right.
+    If ``side = oneapi::mkl::side::right``, :math:`Q` or :math:`Q^{T}` is
+    applied to :math:`C` from the right.
 
 trans
-   If ``trans=onemkl::transpose::trans``, the routine multiplies :math:`C`
-   by :math:`Q`.
+    If ``trans = oneapi::mkl::transpose::nontrans``, the routine multiplies
+    :math:`C` by :math:`Q`.
 
-   If ``trans=onemkl::transpose::nontrans``, the routine multiplies
-   :math:`C` by :math:`Q^{T}`.
+    If ``trans = oneapi::mkl::transpose::trans``, the routine multiplies :math:`C`
+    by :math:`Q^{T}`.
 
 m
-   The number of rows in the matrix :math:`A` (:math:`0 \le m`).
+    The number of rows in the matrix :math:`C` (:math:`0 \le m`).
 
 n
-   The number of columns in the matrix :math:`A` (:math:`0 \le n \le m`).
+    The number of columns in the matrix :math:`C` (:math:`0 \le n`).
 
 k
-   The number of elementary reflectors whose product defines the
-   matrix :math:`Q` (:math:`0 \le k \le n`).
+    The number of elementary reflectors whose product defines the
+    matrix :math:`Q`
+
+    If ``side = oneapi::mkl::side::left``, :math:`0 \le k \le m`
+
+    If ``side = oneapi::mkl::side::right``, :math:`0 \le k \le n`
 
 a
-   The pointer to ``a`` as returned by :ref:`onemkl_lapack_geqrf`.
-   The second dimension of ``a`` must be at least :math:`\max(1,k)`.
+    The pointer to ``a`` as returned by :ref:`onemkl_lapack_geqrf`.
+    The second dimension of ``a`` must be at least :math:`\max(1,k)`.
 
 lda
-   The leading dimension of ``a``.
+    The leading dimension of ``a``.
 
 tau
-   The pointer to ``tau`` as returned by :ref:`onemkl_lapack_geqrf`.
-   The second dimension of ``a`` must be at least :math:`\max(1,k)`.
+    The pointer to ``tau`` as returned by :ref:`onemkl_lapack_geqrf`.
 
 c
-   The pointer to the matrix :math:`C`. The second dimension of ``c``
-   must be at least :math:`\max(1,n)`.
+    The pointer ``c`` points to the matrix :math:`C`. The second dimension of
+    ``c`` must be at least :math:`\max(1,n)`.
 
 ldc
-   The leading dimension of ``c``.
+    The leading dimension of ``c``.
 
 scratchpad_size
-   Size of scratchpad memory as a number of floating point elements of type ``T``.
-   Size should not be less than the value returned by :ref:`onemkl_lapack_ormqr_scratchpad_size` function.
+    Size of scratchpad memory as a number of floating point elements of type
+    ``T``. Size should not be less than the value returned by the
+    :ref:`onemkl_lapack_ormqr_scratchpad_size` function.
 
 events
-   List of events to wait for before starting computation. Defaults to empty list.
+    List of events to wait for before starting computation. Defaults to empty list.
 
 .. container:: section
 
   .. rubric:: Output Parameters
-      
+
 c
-   Overwritten by the product :math:`QC`, :math:`Q^{T}C`, :math:`CQ`, or
-   :math:`CQ^{T}` (as specified by left_right and trans).
+    Overwritten by the product :math:`QC`, :math:`Q^{T}C`, :math:`CQ`, or
+    :math:`CQ^{T}` (as specified by ``side`` and ``trans``).
 
 scratchpad
-   Pointer to scratchpad memory to be used by routine for storing intermediate results.
+    Pointer to scratchpad memory to be used by routine for storing intermediate results.
 
 .. container:: section
 
   .. rubric:: Throws
-         
+
 This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
 
 :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
@@ -233,11 +240,11 @@ This routine shall throw the following exceptions if the associated condition is
 
 :ref:`oneapi::mkl::lapack::computation_error<onemkl_lapack_exception_computation_error>`
 
-   Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
+    Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
 
-   If :math:`\text{info}=-i`, the :math:`i`-th parameter had an illegal value.
+    If :math:`\text{info}=-i`, the :math:`i`-th parameter had an illegal value.
 
-   If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
+    If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
 
 .. container:: section
 
@@ -246,4 +253,3 @@ This routine shall throw the following exceptions if the associated condition is
 Output event to wait on to ensure computation is complete.
 
 **Parent topic:** :ref:`onemkl_lapack-linear-equation-routines`
-

--- a/source/elements/oneMKL/source/domains/lapack/ormqr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ormqr_scratchpad_size.rst
@@ -36,7 +36,7 @@ ormqr_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t ormqr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t ldc, std::int64_t &scratchpad_size) 
+      std::int64_t ormqr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t ldc, std::int64_t &scratchpad_size) 
     }
 
 .. container:: section
@@ -46,11 +46,11 @@ ormqr_scratchpad_size
 queue
    Device queue where calculations by :ref:`onemkl_lapack_ormqr` function will be performed.
 
-left_right
-   If ``left_right=oneapi::mkl::side::left``, :math:`Q` or :math:`Q^{T}` is
+side
+   If ``side=oneapi::mkl::side::left``, :math:`Q` or :math:`Q^{T}` is
    applied to :math:`C` from the left.
 
-   If ``left_right=oneapi::mkl::side::right``, :math:`Q` or :math:`Q^{T}` is
+   If ``side=oneapi::mkl::side::right``, :math:`Q` or :math:`Q^{T}` is
    applied to :math:`C` from the right.
 
 trans

--- a/source/elements/oneMKL/source/domains/lapack/ormqr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ormqr_scratchpad_size.rst
@@ -54,17 +54,17 @@ side
    applied to :math:`C` from the right.
 
 trans
-   If ``trans=oneapi::mkl::transpose::trans``, the routine multiplies
+   If ``trans=oneapi::mkl::transpose::nontrans``, the routine multiplies
    :math:`C` by :math:`Q`.
 
-   If ``trans=oneapi::mkl::transpose::nontrans``, the routine multiplies
+   If ``trans=oneapi::mkl::transpose::trans``, the routine multiplies
    :math:`C` by :math:`Q^{T}`.
 
 m
-   The number of rows in the matrix :math:`A` (:math:`0 \le m`).
+   The number of rows in the matrix :math:`C` (:math:`0 \le m`).
 
 n
-   The number of columns in the matrix :math:`A` (:math:`0 \le n \le m`).
+   The number of columns in the matrix :math:`C` (:math:`0 \le n \le m`).
 
 k
    The number of elementary reflectors whose product defines the

--- a/source/elements/oneMKL/source/domains/lapack/ormqr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ormqr_scratchpad_size.rst
@@ -36,7 +36,7 @@ ormqr_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t ormqr_scratchpad_size(cl::sycl::queue &queue, onemkl::side left_right, onemkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t ldc, std::int64_t &scratchpad_size) 
+      std::int64_t ormqr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t ldc, std::int64_t &scratchpad_size) 
     }
 
 .. container:: section
@@ -47,17 +47,17 @@ queue
    Device queue where calculations by :ref:`onemkl_lapack_ormqr` function will be performed.
 
 left_right
-   If ``left_right=onemkl::side::left``, :math:`Q` or :math:`Q^{T}` is
+   If ``left_right=oneapi::mkl::side::left``, :math:`Q` or :math:`Q^{T}` is
    applied to :math:`C` from the left.
 
-   If ``left_right=onemkl::side::right``, :math:`Q` or :math:`Q^{T}` is
+   If ``left_right=oneapi::mkl::side::right``, :math:`Q` or :math:`Q^{T}` is
    applied to :math:`C` from the right.
 
 trans
-   If ``trans=onemkl::transpose::trans``, the routine multiplies
+   If ``trans=oneapi::mkl::transpose::trans``, the routine multiplies
    :math:`C` by :math:`Q`.
 
-   If ``trans=onemkl::transpose::nontrans``, the routine multiplies
+   If ``trans=oneapi::mkl::transpose::nontrans``, the routine multiplies
    :math:`C` by :math:`Q^{T}`.
 
 m

--- a/source/elements/oneMKL/source/domains/lapack/ormrq.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ormrq.rst
@@ -7,23 +7,31 @@
 ormrq
 =====
 
-Multiplies a real matrix by the orthogonal matrix :math:`Q` of the RQ factorization formed by :ref:`onemkl_lapack_gerqf`.
+Multiplies a real matrix by the orthogonal matrix :math:`Q` of the RQ
+factorization formed by :ref:`onemkl_lapack_gerqf`.
 
 .. container:: section
 
   .. rubric:: Description
-      
+
 ``ormrq`` supports the following precisions.
 
-     .. list-table:: 
-        :header-rows: 1
+    .. list-table::
+       :header-rows: 1
 
-        * -  T 
-        * -  ``float`` 
-        * -  ``double`` 
+       * -  T
+       * -  ``float``
+       * -  ``double``
 
-The routine multiplies a real :math:`m \times n` matrix :math:`C` by :math:`Q` or :math:`Q^T`, where :math:`Q` is the real orthogonal matrix defined as a product of :math:`k` elementary reflectors :math:`H_i` : :math:`Q = H_1H_2 ... H_k` as returned by the RQ factorization routine :ref:`onemkl_lapack_gerqf`.
-Depending on the parameters ``side`` and ``trans``, the routine can form one of the matrix products :math:`QC`, :math:`Q^TC`, :math:`CQ`, or :math:`CQ^T` (overwriting the result over :math:`C`).
+The routine multiplies a rectangular real :math:`m \times n` matrix :math:`C` by
+:math:`Q` or :math:`Q^T`, where :math:`Q` is the complex unitary matrix defined
+as a product of :math:`k` elementary reflectors :math:`H(i)` of order :math:`n`:
+:math:`Q = H(1)^TH(2)^T ... H(k)^T` as returned by the RQ factorization routine
+:ref:`onemkl_lapack_gerqf`.
+
+Depending on the parameters ``side`` and ``trans``, the routine can form one of
+the matrix products :math:`QC`, :math:`Q^TC`, :math:`CQ`, or :math:`CQ^T`
+(overwriting the result over :math:`C`).
 
 ormrq (Buffer Version)
 ----------------------
@@ -41,61 +49,75 @@ ormrq (Buffer Version)
 .. container:: section
 
   .. rubric:: Input Parameters
-      
+
 queue
-   Device queue where calculations will be performed.
+    The queue where the routine should be executed.
 
 side
-   If ``side = oneapi::mkl::side::left``, :math:`Q` or :math:`Q^T` is applied to :math:`C` from the left. 
-   
-   If ``side = oneapi::mkl::side::right``, :math:`Q` or :math:`Q^T` is applied to :math:`C` from the right.
+    If ``side = oneapi::mkl::side::left``, :math:`Q` or :math:`Q^{T}` is applied
+    to :math:`C` from the left.
+
+    If ``side = oneapi::mkl::side::right``, :math:`Q` or :math:`Q^{T}` is
+    applied to :math:`C` from the right.
 
 trans
-   If ``trans=oneapi::mkl::transpose::trans``, the routine multiplies :math:`C` by :math:`Q`.
+    If ``trans = oneapi::mkl::transpose::nontrans``, the routine multiplies
+    :math:`C` by :math:`Q`.
 
-   If ``trans=oneapi::mkl::transpose::nontrans``, the routine multiplies :math:`C` by :math:`Q^T`.
+    If ``trans = oneapi::mkl::transpose::trans``, the routine multiplies :math:`C`
+    by :math:`Q^{T}`.
 
 m
-   The number of rows in the matrix :math:`A` (:math:`0 \le m`).
+    The number of rows in the matrix :math:`C` (:math:`0 \le m`).
 
 n
-   The number of columns in the matrix :math:`A` (:math:`0 \le n \le m`).
+    The number of columns in the matrix :math:`C` (:math:`0 \le n`).
 
 k
-   The number of elementary reflectors whose product defines the matrix :math:`Q` (:math:`0 \le k \le n`).
+    The number of elementary reflectors whose product defines the
+    matrix :math:`Q`
+
+    If ``side = oneapi::mkl::side::left``, :math:`0 \le k \le m`
+
+    If ``side = oneapi::mkl::side::right``, :math:`0 \le k \le n`
 
 a
-   Buffer holding the result of the :ref:`onemkl_lapack_gerqf` function. The second dimension of ``a`` must be at least :math:`\max(1,k)`.
+    The buffer ``a`` as returned by :ref:`onemkl_lapack_gerqf`.
+    The second dimension of ``a`` must be at least :math:`\max(1,k)`.
 
 lda
-   The leading dimension of ``a``.
+    The leading dimension of ``a``.
 
 tau
-   Buffer holding ``tau`` returned by the :ref:`onemkl_lapack_gerqf` function.
+    The buffer ``tau`` as returned by :ref:`onemkl_lapack_gerqf`.
 
 c
-   Buffer holding the matrix :math:`C`. The second dimension of ``c`` must be at least :math:`\max(1,n)`.
+    The buffer ``c`` contains the matrix :math:`C`. The second dimension of
+    ``c`` must be at least :math:`\max(1,n)`.
 
 ldc
-   The leading dimension of ``c``.
-
-scratchpad
-   Buffer holding scratchpad memory to be used by the routine for storing intermediate results.
+    The leading dimension of ``c``.
 
 scratchpad_size
-   Size of scratchpad memory as a number of floating point elements of type ``T``. Size should not be less than the value returned by the :ref:`onemkl_lapack_ormrq_scratchpad_size` function.
+    Size of scratchpad memory as a number of floating point elements of type
+    ``T``. Size should not be less than the value returned by the
+    :ref:`onemkl_lapack_ormrq_scratchpad_size` function.
 
 .. container:: section
 
   .. rubric:: Output Parameters
-      
+
 c
-   Overwritten by the product :math:`QC`, :math:`Q^TC`, :math:`CQ`, or :math:`CQ^T` (as specified by ``side`` and ``trans``).
+    Overwritten by the product :math:`QC`, :math:`Q^{T}C`, :math:`CQ`, or
+    :math:`CQ^{T}` (as specified by ``side`` and ``trans``).
+
+scratchpad
+    Buffer holding scratchpad memory to be used by routine for storing intermediate results.
 
 .. container:: section
 
   .. rubric:: Throws
-         
+
 This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
 
 :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
@@ -110,11 +132,11 @@ This routine shall throw the following exceptions if the associated condition is
 
 :ref:`oneapi::mkl::lapack::computation_error<onemkl_lapack_exception_computation_error>`
 
-   Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
+    Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
 
-   If ``info = -i``, the :math:`i`-th parameter had an illegal value.
+    If :math:`\text{info}=-i`, the :math:`i`-th parameter had an illegal value.
 
-   If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
+    If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
 
 ormrq (USM Version)
 ----------------------
@@ -134,62 +156,76 @@ ormrq (USM Version)
   .. rubric:: Input Parameters
 
 queue
-   Device queue where calculations will be performed.
+    The queue where the routine should be executed.
 
 side
-   If ``side = oneapi::mkl::side::left``, :math:`Q` or :math:`Q^T` is applied to :math:`C` from the left. 
-   
-   If ``side = oneapi::mkl::side::right``, :math:`Q` or :math:`Q^T` is applied to :math:`C` from the right.
+    If ``side = oneapi::mkl::side::left``, :math:`Q` or :math:`Q^{T}` is applied
+    to :math:`C` from the left.
+
+    If ``side = oneapi::mkl::side::right``, :math:`Q` or :math:`Q^{T}` is
+    applied to :math:`C` from the right.
 
 trans
-   If ``trans=oneapi::mkl::transpose::trans``, the routine multiplies :math:`C` by :math:`Q`.
+    If ``trans = oneapi::mkl::transpose::nontrans``, the routine multiplies
+    :math:`C` by :math:`Q`.
 
-   If ``trans=oneapi::mkl::transpose::nontrans``, the routine multiplies :math:`C` by :math:`Q^T`.
+    If ``trans = oneapi::mkl::transpose::trans``, the routine multiplies :math:`C`
+    by :math:`Q^{T}`.
 
 m
-   The number of rows in the matrix :math:`A` (:math:`0 \le m`).
+    The number of rows in the matrix :math:`C` (:math:`0 \le m`).
 
 n
-   The number of columns in the matrix :math:`A` (:math:`0 \le n \le m`).
+    The number of columns in the matrix :math:`C` (:math:`0 \le n`).
 
 k
-   The number of elementary reflectors whose product defines the matrix :math:`Q` (:math:`0 \le k \le n`).
+    The number of elementary reflectors whose product defines the
+    matrix :math:`Q`
+
+    If ``side = oneapi::mkl::side::left``, :math:`0 \le k \le m`
+
+    If ``side = oneapi::mkl::side::right``, :math:`0 \le k \le n`
 
 a
-   Buffer holding the result of the :ref:`onemkl_lapack_gerqf` function. The second dimension of ``a`` must be at least :math:`\max(1,k)`.
+    The pointer to ``a`` as returned by :ref:`onemkl_lapack_gerqf`.
+    The second dimension of ``a`` must be at least :math:`\max(1,k)`.
 
 lda
-   The leading dimension of ``a``.
+    The leading dimension of ``a``.
 
 tau
-   Buffer holding ``tau`` returned by the :ref:`onemkl_lapack_gerqf` function.
+    The pointer to ``tau`` as returned by :ref:`onemkl_lapack_gerqf`.
 
 c
-   Buffer holding the matrix :math:`C`. The second dimension of ``c`` must be at least :math:`\max(1,n)`.
+    The pointer ``c`` points to the matrix :math:`C`. The second dimension of
+    ``c`` must be at least :math:`\max(1,n)`.
 
 ldc
-   The leading dimension of ``c``.
-
-scratchpad
-   Buffer holding scratchpad memory to be used by the routine for storing intermediate results.
+    The leading dimension of ``c``.
 
 scratchpad_size
-   Size of scratchpad memory as a number of floating point elements of type ``T``. Size should not be less than the value returned by the :ref:`onemkl_lapack_ormrq_scratchpad_size` function.
+    Size of scratchpad memory as a number of floating point elements of type
+    ``T``. Size should not be less than the value returned by the
+    :ref:`onemkl_lapack_ormrq_scratchpad_size` function.
 
 events
-   List of events to wait for before starting computation. Defaults to empty list.
+    List of events to wait for before starting computation. Defaults to empty list.
 
 .. container:: section
 
   .. rubric:: Output Parameters
-      
+
 c
-   Overwritten by the product :math:`QC`, :math:`Q^TC`, :math:`CQ`, or :math:`CQ^T` (as specified by ``side`` and ``trans``).
+    Overwritten by the product :math:`QC`, :math:`Q^{T}C`, :math:`CQ`, or
+    :math:`CQ^{T}` (as specified by ``side`` and ``trans``).
+
+scratchpad
+    Pointer to scratchpad memory to be used by routine for storing intermediate results.
 
 .. container:: section
 
   .. rubric:: Throws
-         
+
 This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
 
 :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
@@ -204,16 +240,16 @@ This routine shall throw the following exceptions if the associated condition is
 
 :ref:`oneapi::mkl::lapack::computation_error<onemkl_lapack_exception_computation_error>`
 
-   Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
+    Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
 
-   If ``info = -i``, the :math:`i`-th parameter had an illegal value.
+    If :math:`\text{info}=-i`, the :math:`i`-th parameter had an illegal value.
 
-   If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
+    If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
 
 .. container:: section
 
   .. rubric:: Return Values
-         
+
 Output event to wait on to ensure computation is complete.
 
 **Parent topic:** :ref:`onemkl_lapack-linear-equation-routines`

--- a/source/elements/oneMKL/source/domains/lapack/ormrq_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ormrq_scratchpad_size.rst
@@ -52,15 +52,15 @@ side
    If ``side = oneapi::mkl::side::right``, :math:`Q` or :math:`Q^T` is applied to :math:`C` from the right.
 
 trans
-   If ``trans=oneapi::mkl::transpose::trans``, the routine multiplies :math:`C` by :math:`Q`.
+   If ``trans=oneapi::mkl::transpose::nontrans``, the routine multiplies :math:`C` by :math:`Q`.
 
-   If ``trans=oneapi::mkl::transpose::nontrans``, the routine multiplies :math:`C` by :math:`Q^T`.
+   If ``trans=oneapi::mkl::transpose::trans``, the routine multiplies :math:`C` by :math:`Q^T`.
 
 m
-   The number of rows in the matrix :math:`A` (:math:`0 \le m`).
+   The number of rows in the matrix :math:`C` (:math:`0 \le m`).
 
 n
-   The number of columns in the matrix :math:`A` (:math:`0 \le n \le m`).
+   The number of columns in the matrix :math:`C` (:math:`0 \le n \le m`).
 
 k
    The number of elementary reflectors whose product defines the matrix :math:`Q` (:math:`0 \le k \le n`).

--- a/source/elements/oneMKL/source/domains/lapack/ormtr.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ormtr.rst
@@ -42,7 +42,7 @@ ormtr (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void ormtr(cl::sycl::queue &queue, onemkl::side left_right, onemkl::uplo upper_lower, onemkl::transpose trans, std::int64_t m, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &c, std::int64_t ldc, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void ormtr(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &c, std::int64_t ldc, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -159,7 +159,7 @@ ormtr (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event ormtr(cl::sycl::queue &queue, onemkl::side left_right, onemkl::uplo upper_lower, onemkl::transpose trans, std::int64_t m, std::int64_t n, T *a, std::int64_t lda, T *tau, T *c, std::int64_t ldc, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event ormtr(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, T *a, std::int64_t lda, T *tau, T *c, std::int64_t ldc, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/ormtr.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ormtr.rst
@@ -28,7 +28,7 @@ where :math:`Q` is the orthogonal matrix :math:`Q` formed by:ref:`onemkl_lapack_
 when reducing a real symmetric matrix :math:`A` to tridiagonal form:
 :math:`A = QTQ^T`. Use this routine after a call to :ref:`onemkl_lapack_sytrd`.
 
-Depending on the parameters left_right and trans, the routine can
+Depending on the parameters side and trans, the routine can
 form one of the matrix products :math:`QC`, :math:`Q^TC`, :math:`CQ`, or
 :math:`CQ^T` (overwriting the result on :math:`C`).
 
@@ -42,7 +42,7 @@ ormtr (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void ormtr(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &c, std::int64_t ldc, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void ormtr(cl::sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &c, std::int64_t ldc, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -57,20 +57,20 @@ In the descriptions below, ``r`` denotes the order of :math:`Q`:
         :header-rows: 1
 
         * -  :math:`r = m` 
-          -  if ``left_right = side::left`` 
+          -  if ``side = side::left`` 
         * -  :math:`r = n` 
-          -  if ``left_right = side::right`` 
+          -  if ``side = side::right`` 
 
 queue
    The queue where the routine should be executed.
 
-left_right
+side
    Must be either ``side::left`` or ``side::right``.
 
-   If ``left_right = side::left``, :math:`Q` or :math:`Q^{T}` is
+   If ``side = side::left``, :math:`Q` or :math:`Q^{T}` is
    applied to :math:`C` from the left.
 
-   If ``left_right = side::right``, :math:`Q` or :math:`Q^{T}` is
+   If ``side = side::right``, :math:`Q` or :math:`Q^{T}` is
    applied to :math:`C` from the right.
 
 upper_lower
@@ -120,7 +120,7 @@ scratchpad_size
 
 c
    Overwritten by the product :math:`QC`, :math:`Q^TC`, :math:`CQ`, or :math:`CQ^T`
-   (as specified by ``left_right`` and ``trans``).
+   (as specified by ``side`` and ``trans``).
 
 scratchpad
    Buffer holding scratchpad memory to be used by routine for storing intermediate results.
@@ -159,7 +159,7 @@ ormtr (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event ormtr(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, T *a, std::int64_t lda, T *tau, T *c, std::int64_t ldc, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event ormtr(cl::sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, T *a, std::int64_t lda, T *tau, T *c, std::int64_t ldc, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section
@@ -174,20 +174,20 @@ In the descriptions below, ``r`` denotes the order of :math:`Q`:
         :header-rows: 1
 
         * -  :math:`r = m` 
-          -  if ``left_right = side::left`` 
+          -  if ``side = side::left`` 
         * -  :math:`r = n` 
-          -  if ``left_right = side::right`` 
+          -  if ``side = side::right`` 
 
 queue
    The queue where the routine should be executed.
 
-left_right
+side
    Must be either ``side::left`` or ``side::right``.
 
-   If ``left_right = side::left``, :math:`Q` or :math:`Q^{T}` is
+   If ``side = side::left``, :math:`Q` or :math:`Q^{T}` is
    applied to :math:`C` from the left.
 
-   If ``left_right = side::right``, :math:`Q` or :math:`Q^{T}` is
+   If ``side = side::right``, :math:`Q` or :math:`Q^{T}` is
    applied to :math:`C` from the right.
 
 upper_lower
@@ -239,7 +239,7 @@ events
 
 c
    Overwritten by the product :math:`QC`, :math:`Q^TC`, :math:`CQ`, or :math:`CQ^T`
-   (as specified by ``left_right`` and ``trans``).
+   (as specified by ``side`` and ``trans``).
 
 scratchpad
    Pointer to scratchpad memory to be used by routine for storing intermediate results.

--- a/source/elements/oneMKL/source/domains/lapack/ormtr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ormtr_scratchpad_size.rst
@@ -37,7 +37,7 @@ ormtr_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t ormtr_scratchpad_size(cl::sycl::queue &queue, onemkl::side left_right, onemkl::uplo upper_lower, onemkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t lda, std::int64_t ldc) 
+      std::int64_t ormtr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t lda, std::int64_t ldc) 
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/ormtr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ormtr_scratchpad_size.rst
@@ -37,7 +37,7 @@ ormtr_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t ormtr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t lda, std::int64_t ldc) 
+      std::int64_t ormtr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t lda, std::int64_t ldc) 
     }
 
 .. container:: section
@@ -52,20 +52,20 @@ In the descriptions below, ``r`` denotes the order of :math:`Q`:
         :header-rows: 1
 
         * -  :math:`r = m` 
-          -  if ``left_right = side::left`` 
+          -  if ``side = side::left`` 
         * -  :math:`r = n` 
-          -  if ``left_right = side::right`` 
+          -  if ``side = side::right`` 
 
 queue
    Device queue where calculations by :ref:`onemkl_lapack_ormtr` function will be performed.
 
-left_right
+side
    Must be either ``side::left`` or ``side::right``.
 
-   If ``left_right = side::left``, :math:`Q` or :math:`Q^{T}` is
+   If ``side = side::left``, :math:`Q` or :math:`Q^{T}` is
    applied to :math:`C` from the left.
 
-   If ``left_right = side::right``, :math:`Q` or :math:`Q^{T}` is
+   If ``side = side::right``, :math:`Q` or :math:`Q^{T}` is
    applied to :math:`C` from the right.
 
 upper_lower

--- a/source/elements/oneMKL/source/domains/lapack/potrf.rst
+++ b/source/elements/oneMKL/source/domains/lapack/potrf.rst
@@ -33,9 +33,9 @@ matrix :math:`A`:
        :header-rows: 1
  
        * -  :math:`A` = :math:`U^{T}U` for real data, :math:`A = U^{H}U` for complex data
-         -  if upper_lower=\ ``onemkl::uplo::upper`` 
+         -  if upper_lower=\ ``oneapi::mkl::uplo::upper`` 
        * -  :math:`A` = :math:`LL^{T}` for real data, :math:`A = LL^{H}` for complex data
-         -  if upper_lower=\ ``onemkl::uplo::lower`` 
+         -  if upper_lower=\ ``oneapi::mkl::uplo::lower`` 
 
 where :math:`L` is a lower triangular matrix and :math:`U` is upper
 triangular.
@@ -50,7 +50,7 @@ potrf (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void potrf(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void potrf(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -64,11 +64,11 @@ upper_lower
    Indicates whether the upper or lower triangular part of :math:`A` is
    stored and how :math:`A` is factored:
 
-   If upper_lower=\ ``onemkl::uplo::upper``, the array ``a`` stores the
+   If upper_lower=\ ``oneapi::mkl::uplo::upper``, the array ``a`` stores the
    upper triangular part of the matrix :math:`A`, and the strictly lower
    triangular part of the matrix is not referenced.
 
-   If upper_lower=\ ``onemkl::uplo::lower``, the array ``a`` stores the
+   If upper_lower=\ ``oneapi::mkl::uplo::lower``, the array ``a`` stores the
    lower triangular part of the matrix :math:`A`, and the strictly upper
    triangular part of the matrix is not referenced.
 
@@ -138,7 +138,7 @@ potrf (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event potrf(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event potrf(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section
@@ -152,11 +152,11 @@ upper_lower
    Indicates whether the upper or lower triangular part of :math:`A` is
    stored and how :math:`A` is factored:
 
-   If upper_lower=\ ``onemkl::uplo::upper``, the array ``a`` stores the
+   If upper_lower=\ ``oneapi::mkl::uplo::upper``, the array ``a`` stores the
    upper triangular part of the matrix :math:`A`, and the strictly lower
    triangular part of the matrix is not referenced.
 
-   If upper_lower=\ ``onemkl::uplo::lower``, the array ``a`` stores the
+   If upper_lower=\ ``oneapi::mkl::uplo::lower``, the array ``a`` stores the
    lower triangular part of the matrix :math:`A`, and the strictly upper
    triangular part of the matrix is not referenced.
 

--- a/source/elements/oneMKL/source/domains/lapack/potrf_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/potrf_scratchpad_size.rst
@@ -38,7 +38,7 @@ potrf_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t potrf_scratchpad_size(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
+      std::int64_t potrf_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
     }
 
 .. container:: section
@@ -52,11 +52,11 @@ upper_lower
    Indicates whether the upper or lower triangular part of :math:`A` is
    stored and how :math:`A` is factored:
 
-   If ``upper_lower = onemkl::uplo::upper``, the array ``a`` stores the
+   If ``upper_lower = oneapi::mkl::uplo::upper``, the array ``a`` stores the
    upper triangular part of the matrix :math:`A`, and the strictly lower
    triangular part of the matrix is not referenced.
 
-   If ``upper_lower = onemkl::uplo::lower``, the array ``a`` stores the
+   If ``upper_lower = oneapi::mkl::uplo::lower``, the array ``a`` stores the
    lower triangular part of the matrix :math:`A`, and the strictly upper
    triangular part of the matrix is not referenced.
 

--- a/source/elements/oneMKL/source/domains/lapack/potri.rst
+++ b/source/elements/oneMKL/source/domains/lapack/potri.rst
@@ -40,7 +40,7 @@ potri (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void potri(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void potri(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -53,9 +53,9 @@ queue
 upper_lower
    Indicates how the input matrix :math:`A` has been    factored:
 
-   If ``upper_lower = onemkl::uplo::upper``, the upper   triangle of :math:`A` is stored.
+   If ``upper_lower = oneapi::mkl::uplo::upper``, the upper   triangle of :math:`A` is stored.
 
-   If   ``upper_lower = onemkl::uplo::lower``, the lower triangle of :math:`A` is   stored.
+   If   ``upper_lower = oneapi::mkl::uplo::lower``, the lower triangle of :math:`A` is   stored.
 
 n
    Specifies the order of the matrix    :math:`A` (:math:`0 \le n`).
@@ -117,7 +117,7 @@ potri (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event potri(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event potri(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section
@@ -130,9 +130,9 @@ queue
 upper_lower
    Indicates how the input matrix :math:`A` has been    factored:
 
-   If ``upper_lower = onemkl::uplo::upper``, the upper   triangle of :math:`A` is stored.
+   If ``upper_lower = oneapi::mkl::uplo::upper``, the upper   triangle of :math:`A` is stored.
 
-   If   ``upper_lower = onemkl::uplo::lower``, the lower triangle of :math:`A` is   stored.
+   If   ``upper_lower = oneapi::mkl::uplo::lower``, the lower triangle of :math:`A` is   stored.
 
 n
    Specifies the order of the matrix    :math:`A` (:math:`0 \le n`).

--- a/source/elements/oneMKL/source/domains/lapack/potri_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/potri_scratchpad_size.rst
@@ -38,7 +38,7 @@ potri_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t potri_scratchpad_size(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
+      std::int64_t potri_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
     }
 
 .. container:: section
@@ -51,9 +51,9 @@ queue
 upper_lower
    Indicates how the input matrix :math:`A` has been    factored:
 
-   If ``upper_lower = onemkl::uplo::upper``, the upper   triangle of :math:`A` is stored.
+   If ``upper_lower = oneapi::mkl::uplo::upper``, the upper   triangle of :math:`A` is stored.
 
-   If   ``upper_lower = onemkl::uplo::lower``, the lower triangle of :math:`A` is   stored.
+   If   ``upper_lower = oneapi::mkl::uplo::lower``, the lower triangle of :math:`A` is   stored.
 
 n
    Specifies the order of the matrix    :math:`A` (:math:`0 \le n`).

--- a/source/elements/oneMKL/source/domains/lapack/potrs.rst
+++ b/source/elements/oneMKL/source/domains/lapack/potrs.rst
@@ -34,9 +34,9 @@ factorization of :math:`A`:
    :header-rows: 1
 
    * -  :math:`A = U^TU` for real data, :math:`A = U^HU` for complex data
-     -  if ``upper_lower=onemkl::uplo::upper``
+     -  if ``upper_lower=oneapi::mkl::uplo::upper``
    * -  :math:`A = LL^T` for real data, :math:`A = LL^H` for complex data
-     -  if ``upper_lower=onemkl::uplo::lower``
+     -  if ``upper_lower=oneapi::mkl::uplo::lower``
 
 where :math:`L` is a lower triangular matrix and :math:`U` is upper
 triangular. The system is solved with multiple right-hand sides
@@ -55,7 +55,7 @@ potrs (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void potrs(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, std::int64_t nrhs, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &b, std::int64_t ldb, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void potrs(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t nrhs, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &b, std::int64_t ldb, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -68,9 +68,9 @@ queue
 upper_lower
    Indicates how the input matrix has been factored:
 
-   If ``upper_lower = onemkl::uplo::upper``, the upper triangle   :math:`U` of :math:`A` is stored, where :math:`A` = :math:`U^{T}`U`   for real data, :math:`A` = :math:`U^{H}U` for complex data.
+   If ``upper_lower = oneapi::mkl::uplo::upper``, the upper triangle   :math:`U` of :math:`A` is stored, where :math:`A` = :math:`U^{T}`U`   for real data, :math:`A` = :math:`U^{H}U` for complex data.
 
-   If ``upper_lower = onemkl::uplo::lower``, the lower triangle   :math:`L` of :math:`A` is stored, where :math:`A` = :math:`LL^{T}`   for real data, :math:`A` = :math:`LL^{H}` for complex   data.
+   If ``upper_lower = oneapi::mkl::uplo::lower``, the lower triangle   :math:`L` of :math:`A` is stored, where :math:`A` = :math:`LL^{T}`   for real data, :math:`A` = :math:`LL^{H}` for complex   data.
 
 n
    The order of matrix :math:`A` (:math:`0 \le n`).\
@@ -140,7 +140,7 @@ potrs (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event potrs(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, std::int64_t nrhs, T *a, std::int64_t lda, T *b, std::int64_t ldb, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event potrs(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t nrhs, T *a, std::int64_t lda, T *b, std::int64_t ldb, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section
@@ -153,9 +153,9 @@ queue
 upper_lower
    Indicates how the input matrix has been factored:
 
-   If ``upper_lower = onemkl::uplo::upper``, the upper triangle   :math:`U` of :math:`A` is stored, where :math:`A` = :math:`U^{T}U`   for real data, :math:`A` = :math:`U^{H}U` for complex data.
+   If ``upper_lower = oneapi::mkl::uplo::upper``, the upper triangle   :math:`U` of :math:`A` is stored, where :math:`A` = :math:`U^{T}U`   for real data, :math:`A` = :math:`U^{H}U` for complex data.
 
-   If ``upper_lower = onemkl::uplo::lower``, the lower triangle   :math:`L` of :math:`A` is stored, where :math:`A` = :math:`LL^{T}`   for real data, :math:`A` = :math:`LL^{H}` for complex   data.
+   If ``upper_lower = oneapi::mkl::uplo::lower``, the lower triangle   :math:`L` of :math:`A` is stored, where :math:`A` = :math:`LL^{T}`   for real data, :math:`A` = :math:`LL^{H}` for complex   data.
 
 n
    The order of matrix :math:`A` (:math:`0 \le n`).\

--- a/source/elements/oneMKL/source/domains/lapack/potrs_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/potrs_scratchpad_size.rst
@@ -38,7 +38,7 @@ potrs_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t potrs_scratchpad_size(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, std::int64_t nrhs, std::int64_t lda, std::int64_t ldb) 
+      std::int64_t potrs_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t nrhs, std::int64_t lda, std::int64_t ldb) 
     }
 
 .. container:: section
@@ -51,9 +51,9 @@ queue
 upper_lower
    Indicates how the input matrix has been factored:
 
-   If ``upper_lower = onemkl::uplo::upper``, the upper triangle   :math:`U` of :math:`A` is stored, where :math:`A = U^{T}U`   for real data, :math:`A = U^{H}U` for complex data.
+   If ``upper_lower = oneapi::mkl::uplo::upper``, the upper triangle   :math:`U` of :math:`A` is stored, where :math:`A = U^{T}U`   for real data, :math:`A = U^{H}U` for complex data.
 
-   If ``upper_lower = onemkl::uplo::lower``, the lower triangle   :math:`L` of :math:`A` is stored, where :math:`A = LL^{T}`   for real data, :math:`A = LL^{H}` for complex   data.
+   If ``upper_lower = oneapi::mkl::uplo::lower``, the lower triangle   :math:`L` of :math:`A` is stored, where :math:`A = LL^{T}`   for real data, :math:`A = LL^{H}` for complex   data.
 
 n
    The order of matrix :math:`A` (:math:`0 \le n`).

--- a/source/elements/oneMKL/source/domains/lapack/syevd.rst
+++ b/source/elements/oneMKL/source/domains/lapack/syevd.rst
@@ -48,7 +48,7 @@ syevd (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void syevd(cl::sycl::queue &queue, jobz jobz, onemkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &w, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void syevd(cl::sycl::queue &queue, jobz jobz, oneapi::mkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &w, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -127,12 +127,12 @@ This routine shall throw the following exceptions if the associated condition is
 
    If :math:`\text{info}=-i`, the :math:`i`-th parameter had an illegal value.
 
-   If :math:`\text{info}=i`, and ``jobz = onemkl::job::novec``, then the algorithm
+   If :math:`\text{info}=i`, and ``jobz = oneapi::mkl::job::novec``, then the algorithm
    failed to converge; :math:`i` indicates the number of off-diagonal
    elements of an intermediate tridiagonal form which did not
    converge to zero.
 
-   If :math:`\text{info}=i`, and ``jobz = onemkl::job::vec``, then the algorithm failed
+   If :math:`\text{info}=i`, and ``jobz = oneapi::mkl::job::vec``, then the algorithm failed
    to compute an eigenvalue while working on the submatrix lying in
    rows and columns :math:`\text{info}/(n+1)` through :math:`\text{mod}(\text{info},n+1)`.
 
@@ -148,7 +148,7 @@ syevd (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event syevd(cl::sycl::queue &queue, jobz jobz, onemkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *w, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event syevd(cl::sycl::queue &queue, jobz jobz, oneapi::mkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *w, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section
@@ -230,12 +230,12 @@ This routine shall throw the following exceptions if the associated condition is
 
    If :math:`\text{info}=-i`, the :math:`i`-th parameter had an illegal value.
 
-   If :math:`\text{info}=i`, and ``jobz = onemkl::job::novec``, then the algorithm
+   If :math:`\text{info}=i`, and ``jobz = oneapi::mkl::job::novec``, then the algorithm
    failed to converge; :math:`i` indicates the number of off-diagonal
    elements of an intermediate tridiagonal form which did not
    converge to zero.
 
-   If :math:`\text{info}=i`, and ``jobz = onemkl::job::vec``, then the algorithm failed
+   If :math:`\text{info}=i`, and ``jobz = oneapi::mkl::job::vec``, then the algorithm failed
    to compute an eigenvalue while working on the submatrix lying in
    rows and columns :math:`\text{info}/(n+1)` through :math:`\text{mod}(\text{info},n+1)`.
 

--- a/source/elements/oneMKL/source/domains/lapack/syevd_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/syevd_scratchpad_size.rst
@@ -36,7 +36,7 @@ syevd_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t syevd_scratchpad_size(cl::sycl::queue &queue, onemkl::job jobz, onemkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
+      std::int64_t syevd_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/sygvd.rst
+++ b/source/elements/oneMKL/source/domains/lapack/sygvd.rst
@@ -45,7 +45,7 @@ sygvd (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void sygvd(cl::sycl::queue &queue, std::int64_t itype, onemkl::job jobz, onemkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &b, std::int64_t ldb, cl::sycl::buffer<T,1> &w, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void sygvd(cl::sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz, oneapi::mkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &b, std::int64_t ldb, cl::sycl::buffer<T,1> &w, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -159,12 +159,12 @@ This routine shall throw the following exceptions if the associated condition is
 
    For :math:`\text{info} \le n`:
 
-      If :math:`\text{info}=i`, and ``jobz = onemkl::job::novec``, then the algorithm
+      If :math:`\text{info}=i`, and ``jobz = oneapi::mkl::job::novec``, then the algorithm
       failed to converge; :math:`i` indicates the number of off-diagonal
       elements of an intermediate tridiagonal form which did not
       converge to zero.
 
-      If :math:`\text{info}=i`, and ``jobz = onemkl::job::vec``, then the algorithm
+      If :math:`\text{info}=i`, and ``jobz = oneapi::mkl::job::vec``, then the algorithm
       failed to compute an eigenvalue while working on the submatrix
       lying in rows and columns :math:`\text{info}/(n+1)` through
       :math:`\text{mod}(\text{info},n+1)`.
@@ -188,7 +188,7 @@ sygvd (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event sygvd(cl::sycl::queue &queue, std::int64_t itype, onemkl::job jobz, onemkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *b, std::int64_t ldb, T *w, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event sygvd(cl::sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz, oneapi::mkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *b, std::int64_t ldb, T *w, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section
@@ -305,12 +305,12 @@ This routine shall throw the following exceptions if the associated condition is
 
    For :math:`\text{info} \le n`:
 
-      If :math:`\text{info}=i`, and ``jobz = onemkl::job::novec``, then the algorithm
+      If :math:`\text{info}=i`, and ``jobz = oneapi::mkl::job::novec``, then the algorithm
       failed to converge; :math:`i` indicates the number of off-diagonal
       elements of an intermediate tridiagonal form which did not
       converge to zero.
 
-      If :math:`\text{info}=i`, and ``jobz = onemkl::job::vec``, then the algorithm
+      If :math:`\text{info}=i`, and ``jobz = oneapi::mkl::job::vec``, then the algorithm
       failed to compute an eigenvalue while working on the submatrix
       lying in rows and columns :math:`\text{info}/(n+1)` through
       :math:`\text{mod}(\text{info},n+1)`.

--- a/source/elements/oneMKL/source/domains/lapack/sygvd_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/sygvd_scratchpad_size.rst
@@ -36,7 +36,7 @@ sygvd_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t sygvd_scratchpad_size(cl::sycl::queue &queue, std::int64_t itype, onemkl::job jobz, onemkl::uplo upper_lower, std::int64_t n, std::int64_t lda, std::int64_t ldb) 
+      std::int64_t sygvd_scratchpad_size(cl::sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t lda, std::int64_t ldb) 
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/sytrd.rst
+++ b/source/elements/oneMKL/source/domains/lapack/sytrd.rst
@@ -38,7 +38,7 @@ sytrd (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void sytrd(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &d, cl::sycl::buffer<T,1> &e, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void sytrd(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &d, cl::sycl::buffer<T,1> &e, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -144,7 +144,7 @@ sytrd (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event sytrd(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *d, T *e, T *tau, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event sytrd(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *d, T *e, T *tau, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/sytrd_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/sytrd_scratchpad_size.rst
@@ -36,7 +36,7 @@ sytrd_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t sytrd_scratchpad_size(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
+      std::int64_t sytrd_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/sytrf.rst
+++ b/source/elements/oneMKL/source/domains/lapack/sytrf.rst
@@ -49,7 +49,7 @@ sytrf (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void sytrf(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<int_64,1> &ipiv, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void sytrf(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<int_64,1> &ipiv, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -89,9 +89,9 @@ a
 ipiv
    Buffer, size at least :math:`\max(1, n)`. Contains details of    the interchanges and the block structure of :math:`D`. If   :math:`\text{ipiv}(i)=k>0`, then :math:`d_{ii}` is a :math:`1 \times 1` block, and the   :math:`i`-th row and column of :math:`A` was interchanged with the :math:`k`-th   row and column.
 
-      If ``upper_lower=onemkl::uplo::upper``   and :math:`\text{ipiv}(i)=\text{ipiv}(i-1)=-m<0`, then :math:`D` has a :math:`2 \times 2` block in   rows/columns :math:`i` and :math:`i`-1, and (:math:`i-1`)-th row and column of   :math:`A` was interchanged with the :math:`m`-th row and   column.
+      If ``upper_lower=oneapi::mkl::uplo::upper``   and :math:`\text{ipiv}(i)=\text{ipiv}(i-1)=-m<0`, then :math:`D` has a :math:`2 \times 2` block in   rows/columns :math:`i` and :math:`i`-1, and (:math:`i-1`)-th row and column of   :math:`A` was interchanged with the :math:`m`-th row and   column.
 
-      If ``upper_lower=onemkl::uplo::lower`` and   :math:`\text{ipiv}(i)=\text{ipiv}(i+1)=-m<0`, then :math:`D` has a :math:`2 \times 2` block in   rows/columns :math:`i` and :math:`i+1`, and (:math:`i+1`)-th row and column   of :math:`A` was interchanged with the :math:`m`-th row and column.
+      If ``upper_lower=oneapi::mkl::uplo::lower`` and   :math:`\text{ipiv}(i)=\text{ipiv}(i+1)=-m<0`, then :math:`D` has a :math:`2 \times 2` block in   rows/columns :math:`i` and :math:`i+1`, and (:math:`i+1`)-th row and column   of :math:`A` was interchanged with the :math:`m`-th row and column.
 
 scratchpad
    Buffer holding scratchpad memory to be used by routine for storing intermediate results.
@@ -132,7 +132,7 @@ sytrf (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event sytrf(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, int_64 *ipiv, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event sytrf(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, int_64 *ipiv, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section
@@ -175,9 +175,9 @@ a
 ipiv
    Pointer to array of size at least :math:`\max(1, n)`. Contains details of    the interchanges and the block structure of :math:`D`. If   :math:`\text{ipiv}(i)=k>0`, then :math:`d_{ii}` is a :math:`1 \times 1` block, and the   :math:`i`-th row and column of :math:`A` was interchanged with the :math:`k`-th   row and column.
 
-      If ``upper_lower=onemkl::uplo::upper``   and :math:`\text{ipiv}(i)=\text{ipiv}(i-1)=-m<0`, then :math:`D` has a :math:`2 \times 2` block in   rows/columns :math:`i` and :math:`i-1`, and (:math:`i-1`)-th row and column of   :math:`A` was interchanged with the :math:`m`-th row and   column.
+      If ``upper_lower=oneapi::mkl::uplo::upper``   and :math:`\text{ipiv}(i)=\text{ipiv}(i-1)=-m<0`, then :math:`D` has a :math:`2 \times 2` block in   rows/columns :math:`i` and :math:`i-1`, and (:math:`i-1`)-th row and column of   :math:`A` was interchanged with the :math:`m`-th row and   column.
       
-      If ``upper_lower=onemkl::uplo::lower`` and   :math:`\text{ipiv}(i)=\text{ipiv}(i+1)=-m<0`, then :math:`D` has a :math:`2 \times 2` block in   rows/columns :math:`i` and :math:`i+1`, and (:math:`i+1`)-th row and column   of :math:`A` was interchanged with the :math:`m`-th row and column.
+      If ``upper_lower=oneapi::mkl::uplo::lower`` and   :math:`\text{ipiv}(i)=\text{ipiv}(i+1)=-m<0`, then :math:`D` has a :math:`2 \times 2` block in   rows/columns :math:`i` and :math:`i+1`, and (:math:`i+1`)-th row and column   of :math:`A` was interchanged with the :math:`m`-th row and column.
 
 scratchpad
    Pointer to scratchpad memory to be used by routine for storing intermediate results.

--- a/source/elements/oneMKL/source/domains/lapack/sytrf_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/sytrf_scratchpad_size.rst
@@ -39,7 +39,7 @@ sytrf_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t sytrf_scratchpad_size(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
+      std::int64_t sytrf_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/trtrs.rst
+++ b/source/elements/oneMKL/source/domains/lapack/trtrs.rst
@@ -52,7 +52,7 @@ trtrs (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void trtrs(cl::sycl::queue &queue, onemkl::uplo upper_lower, onemkl::transpose transa, onemkl::diag unit_diag, std::int64_t n, std::int64_t nrhs, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &b, std::int64_t ldb, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void trtrs(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa, oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t nrhs, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &b, std::int64_t ldb, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -147,7 +147,7 @@ trtrs (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event trtrs(cl::sycl::queue &queue, onemkl::uplo upper_lower, onemkl::transpose transa, onemkl::diag unit_diag, std::int64_t n, std::int64_t nrhs, T *a, std::int64_t lda, T *b, std::int64_t ldb, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event trtrs(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa, oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t nrhs, T *a, std::int64_t lda, T *b, std::int64_t ldb, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/trtrs_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/trtrs_scratchpad_size.rst
@@ -38,7 +38,7 @@ trtrs_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t trtrs_scratchpad_size(cl::sycl::queue &queue, onemkl::uplo upper_lower, onemkl::transpose trans, onemkl::diag diag, std::int64_t n, std::int64_t nrhs, std::int64_t lda, std::int64_t ldb) 
+      std::int64_t trtrs_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs, std::int64_t lda, std::int64_t ldb) 
     }
 
 .. container:: section
@@ -58,17 +58,17 @@ upper_lower
 trans
    Indicates the form of the equations:
 
-   If ``trans=onemkl::transpose::nontrans``, then :math:`AX = B` is solved
+   If ``trans=oneapi::mkl::transpose::nontrans``, then :math:`AX = B` is solved
    for :math:`X`.
 
-   If ``trans=onemkl::transpose::trans``, then :math:`A^TX = B` is solved
+   If ``trans=oneapi::mkl::transpose::trans``, then :math:`A^TX = B` is solved
    for :math:`X`.
 
-   If ``trans=onemkl::transpose::conjtrans``, then :math:`A^HX = B` is
+   If ``trans=oneapi::mkl::transpose::conjtrans``, then :math:`A^HX = B` is
    solved for :math:`X`.
 
 diag
-   If diag = ``onemkl::diag::nonunit``, then :math:`A` is not a    unit triangular matrix.
+   If diag = ``oneapi::mkl::diag::nonunit``, then :math:`A` is not a    unit triangular matrix.
 
    If unit_diag = ``diag::unit``,   then :math:`A` is unit triangular: diagonal elements of :math:`A` are assumed   to be 1 and not referenced in the array ``a``.
 

--- a/source/elements/oneMKL/source/domains/lapack/ungbr.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ungbr.rst
@@ -67,7 +67,7 @@ ungbr (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void ungbr(cl::sycl::queue &queue, onemkl::generate gen, std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void ungbr(cl::sycl::queue &queue, oneapi::mkl::generate gen, std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -171,7 +171,7 @@ ungbr (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event ungbr(cl::sycl::queue &queue, onemkl::generate gen, std::int64_t m, std::int64_t n, std::int64_t k, T *a, std::int64_t lda, T *tau, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event ungbr(cl::sycl::queue &queue, oneapi::mkl::generate gen, std::int64_t m, std::int64_t n, std::int64_t k, T *a, std::int64_t lda, T *tau, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/ungbr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ungbr_scratchpad_size.rst
@@ -36,7 +36,7 @@ ungbr_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t ungbr_scratchpad_size(cl::sycl::queue &queue, onemkl::generate gen, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t &scratchpad_size) 
+      std::int64_t ungbr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::generate gen, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t &scratchpad_size) 
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/ungtr.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ungtr.rst
@@ -39,7 +39,7 @@ ungtr (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void ungtr(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void ungtr(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -118,7 +118,7 @@ ungtr (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event ungtr(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *tau, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event ungtr(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, T *a, std::int64_t lda, T *tau, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/ungtr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ungtr_scratchpad_size.rst
@@ -36,7 +36,7 @@ ungtr_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t ungtr_scratchpad_size(cl::sycl::queue &queue, onemkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
+      std::int64_t ungtr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t lda) 
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/unmqr.rst
+++ b/source/elements/oneMKL/source/domains/lapack/unmqr.rst
@@ -8,29 +8,30 @@ unmqr
 =====
 
 Multiplies a complex matrix by the unitary matrix :math:`Q` of the QR
-factorization formed by :ref:`onemkl_lapack_unmqr`.
+factorization formed by :ref:`onemkl_lapack_geqrf`.
 
 .. container:: section
 
   .. rubric:: Description
-      
+
 ``unmqr`` supports the following precisions.
 
-     .. list-table:: 
-        :header-rows: 1
+    .. list-table::
+       :header-rows: 1
 
-        * -  T 
-        * -  ``std::complex<float>`` 
-        * -  ``std::complex<double>`` 
+       * -  T
+       * -  ``std::complex<float>``
+       * -  ``std::complex<double>``
 
-The routine multiplies a rectangular complex matrix :math:`C \times Q` or
-:math:`Q^{H}`, where :math:`Q` is the unitary matrix :math:`Q` of the
-``QR`` factorization formed by the routines
-:ref:`onemkl_lapack_geqrf`.
+The routine multiplies a rectangular complex :math:`m \times n` matrix :math:`C` by
+:math:`Q` or :math:`Q^H`, where :math:`Q` is the complex unitary matrix defined
+as a product of :math:`k` elementary reflectors :math:`H(i)` of order :math:`n`:
+:math:`Q = H(1)^HH(2)^H ... H(k)^H` as returned by the RQ factorization routine
+:ref:`onemkl_lapack_gerqf`.
 
-Depending on the parameters ``left_right`` and ``trans``, the routine
-can form one of the matrix products :math:`QC`, :math:`Q^{H}C`,
-:math:`CQ`, or :math:`CQ^{H}` (overwriting the result on :math:`C`).
+Depending on the parameters ``side`` and ``trans``, the routine can form one of
+the matrix products :math:`QC`, :math:`Q^HC`, :math:`CQ`, or :math:`CQ^H`
+(overwriting the result over :math:`C`).
 
 unmqr (Buffer Version)
 ----------------------
@@ -42,73 +43,76 @@ unmqr (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void unmqr(cl::sycl::queue &queue, onemkl::side left_right, onemkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &c, std::int64_t ldc, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void unmqr(cl::sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &c, std::int64_t ldc, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
 
   .. rubric:: Input Parameters
-      
+
 queue
-   The queue where the routine should be executed.
+    The queue where the routine should be executed.
 
-left_right
-   If ``left_right=onemkl::side::left``, :math:`Q` or :math:`Q^{H}` is
-   applied to :math:`C` from the left.
+side
+    If ``side = oneapi::mkl::side::left``, :math:`Q` or :math:`Q^{H}` is applied
+    to :math:`C` from the left.
 
-   If ``left_right=onemkl::side::right``, :math:`Q` or :math:`Q^{H}` is
-   applied to :math:`C` from the right.
+    If ``side = oneapi::mkl::side::right``, :math:`Q` or :math:`Q^{H}` is
+    applied to :math:`C` from the right.
 
 trans
-   If ``trans=onemkl::transpose::trans``, the routine multiplies :math:`C`
-   by :math:`Q`.
+    If ``trans = oneapi::mkl::transpose::nontrans``, the routine multiplies
+    :math:`C` by :math:`Q`.
 
-   If ``trans=onemkl::transpose::nontrans``, the routine multiplies
-   :math:`C` by :math:`Q^H`.
+    If ``trans = oneapi::mkl::transpose::conjtrans``, the routine multiplies :math:`C`
+    by :math:`Q^{H}`.
 
 m
-   The number of rows in the matrix :math:`A` (:math:`m \ge 0`).
+    The number of rows in the matrix :math:`C` (:math:`0 \le m`).
 
 n
-   The number of columns in the matrix :math:`A` (:math:`0 \le n \le m`).
+    The number of columns in the matrix :math:`C` (:math:`0 \le n`).
 
 k
-   The number of elementary reflectors whose product defines the
-   matrix :math:`Q` (:math:`0 \le k \le n`).
+    The number of elementary reflectors whose product defines the
+    matrix :math:`Q` 
+
+    If ``side = oneapi::mkl::side::left``, :math:`0 \le k \le m`
+
+    If ``side = oneapi::mkl::side::right``, :math:`0 \le k \le n`
 
 a
-   The buffer ``a`` as returned by
-   :ref:`onemkl_lapack_geqrf`.
-   The second dimension of ``a`` must be at least :math:`\max(1,k)`.
+    The buffer ``a`` as returned by :ref:`onemkl_lapack_geqrf`.
+    The second dimension of ``a`` must be at least :math:`\max(1,k)`.
 
 lda
-   The leading dimension of ``a``.
+    The leading dimension of ``a``.
 
 tau
-   The buffer ``tau`` as returned by
-   :ref:`onemkl_lapack_geqrf`.
-   The second dimension of ``a`` must be at least :math:`\max(1,k)`.
+    The buffer ``tau`` as returned by :ref:`onemkl_lapack_geqrf`.
 
 c
-   The buffer ``c`` contains the matrix :math:`C`. The second dimension
-   of ``c`` must be at least :math:`\max(1,n)`.
+    The buffer ``c`` contains the matrix :math:`C`. The second dimension of
+    ``c`` must be at least :math:`\max(1,n)`.
 
 ldc
-   The leading dimension of ``c``.
+    The leading dimension of ``c``.
 
 scratchpad_size
-   Size of scratchpad memory as a number of floating point elements of type ``T``.
-   Size should not be less than the value returned by :ref:`onemkl_lapack_unmqr_scratchpad_size` function.
+    Size of scratchpad memory as a number of floating point elements of type
+    ``T``. Size should not be less than the value returned by the
+    :ref:`onemkl_lapack_unmqr_scratchpad_size` function.
 
 .. container:: section
 
   .. rubric:: Output Parameters
 
 c
-   Overwritten by the product :math:`QC`,   :math:`Q^{H}C`, :math:`CQ`, or :math:`CQ^H` (as specified by ``left_right`` and   ``trans``).
+    Overwritten by the product :math:`QC`, :math:`Q^{H}C`, :math:`CQ`, or
+    :math:`CQ^H` (as specified by ``side`` and ``trans``).
 
 scratchpad
-   Buffer holding scratchpad memory to be used by routine for storing intermediate results.
+    Buffer holding scratchpad memory to be used by routine for storing intermediate results.
 
 .. container:: section
 
@@ -128,11 +132,11 @@ This routine shall throw the following exceptions if the associated condition is
 
 :ref:`oneapi::mkl::lapack::computation_error<onemkl_lapack_exception_computation_error>`
 
-   Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
+    Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
 
-   If :math:`\text{info}=-i`, the :math:`i`-th parameter had an illegal value.
+    If :math:`\text{info}=-i`, the :math:`i`-th parameter had an illegal value.
 
-   If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
+    If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
 
 unmqr (USM Version)
 ----------------------
@@ -144,7 +148,7 @@ unmqr (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event unmqr(cl::sycl::queue &queue, onemkl::side left_right, onemkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, T *a, std::int64_t lda, T *tau, T *c, std::int64_t ldc, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event unmqr(cl::sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, T *a, std::int64_t lda, T *tau, T *c, std::int64_t ldc, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section
@@ -152,68 +156,71 @@ unmqr (USM Version)
   .. rubric:: Input Parameters
 
 queue
-   The queue where the routine should be executed.
+    The queue where the routine should be executed.
 
-left_right
-   If ``left_right=onemkl::side::left``, :math:`Q` or :math:`Q^{H}` is
-   applied to :math:`C` from the left.
+side
+    If ``side = oneapi::mkl::side::left``, :math:`Q` or :math:`Q^{H}` is applied
+    to :math:`C` from the left.
 
-   If ``left_right=onemkl::side::right``, :math:`Q` or :math:`Q^{H}` is
-   applied to :math:`C` from the right.
+    If ``side = oneapi::mkl::side::right``, :math:`Q` or :math:`Q^{H}` is
+    applied to :math:`C` from the right.
 
 trans
-   If ``trans=onemkl::transpose::trans``, the routine multiplies :math:`C`
-   by :math:`Q`.
+    If ``trans = oneapi::mkl::transpose::nontrans``, the routine multiplies
+    :math:`C` by :math:`Q`.
 
-   If ``trans=onemkl::transpose::nontrans``, the routine multiplies
-   :math:`C` by :math:`Q^H`.
+    If ``trans = oneapi::mkl::transpose::conjtrans``, the routine multiplies :math:`C`
+    by :math:`Q^{H}`.
 
 m
-   The number of rows in the matrix :math:`A` (:math:`m \ge 0`).
+    The number of rows in the matrix :math:`C` (:math:`0 \le m`).
 
 n
-   The number of columns in the matrix :math:`A` (:math:`0 \le n \le m`).
+    The number of columns in the matrix :math:`C` (:math:`0 \le n`).
 
 k
-   The number of elementary reflectors whose product defines the
-   matrix :math:`Q` (:math:`0 \le k \le n`).
+    The number of elementary reflectors whose product defines the
+    matrix :math:`Q`
+
+    If ``side = oneapi::mkl::side::left``, :math:`0 \le k \le m`
+
+    If ``side = oneapi::mkl::side::right``, :math:`0 \le k \le n`
 
 a
-   The pointer to ``a`` as returned by
-   :ref:`onemkl_lapack_geqrf`.
-   The second dimension of ``a`` must be at least :math:`\max(1,k)`.
+    The pointer to ``a`` as returned by :ref:`onemkl_lapack_geqrf`.
+    The second dimension of ``a`` must be at least :math:`\max(1,k)`.
 
 lda
-   The leading dimension of ``a``.
+    The leading dimension of ``a``.
 
 tau
-   The pointer to ``tau`` as returned by
-   :ref:`onemkl_lapack_geqrf`.
-   The second dimension of ``a`` must be at least :math:`\max(1,k)`.
+    The pointer to ``tau`` as returned by :ref:`onemkl_lapack_geqrf`.
 
 c
-   The array ``c`` contains the matrix :math:`C`. The second dimension
-   of ``c`` must be at least :math:`\max(1,n)`.
+    The pointer ``c`` points to the matrix :math:`C`. The second dimension of
+    ``c`` must be at least :math:`\max(1,n)`.
 
 ldc
-   The leading dimension of ``c``.
+    The leading dimension of ``c``.
 
 scratchpad_size
-   Size of scratchpad memory as a number of floating point elements of type ``T``.
-   Size should not be less than the value returned by :ref:`onemkl_lapack_unmqr_scratchpad_size` function.
+    Size of scratchpad memory as a number of floating point elements of type
+    ``T``. Size should not be less than the value returned by
+    :ref:`onemkl_lapack_unmqr_scratchpad_size` function.
 
 events
-   List of events to wait for before starting computation. Defaults to empty list.
+    List of events to wait for before starting computation. Defaults to empty list.
 
 .. container:: section
 
   .. rubric:: Output Parameters
-      
+
 c
-   Overwritten by the product :math:`QC`,   :math:`Q^{H}C`, :math:`CQ`, or :math:`CQ^{H}` (as specified by ``left_right`` and   ``trans``).
+    Overwritten by the product :math:`QC`, :math:`Q^{H}C`, :math:`CQ`, or
+    :math:`CQ^{H}` (as specified by ``side`` and ``trans``).
 
 scratchpad
-   Pointer to scratchpad memory to be used by routine for storing intermediate results.
+    Pointer to scratchpad memory to be used by routine for storing intermediate results.
 
 .. container:: section
 
@@ -233,11 +240,11 @@ This routine shall throw the following exceptions if the associated condition is
 
 :ref:`oneapi::mkl::lapack::computation_error<onemkl_lapack_exception_computation_error>`
 
-   Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
+    Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
 
-   If :math:`\text{info}=-i`, the :math:`i`-th parameter had an illegal value.
+    If :math:`\text{info}=-i`, the :math:`i`-th parameter had an illegal value.
 
-   If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
+    If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
 
 .. container:: section
 
@@ -246,5 +253,3 @@ This routine shall throw the following exceptions if the associated condition is
 Output event to wait on to ensure computation is complete.
 
 **Parent topic:** :ref:`onemkl_lapack-linear-equation-routines`
-
-

--- a/source/elements/oneMKL/source/domains/lapack/unmqr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/unmqr_scratchpad_size.rst
@@ -37,7 +37,7 @@ unmqr_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t unmqr_scratchpad_size(cl::sycl::queue &queue, onemkl::side left_right, onemkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t ldc, std::int64_t &scratchpad_size) 
+      std::int64_t unmqr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t ldc, std::int64_t &scratchpad_size) 
     }
 
 .. container:: section
@@ -48,17 +48,17 @@ queue
    Device queue where calculations by :ref:`onemkl_lapack_unmqr` function will be performed.
 
 left_right
-   If ``left_right=onemkl::side::left``, :math:`Q` or :math:`Q^{H}` is
+   If ``left_right=oneapi::mkl::side::left``, :math:`Q` or :math:`Q^{H}` is
    applied to :math:`C` from the left.
 
-   If ``left_right=onemkl::side::right``, :math:`Q` or :math:`Q^{H}` is
+   If ``left_right=oneapi::mkl::side::right``, :math:`Q` or :math:`Q^{H}` is
    applied to :math:`C` from the right.
 
 trans
-   If ``trans=onemkl::transpose::trans``, the routine multiplies
+   If ``trans=oneapi::mkl::transpose::trans``, the routine multiplies
    :math:`C` by :math:`Q`.
 
-   If ``trans=onemkl::transpose::conjtrans``, the routine multiplies
+   If ``trans=oneapi::mkl::transpose::conjtrans``, the routine multiplies
    :math:`C` by :math:`Q^H`.
 
 m

--- a/source/elements/oneMKL/source/domains/lapack/unmqr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/unmqr_scratchpad_size.rst
@@ -55,17 +55,17 @@ side
    applied to :math:`C` from the right.
 
 trans
-   If ``trans=oneapi::mkl::transpose::trans``, the routine multiplies
+   If ``trans=oneapi::mkl::transpose::nontrans``, the routine multiplies
    :math:`C` by :math:`Q`.
 
    If ``trans=oneapi::mkl::transpose::conjtrans``, the routine multiplies
    :math:`C` by :math:`Q^H`.
 
 m
-   The number of rows in the matrix :math:`A` (:math:`0 \le m`).
+   The number of rows in the matrix :math:`C` (:math:`0 \le m`).
 
 n
-   The number of columns the matrix :math:`A` (:math:`0 \le n \le m`).
+   The number of columns the matrix :math:`C` (:math:`0 \le n \le m`).
 
 k
    The number of elementary reflectors whose product defines the

--- a/source/elements/oneMKL/source/domains/lapack/unmqr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/unmqr_scratchpad_size.rst
@@ -37,7 +37,7 @@ unmqr_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t unmqr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t ldc, std::int64_t &scratchpad_size) 
+      std::int64_t unmqr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t ldc, std::int64_t &scratchpad_size) 
     }
 
 .. container:: section
@@ -47,11 +47,11 @@ unmqr_scratchpad_size
 queue
    Device queue where calculations by :ref:`onemkl_lapack_unmqr` function will be performed.
 
-left_right
-   If ``left_right=oneapi::mkl::side::left``, :math:`Q` or :math:`Q^{H}` is
+side
+   If ``side=oneapi::mkl::side::left``, :math:`Q` or :math:`Q^{H}` is
    applied to :math:`C` from the left.
 
-   If ``left_right=oneapi::mkl::side::right``, :math:`Q` or :math:`Q^{H}` is
+   If ``side=oneapi::mkl::side::right``, :math:`Q` or :math:`Q^{H}` is
    applied to :math:`C` from the right.
 
 trans

--- a/source/elements/oneMKL/source/domains/lapack/unmrq.rst
+++ b/source/elements/oneMKL/source/domains/lapack/unmrq.rst
@@ -7,24 +7,31 @@
 unmrq
 =====
 
-Multiplies a complex matrix by the unitary matrix :math:`Q` of the RQ factorization formed by :ref:`onemkl_lapack_gerqf`.
+Multiplies a complex matrix by the unitary matrix :math:`Q` of the RQ
+factorization formed by :ref:`onemkl_lapack_gerqf`.
 
 .. container:: section
 
   .. rubric:: Description
-      
+
 ``unmrq`` supports the following precisions.
 
-     .. list-table:: 
-        :header-rows: 1
+    .. list-table::
+       :header-rows: 1
 
-        * -  T 
-        * -  ``std::complex<float>`` 
-        * -  ``std::complex<double>`` 
+       * -  T
+       * -  ``std::complex<float>``
+       * -  ``std::complex<double>``
 
-The routine multiplies a complex :math:`m \times n` matrix :math:`C` by :math:`Q` or :math:`Q^H`, where :math:`Q` is the complex unitary matrix defined as a product of :math:`k` elementary reflectors :math:`H(i)` of order :math:`n`: :math:`Q = H(1)^HH(2)^H ... H(k)^H` Has returned by the RQ factorization routine :ref:`onemkl_lapack_gerqf`.
+The routine multiplies a rectangular complex :math:`m \times n` matrix :math:`C` by
+:math:`Q` or :math:`Q^H`, where :math:`Q` is the complex unitary matrix defined
+as a product of :math:`k` elementary reflectors :math:`H(i)` of order :math:`n`:
+:math:`Q = H(1)^HH(2)^H ... H(k)^H` as returned by the RQ factorization routine
+:ref:`onemkl_lapack_gerqf`.
 
-Depending on the parameters ``side`` and ``trans``, the routine can form one of the matrix products :math:`QC`, :math:`Q^HC`, :math:`CQ`, or :math:`CQ^H` (overwriting the result over :math:`C`).
+Depending on the parameters ``side`` and ``trans``, the routine can form one of
+the matrix products :math:`QC`, :math:`Q^HC`, :math:`CQ`, or :math:`CQ^H`
+(overwriting the result over :math:`C`).
 
 unmrq (Buffer Version)
 ----------------------
@@ -42,61 +49,75 @@ unmrq (Buffer Version)
 .. container:: section
 
   .. rubric:: Input Parameters
-      
+
 queue
-   Device queue where calculations will be performed.
+    The queue where the routine should be executed.
 
 side
-   If ``side = oneapi::mkl::side::left``, :math:`Q` or :math:`Q^T` is applied to :math:`C` from the left. 
-   
-   If ``side = oneapi::mkl::side::right``, :math:`Q` or :math:`Q^T` is applied to :math:`C` from the right.
+    If ``side = oneapi::mkl::side::left``, :math:`Q` or :math:`Q^{H}` is applied
+    to :math:`C` from the left.
+
+    If ``side = oneapi::mkl::side::right``, :math:`Q` or :math:`Q^{H}` is
+    applied to :math:`C` from the right.
 
 trans
-   If ``trans=oneapi::mkl::transpose::trans``, the routine multiplies :math:`C` by :math:`Q`.
+    If ``trans = oneapi::mkl::transpose::nontrans``, the routine multiplies
+    :math:`C` by :math:`Q`.
 
-   If ``trans=oneapi::mkl::transpose::nontrans``, the routine multiplies :math:`C` by :math:`Q^T`.
+    If ``trans = oneapi::mkl::transpose::conjtrans``, the routine multiplies :math:`C`
+    by :math:`Q^{H}`.
 
 m
-   The number of rows in the matrix :math:`A` (:math:`0 \le m`).
+    The number of rows in the matrix :math:`C` (:math:`0 \le m`).
 
 n
-   The number of columns in the matrix :math:`A` (:math:`0 \le n \le m`).
+    The number of columns in the matrix :math:`C` (:math:`0 \le n`).
 
 k
-   The number of elementary reflectors whose product defines the matrix :math:`Q` (:math:`0 \le k \le n`).
+    The number of elementary reflectors whose product defines the
+    matrix :math:`Q` 
+
+    If ``side = oneapi::mkl::side::left``, :math:`0 \le k \le m`
+
+    If ``side = oneapi::mkl::side::right``, :math:`0 \le k \le n`
 
 a
-   Buffer holding the result of the :ref:`onemkl_lapack_gerqf` function. The second dimension of ``a`` must be at least :math:`\max(1,k)`.
+    The buffer ``a`` as returned by :ref:`onemkl_lapack_gerqf`.
+    The second dimension of ``a`` must be at least :math:`\max(1,k)`.
 
 lda
-   The leading dimension of ``a``.
+    The leading dimension of ``a``.
 
 tau
-   Buffer holding ``tau`` returned by the :ref:`onemkl_lapack_gerqf` function.
+    The buffer ``tau`` as returned by :ref:`onemkl_lapack_gerqf`.
 
 c
-   Buffer holding the matrix :math:`C`. The second dimension of ``c`` must be at least :math:`\max(1,n)`.
+    The buffer ``c`` contains the matrix :math:`C`. The second dimension of
+    ``c`` must be at least :math:`\max(1,n)`.
 
 ldc
-   The leading dimension of ``c``.
-
-scratchpad
-   Buffer holding scratchpad memory to be used by the routine for storing intermediate results.
+    The leading dimension of ``c``.
 
 scratchpad_size
-   Size of scratchpad memory as a number of floating point elements of type ``T``. Size should not be less than the value returned by the unmrq_scratchpad_size function.
+    Size of scratchpad memory as a number of floating point elements of type
+    ``T``. Size should not be less than the value returned by
+    :ref:`onemkl_lapack_unmrq_scratchpad_size` function.
 
 .. container:: section
 
   .. rubric:: Output Parameters
-      
+
 c
-   Overwritten by the product :math:`QC`, :math:`Q^TC`, :math:`CQ`, or :math:`CQ^T` (as specified by ``side`` and ``trans``).
+    Overwritten by the product :math:`QC`, :math:`Q^{H}C`, :math:`CQ`, or
+    :math:`CQ^H` (as specified by ``side`` and ``trans``).
+
+scratchpad
+    Buffer holding scratchpad memory to be used by routine for storing intermediate results.
 
 .. container:: section
 
   .. rubric:: Throws
-         
+
 This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
 
 :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
@@ -111,11 +132,11 @@ This routine shall throw the following exceptions if the associated condition is
 
 :ref:`oneapi::mkl::lapack::computation_error<onemkl_lapack_exception_computation_error>`
 
-   Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
+    Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
 
-   If ``info = -i``, the :math:`i`-th parameter had an illegal value.
+    If :math:`\text{info}=-i`, the :math:`i`-th parameter had an illegal value.
 
-   If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
+    If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
 
 unmrq (USM Version)
 ----------------------
@@ -135,62 +156,76 @@ unmrq (USM Version)
   .. rubric:: Input Parameters
 
 queue
-   Device queue where calculations will be performed.
+    The queue where the routine should be executed.
 
 side
-   If ``side = oneapi::mkl::side::left``, :math:`Q` or :math:`Q^T` is applied to :math:`C` from the left. 
-   
-   If ``side = oneapi::mkl::side::right``, :math:`Q` or :math:`Q^T` is applied to :math:`C` from the right.
+    If ``side = oneapi::mkl::side::left``, :math:`Q` or :math:`Q^{H}` is applied
+    to :math:`C` from the left.
+
+    If ``side = oneapi::mkl::side::right``, :math:`Q` or :math:`Q^{H}` is
+    applied to :math:`C` from the right.
 
 trans
-   If ``trans=oneapi::mkl::transpose::trans``, the routine multiplies :math:`C` by :math:`Q`.
+    If ``trans = oneapi::mkl::transpose::nontrans``, the routine multiplies
+    :math:`C` by :math:`Q`.
 
-   If ``trans=oneapi::mkl::transpose::nontrans``, the routine multiplies :math:`C` by :math:`Q^T`.
+    If ``trans = oneapi::mkl::transpose::conjtrans``, the routine multiplies :math:`C`
+    by :math:`Q^{H}`.
 
 m
-   The number of rows in the matrix :math:`A` (:math:`0 \le m`).
+    The number of rows in the matrix :math:`C` (:math:`0 \le m`).
 
 n
-   The number of columns in the matrix :math:`A` (:math:`0 \le n \le m`).
+    The number of columns in the matrix :math:`C` (:math:`0 \le n`).
 
 k
-   The number of elementary reflectors whose product defines the matrix :math:`Q` (:math:`0 \le k \le n`).
+    The number of elementary reflectors whose product defines the
+    matrix :math:`Q`
+
+    If ``side = oneapi::mkl::side::left``, :math:`0 \le k \le m`
+
+    If ``side = oneapi::mkl::side::right``, :math:`0 \le k \le n`
 
 a
-   Buffer holding the result of the :ref:`onemkl_lapack_gerqf` function. The second dimension of ``a`` must be at least :math:`\max(1,k)`.
+    The pointer to ``a`` as returned by :ref:`onemkl_lapack_gerqf`.
+    The second dimension of ``a`` must be at least :math:`\max(1,k)`.
 
 lda
-   The leading dimension of ``a``.
+    The leading dimension of ``a``.
 
 tau
-   Buffer holding ``tau`` returned by the :ref:`onemkl_lapack_gerqf` function.
+    The pointer to ``tau`` as returned by :ref:`onemkl_lapack_gerqf`.
 
 c
-   Buffer holding the matrix :math:`C`. The second dimension of ``c`` must be at least :math:`\max(1,n)`.
+    The pointer ``c`` points to the matrix :math:`C`. The second dimension of
+    ``c`` must be at least :math:`\max(1,n)`.
 
 ldc
-   The leading dimension of ``c``.
-
-scratchpad
-   Buffer holding scratchpad memory to be used by the routine for storing intermediate results.
+    The leading dimension of ``c``.
 
 scratchpad_size
-   Size of scratchpad memory as a number of floating point elements of type ``T``. Size should not be less than the value returned by the unmrq_scratchpad_size function.
+    Size of scratchpad memory as a number of floating point elements of type
+    ``T``. Size should not be less than the value returned by
+    :ref:`onemkl_lapack_unmrq_scratchpad_size` function.
 
 events
-   List of events to wait for before starting computation. Defaults to empty list.
+    List of events to wait for before starting computation. Defaults to empty list.
 
 .. container:: section
 
   .. rubric:: Output Parameters
-      
+
 c
-   Overwritten by the product :math:`QC`, :math:`Q^TC`, :math:`CQ`, or :math:`CQ^T` (as specified by ``side`` and ``trans``).
+    Overwritten by the product :math:`QC`, :math:`Q^{H}C`, :math:`CQ`, or
+    :math:`CQ^{H}` (as specified by ``side`` and ``trans``).
+
+scratchpad
+    Pointer to scratchpad memory to be used by routine for storing intermediate results.
 
 .. container:: section
 
   .. rubric:: Throws
-         
+
 This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
 
 :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
@@ -205,17 +240,16 @@ This routine shall throw the following exceptions if the associated condition is
 
 :ref:`oneapi::mkl::lapack::computation_error<onemkl_lapack_exception_computation_error>`
 
-   Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
+    Exception is thrown in case of problems during calculations. The ``info`` code of the problem can be obtained by `info()` method of exception object:
 
-   If ``info = -i``, the :math:`i`-th parameter had an illegal value.
+    If :math:`\text{info}=-i`, the :math:`i`-th parameter had an illegal value.
 
-   If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
+    If ``info`` equals to value passed as scratchpad size, and `detail()` returns non zero, then passed scratchpad is of insufficient size, and required size should not be less than value return by `detail()` method of exception object.
 
 .. container:: section
 
   .. rubric:: Return Values
-         
+
 Output event to wait on to ensure computation is complete.
 
 **Parent topic:** :ref:`onemkl_lapack-linear-equation-routines`
-

--- a/source/elements/oneMKL/source/domains/lapack/unmrq_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/unmrq_scratchpad_size.rst
@@ -50,15 +50,15 @@ side
    If ``side = oneapi::mkl::side::left``, :math:`Q` or :math:`Q^T` is applied to :math:`C` from the left. If ``side = oneapi::mkl::side::right``, :math:`Q` or :math:`Q^T` is applied to :math:`C` from the right.
 
 trans
-   If ``trans=oneapi::mkl::transpose::trans``, the routine multiplies :math:`C` by :math:`Q`.
+   If ``trans=oneapi::mkl::transpose::nontrans``, the routine multiplies :math:`C` by :math:`Q`.
 
-   If ``trans=oneapi::mkl::transpose::nontrans``, the routine multiplies :math:`C` by :math:`Q^T`.
+   If ``trans=oneapi::mkl::transpose::conjtrans``, the routine multiplies :math:`C` by :math:`Q^H`.
 
 m
-   The number of rows in the matrix :math:`A` (:math:`0 \le m`).
+   The number of rows in the matrix :math:`C` (:math:`0 \le m`).
 
 n
-   The number of columns in the matrix :math:`A` (:math:`0 \le n \le m`).
+   The number of columns in the matrix :math:`C` (:math:`0 \le n \le m`).
 
 k
    The number of elementary reflectors whose product defines the matrix :math:`Q` (:math:`0 \le k \le n`).

--- a/source/elements/oneMKL/source/domains/lapack/unmtr.rst
+++ b/source/elements/oneMKL/source/domains/lapack/unmtr.rst
@@ -31,7 +31,7 @@ when reducing a complex Hermitian matrix :math:`A` to tridiagonal form:
 :math:`A = QTQ^H`. Use this routine after a call to
 :ref:`onemkl_lapack_hetrd`.
 
-Depending on the parameters ``left_right`` and ``trans``, the routine can
+Depending on the parameters ``side`` and ``trans``, the routine can
 form one of the matrix products :math:`QC`, :math:`Q^{H}C`,
 :math:`CQ`, or :math:`CQ^{H}` (overwriting the result on :math:`C`).
 
@@ -45,7 +45,7 @@ unmtr (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void unmtr(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &c, std::int64_t ldc, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void unmtr(cl::sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &c, std::int64_t ldc, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -60,20 +60,20 @@ In the descriptions below, ``r`` denotes the order of :math:`Q`:
         :header-rows: 1
 
         * -  :math:`r`\ =\ :math:`m` 
-          -  if ``left_right = side::left`` 
+          -  if ``side = side::left`` 
         * -  :math:`r`\ =\ :math:`n` 
-          -  if ``left_right = side::right`` 
+          -  if ``side = side::right`` 
 
 queue
    The queue where the routine should be executed.
 
-left_right
+side
    Must be either ``side::left`` or ``side::right``.
 
-   If ``left_right=side::left``, :math:`Q` or :math:`Q^{H}` is applied
+   If ``side=side::left``, :math:`Q` or :math:`Q^{H}` is applied
    to :math:`C` from the left.
 
-   If ``left_right=side::right``, :math:`Q` or :math:`Q^{H}` is applied
+   If ``side=side::right``, :math:`Q` or :math:`Q^{H}` is applied
    to :math:`C` from the right.
 
 upper_lower
@@ -130,7 +130,7 @@ scratchpad_size
       
 c
    Overwritten by the product :math:`QC`, :math:`Q^{H}C`,
-   :math:`CQ`, or :math:`CQ^{H}` (as specified by ``left_right`` and
+   :math:`CQ`, or :math:`CQ^{H}` (as specified by ``side`` and
    ``trans``).
 
 scratchpad
@@ -170,7 +170,7 @@ unmtr (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event unmtr(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, T *a, std::int64_t lda, T *tau, T *c, std::int64_t ldc, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event unmtr(cl::sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, T *a, std::int64_t lda, T *tau, T *c, std::int64_t ldc, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section
@@ -185,20 +185,20 @@ In the descriptions below, ``r`` denotes the order of :math:`Q`:
         :header-rows: 1
 
         * -  :math:`r`\ =\ :math:`m` 
-          -  if ``left_right = side::left`` 
+          -  if ``side = side::left`` 
         * -  :math:`r`\ =\ :math:`n` 
-          -  if ``left_right = side::right`` 
+          -  if ``side = side::right`` 
 
 queue
    The queue where the routine should be executed.
 
-left_right
+side
    Must be either ``side::left`` or ``side::right``.
 
-   If ``left_right=side::left``, :math:`Q` or :math:`Q^{H}` is applied
+   If ``side=side::left``, :math:`Q` or :math:`Q^{H}` is applied
    to :math:`C` from the left.
 
-   If ``left_right=side::right``, :math:`Q` or :math:`Q^{H}` is applied
+   If ``side=side::right``, :math:`Q` or :math:`Q^{H}` is applied
    to :math:`C` from the right.
 
 upper_lower
@@ -258,7 +258,7 @@ events
       
 c
    Overwritten by the product :math:`QC`, :math:`Q^{H}C`,
-   :math:`CQ`, or :math:`CQ^{H}` (as specified by ``left_right`` and
+   :math:`CQ`, or :math:`CQ^{H}` (as specified by ``side`` and
    trans).
 
 scratchpad

--- a/source/elements/oneMKL/source/domains/lapack/unmtr.rst
+++ b/source/elements/oneMKL/source/domains/lapack/unmtr.rst
@@ -45,7 +45,7 @@ unmtr (Buffer Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      void unmtr(cl::sycl::queue &queue, onemkl::side left_right, onemkl::uplo upper_lower, onemkl::transpose trans, std::int64_t m, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &c, std::int64_t ldc, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
+      void unmtr(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, cl::sycl::buffer<T,1> &a, std::int64_t lda, cl::sycl::buffer<T,1> &tau, cl::sycl::buffer<T,1> &c, std::int64_t ldc, cl::sycl::buffer<T,1> &scratchpad, std::int64_t scratchpad_size)
     }
 
 .. container:: section
@@ -170,7 +170,7 @@ unmtr (USM Version)
 .. code-block:: cpp
 
     namespace oneapi::mkl::lapack {
-      cl::sycl::event unmtr(cl::sycl::queue &queue, onemkl::side left_right, onemkl::uplo upper_lower, onemkl::transpose trans, std::int64_t m, std::int64_t n, T *a, std::int64_t lda, T *tau, T *c, std::int64_t ldc, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
+      cl::sycl::event unmtr(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, T *a, std::int64_t lda, T *tau, T *c, std::int64_t ldc, T *scratchpad, std::int64_t scratchpad_size, const cl::sycl::vector_class<cl::sycl::event> &events = {})
     }
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/lapack/unmtr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/unmtr_scratchpad_size.rst
@@ -36,7 +36,7 @@ unmtr_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t unmtr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t lda, std::int64_t ldc) 
+      std::int64_t unmtr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t lda, std::int64_t ldc) 
     }
 
 .. container:: section
@@ -46,13 +46,13 @@ unmtr_scratchpad_size
 queue
    Device queue where calculations by :ref:`onemkl_lapack_unmtr` function will be performed.
 
-left_right
+side
    Must be either ``side::left`` or ``side::right``.
 
-   If ``left_right=side::left``, :math:`Q` or :math:`Q^{H}` is
+   If ``side=side::left``, :math:`Q` or :math:`Q^{H}` is
    applied to :math:`C` from the left.
 
-   If ``left_right=side::right``, :math:`Q` or :math:`Q^{H}` is
+   If ``side=side::right``, :math:`Q` or :math:`Q^{H}` is
    applied to :math:`C` from the right.
 
 upper_lower

--- a/source/elements/oneMKL/source/domains/lapack/unmtr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/unmtr_scratchpad_size.rst
@@ -36,7 +36,7 @@ unmtr_scratchpad_size
 
     namespace oneapi::mkl::lapack {
       template <typename T>
-      std::int64_t unmtr_scratchpad_size(cl::sycl::queue &queue, onemkl::side left_right, onemkl::uplo upper_lower, onemkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t lda, std::int64_t ldc) 
+      std::int64_t unmtr_scratchpad_size(cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t lda, std::int64_t ldc) 
     }
 
 .. container:: section


### PR DESCRIPTION
Corrects documentation errors as pointed out in issue #301.

additionally fixes onemkl:: namespace and left_right parameter name.