### PR TITLE
[oneTBB] Rework the parallel_for_each algorithm requirements

### DIFF
--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -33,25 +33,25 @@ It should also meet one of the following requirements:
 Terms
 -----
 
-* ``iterator`` determines the type of the iterator passed into ``parallel_for_each`` algorithm
+* ``iterator`` determines the type of the iterator passed into the ``parallel_for_each`` algorithm.
   (which is ``InputIterator`` or ``decltype(std::begin(c))`` for the overloads which accepts the `Container` template argument)
-* ``value_type`` - the type ``std::iterator_traits<iterator>::value_type``
+* ``value_type`` - the type ``std::iterator_traits<iterator>::value_type``.
 * ``reference`` -  the type ``std::iterator_traits<iterator>::reference``.
 
 If the ``iterator`` satisfies `Input iterator` named requirements from [input.iterators]
 ISO C++ Standard section and do not satisfies `Forward iterator` named requirements from
 [forward.iterators] ISO C++ Standard section, `tbb::parallel_for_each algorithm <../../algorithms/functions/parallel_for_each_func>`
 requires the ``Body::operator()`` call with an object of type ``const value_type&`` or ``value_type&&`` to be well-formed.
-If both forms are well-formed, an overload with rvalue reference will be preferred.
+If both forms are well-formed, an overload with rvalue reference is preferred.
 
 .. caution::
 
   If the ``Body`` only takes non-const lvalue reference to ``value_type``, named requirements above
-  are violated and the program can be ill-formed.
+  are violated, and the program can be ill-formed.
 
-If the ``iterator`` satisfies `Forward iterator` named requirements from [forward.iterators]
-ISO C++Standard section, ``tbb::parallel_for_each`` requires the ``Body::operator()`` call
-with an object of type ``reference`` to be well-formed.
+If the ``iterator`` meets all of the `Forward iterator` requirements described in the [forward.iterators] section of the 
+ISO C++Standard, ``tbb::parallel_for_each`` requires the ``Body::operator()`` call
+with an object of the ``reference`` type to be well-formed.
 
 Additional elements submitted into ``tbb::parallel_for_each`` through the ``feeder::add`` passes to the ``Body`` as rvalues and therefore the corresponding
 execution of the ``Body`` is required to be well-formed.

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -30,18 +30,28 @@ It should also meet one of the following requirements:
     ``ItemType`` may be optionally passed to ``Body::operator()`` by reference.
     ``const`` and ``volatile`` type qualifiers are also applicable.
 
-ItemType
---------
+Terms
+-----
 
-The argument type ``ItemType`` should either satisfy the *CopyConstructibe*, *MoveConstructibe* or
-both requirements from the ISO C++ [utility.arg.requirements] section.
-If the type is not *CopyConstructibe*, there are additional usage restrictions:
+* ``iterator`` determines the type of the iterator passed into ``parallel_for_each`` algorithm
+  (which is ``InputIterator`` or ``decltype(std::begin(c))`` for the overloads which accepts the `Container` template argument)
+* ``value_type`` - the type ``std::iterator_traits<iterator>::value_type``
+* ``reference`` -  the type ``std::iterator_traits<iterator>::reference``.
 
-* If ``Body::operator()`` accepts an argument by value, or if the ``InputIterator`` type
-  from :doc:`parallel_for_each algorithm <../../algorithms/functions/parallel_for_each_func>` does
-  not satisfy the `Forward Iterator` requirements from the [forward.iterators] ISO C++ Standard section,
-  dereferencing an ``InputIterator`` must produce an rvalue reference.
-* Additional work items should be passed to the feeder as rvalues, for example, via the ``std::move`` function.
+If the ``iterator`` satisfies `Input iterator` named requirements from [input.iterators]
+ISO C++ Standard section and do not satisfies `Forward iterator` named requirements from
+[forward.iterators] ISO C++ Standard section, `tbb::parallel_for_each algorithm <../../algorithms/functions/parallel_for_each_func>`
+requires the ``Body::operator()`` call with an object of type ``const value_type&`` or ``value_type&&`` to be well-formed.
+If both forms are well-formed, an overload with rvalue reference will be preferred.
+
+.. caution::
+
+  If the ``Body`` only takes non-const lvalue reference to ``value_type``, named requirements above
+  are violated and the program can be ill-formed.
+
+If the ``iterator`` satisfies `Forward iterator` named requirements from [forward.iterators]
+ISO C++Standard section, ``tbb::parallel_for_each`` requires the ``Body::operator()`` call
+with an object of type ``reference`` to be well-formed.
 
 See also:
 

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -39,14 +39,14 @@ Terms
 * ``reference`` -  the type ``std::iterator_traits<iterator>::reference``.
 
 ``oneapi::tbb::parallel_for_each`` requires the ``Body::operator()`` call with an object of the ``reference`` type to be well-formed if
-the ``iterator`` meets all of the `Forward iterator` requirements described in the [forward.iterators] section of the 
+the ``iterator`` meets the `Forward iterator` requirements described in the [forward.iterators] section of the 
 ISO C++ Standard.
 
 `oneapi::tbb::parallel_for_each algorithm <../../algorithms/functions/parallel_for_each_func>`
 requires the ``Body::operator()`` call with an object of type ``const value_type&`` or ``value_type&&`` to be well-formed if following requirements are met:
 
-* the iterator meets all of the `Input iterator` requirements described in the [input.iterators] section of the ISO C++ Standard
-* the iterator does not meet all of the `Forward iterator` requirements described in the [forward.iterators] section of the ISO C++ Standard
+* the iterator meets the `Input iterator` requirements described in the [input.iterators] section of the ISO C++ Standard
+* the iterator does not meet the `Forward iterator` requirements described in the [forward.iterators] section of the ISO C++ Standard
 .. caution::
 
   If the ``Body`` only takes non-const lvalue reference to the ``value_type``, the requirements described above

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -38,20 +38,19 @@ Terms
 * ``value_type`` - the type ``std::iterator_traits<iterator>::value_type``.
 * ``reference`` -  the type ``std::iterator_traits<iterator>::reference``.
 
-If the ``iterator`` satisfies `Input iterator` named requirements from [input.iterators]
-ISO C++ Standard section and do not satisfies `Forward iterator` named requirements from
-[forward.iterators] ISO C++ Standard section, `tbb::parallel_for_each algorithm <../../algorithms/functions/parallel_for_each_func>`
-requires the ``Body::operator()`` call with an object of type ``const value_type&`` or ``value_type&&`` to be well-formed.
-If both forms are well-formed, an overload with rvalue reference is preferred.
+``tbb::parallel_for_each`` requires the ``Body::operator()`` call with an object of the ``reference`` type to be well-formed if:
+* If the ``iterator`` meets all of the `Forward iterator` requirements described in the [forward.iterators] section of the 
+ISO C++Standard,
+
+`tbb::parallel_for_each algorhitm <../../algorithms/functions/parallel_for_each_func>`
+requires the Body::operator() call with an object of type const value_type& or value_type&& to be well-formed if:
+* the iterator does not meet all of the Forward iterator requirements described in the [forward.iterators] section of the ISO C++ Standard
+* the iterator meets all of the Input iterator requirements described in the [input.iterators] section of the ISO C++ Standard
 
 .. caution::
 
   If the ``Body`` only takes non-const lvalue reference to ``value_type``, named requirements above
   are violated, and the program can be ill-formed.
-
-If the ``iterator`` meets all of the `Forward iterator` requirements described in the [forward.iterators] section of the 
-ISO C++Standard, ``tbb::parallel_for_each`` requires the ``Body::operator()`` call
-with an object of the ``reference`` type to be well-formed.
 
 Additional elements submitted into ``tbb::parallel_for_each`` through the ``feeder::add`` passes to the ``Body`` as rvalues and therefore the corresponding
 execution of the ``Body`` is required to be well-formed.

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -38,12 +38,12 @@ Terms
 * ``value_type`` - the type ``std::iterator_traits<iterator>::value_type``.
 * ``reference`` -  the type ``std::iterator_traits<iterator>::reference``.
 
-``tbb::parallel_for_each`` requires the ``Body::operator()`` call with an object of the ``reference`` type to be well-formed if
+``oneapi::tbb::parallel_for_each`` requires the ``Body::operator()`` call with an object of the ``reference`` type to be well-formed if
 the ``iterator`` meets all of the `Forward iterator` requirements described in the [forward.iterators] section of the 
-ISO C++Standard.
+ISO C++ Standard.
 
-`tbb::parallel_for_each algorithm <../../algorithms/functions/parallel_for_each_func>`
-requires the Body::operator() call with an object of type const value_type& or value_type&& to be well-formed if:
+`oneapi::tbb::parallel_for_each algorithm <../../algorithms/functions/parallel_for_each_func>`
+requires the ``Body::operator()`` call with an object of type ``const value_type&`` or ``value_type&&`` to be well-formed if:
 
 * the iterator does not meet all of the `Forward iterator` requirements described in the [forward.iterators] section of the ISO C++ Standard
 * the iterator meets all of the `Input iterator` requirements described in the [input.iterators] section of the ISO C++ Standard
@@ -53,7 +53,7 @@ requires the Body::operator() call with an object of type const value_type& or v
   If the ``Body`` only takes non-const lvalue reference to the ``value_type``, the requirements described above
   are violated, and the program can be ill-formed.
 
-Additional elements submitted into ``tbb::parallel_for_each`` through the ``feeder::add`` are passed to the ``Body`` as rvalues. In this case, the corresponding
+Additional elements submitted into ``oneapi::tbb::parallel_for_each`` through the ``feeder::add`` are passed to the ``Body`` as rvalues. In this case, the corresponding
 execution of the ``Body`` is required to be well-formed.
 
 See also:

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -53,6 +53,9 @@ If the ``iterator`` satisfies `Forward iterator` named requirements from [forwar
 ISO C++Standard section, ``tbb::parallel_for_each`` requires the ``Body::operator()`` call
 with an object of type ``reference`` to be well-formed.
 
+Additional elements submitted into ``tbb::parallel_for_each`` through the ``feeder::add`` passes to the ``Body`` as rvalues and therefore the corresponding
+execution of the ``Body`` is required to be well-formed.
+
 See also:
 
 * :doc:`parallel_for_each algorithm <../../algorithms/functions/parallel_for_each_func>`

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -42,7 +42,7 @@ Terms
 the ``iterator`` meets the `Forward iterator` requirements described in the [forward.iterators] section of the 
 ISO C++ Standard.
 
-`oneapi::tbb::parallel_for_each algorithm <../../algorithms/functions/parallel_for_each_func>`
+`oneapi::tbb::parallel_for_each algorithm <../../algorithms/functions/parallel_for_each_func>`_
 requires the ``Body::operator()`` call with an object of type ``const value_type&`` or ``value_type&&`` to be well-formed if following requirements are met:
 
 * the iterator meets the `Input iterator` requirements described in the [input.iterators] section of the ISO C++ Standard

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -49,10 +49,10 @@ requires the Body::operator() call with an object of type const value_type& or v
 
 .. caution::
 
-  If the ``Body`` only takes non-const lvalue reference to ``value_type``, named requirements above
+  If the ``Body`` only takes non-const lvalue reference to the ``value_type``, the requirements described above
   are violated, and the program can be ill-formed.
 
-Additional elements submitted into ``tbb::parallel_for_each`` through the ``feeder::add`` passes to the ``Body`` as rvalues and therefore the corresponding
+Additional elements submitted into ``tbb::parallel_for_each`` through the ``feeder::add`` are passed to the ``Body`` as rvalues. In this case, the corresponding
 execution of the ``Body`` is required to be well-formed.
 
 See also:

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -34,7 +34,7 @@ Terms
 -----
 
 * ``iterator`` determines the type of the iterator passed into the ``parallel_for_each`` algorithm,
-which is ``decltype(std::begin(c))`` for the overloads that accept the `Container` template argument or ``InputIterator``.
+  which is ``decltype(std::begin(c))`` for the overloads that accept the ``Container`` template argument or ``InputIterator``.
 * ``value_type`` - the type ``std::iterator_traits<iterator>::value_type``.
 * ``reference`` -  the type ``std::iterator_traits<iterator>::reference``.
 
@@ -42,8 +42,9 @@ which is ``decltype(std::begin(c))`` for the overloads that accept the `Containe
 the ``iterator`` meets all of the `Forward iterator` requirements described in the [forward.iterators] section of the 
 ISO C++Standard.
 
-`tbb::parallel_for_each algorhitm <../../algorithms/functions/parallel_for_each_func>`
+`tbb::parallel_for_each algorithm <../../algorithms/functions/parallel_for_each_func>`
 requires the Body::operator() call with an object of type const value_type& or value_type&& to be well-formed if:
+
 * the iterator does not meet all of the `Forward iterator` requirements described in the [forward.iterators] section of the ISO C++ Standard
 * the iterator meets all of the `Input iterator` requirements described in the [input.iterators] section of the ISO C++ Standard
 

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -43,11 +43,10 @@ the ``iterator`` meets all of the `Forward iterator` requirements described in t
 ISO C++ Standard.
 
 `oneapi::tbb::parallel_for_each algorithm <../../algorithms/functions/parallel_for_each_func>`
-requires the ``Body::operator()`` call with an object of type ``const value_type&`` or ``value_type&&`` to be well-formed if:
+requires the ``Body::operator()`` call with an object of type ``const value_type&`` or ``value_type&&`` to be well-formed if following requirements are met:
 
-* the iterator does not meet all of the `Forward iterator` requirements described in the [forward.iterators] section of the ISO C++ Standard
 * the iterator meets all of the `Input iterator` requirements described in the [input.iterators] section of the ISO C++ Standard
-
+* the iterator does not meet all of the `Forward iterator` requirements described in the [forward.iterators] section of the ISO C++ Standard
 .. caution::
 
   If the ``Body`` only takes non-const lvalue reference to the ``value_type``, the requirements described above

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -47,6 +47,7 @@ requires the ``Body::operator()`` call with an object of type ``const value_type
 
 * the iterator meets the `Input iterator` requirements described in the [input.iterators] section of the ISO C++ Standard
 * the iterator does not meet the `Forward iterator` requirements described in the [forward.iterators] section of the ISO C++ Standard
+
 .. caution::
 
   If the ``Body`` only takes non-const lvalue reference to the ``value_type``, the requirements described above

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -34,7 +34,7 @@ Terms
 -----
 
 * ``iterator`` determines the type of the iterator passed into the ``parallel_for_each`` algorithm.
-  (which is ``InputIterator`` or ``decltype(std::begin(c))`` for the overloads which accepts the `Container` template argument)
+  (which is ``decltype(std::begin(c))`` for the overloads which accepts the `Container` template argument or ``InputIterator`` otherwise)
 * ``value_type`` - the type ``std::iterator_traits<iterator>::value_type``.
 * ``reference`` -  the type ``std::iterator_traits<iterator>::reference``.
 

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -33,19 +33,19 @@ It should also meet one of the following requirements:
 Terms
 -----
 
-* ``iterator`` determines the type of the iterator passed into the ``parallel_for_each`` algorithm.
-  (which is ``decltype(std::begin(c))`` for the overloads which accepts the `Container` template argument or ``InputIterator`` otherwise)
+* ``iterator`` determines the type of the iterator passed into the ``parallel_for_each`` algorithm,
+which is ``decltype(std::begin(c))`` for the overloads that accept the `Container` template argument or ``InputIterator``.
 * ``value_type`` - the type ``std::iterator_traits<iterator>::value_type``.
 * ``reference`` -  the type ``std::iterator_traits<iterator>::reference``.
 
-``tbb::parallel_for_each`` requires the ``Body::operator()`` call with an object of the ``reference`` type to be well-formed if:
-* If the ``iterator`` meets all of the `Forward iterator` requirements described in the [forward.iterators] section of the 
-ISO C++Standard,
+``tbb::parallel_for_each`` requires the ``Body::operator()`` call with an object of the ``reference`` type to be well-formed if
+the ``iterator`` meets all of the `Forward iterator` requirements described in the [forward.iterators] section of the 
+ISO C++Standard.
 
 `tbb::parallel_for_each algorhitm <../../algorithms/functions/parallel_for_each_func>`
 requires the Body::operator() call with an object of type const value_type& or value_type&& to be well-formed if:
-* the iterator does not meet all of the Forward iterator requirements described in the [forward.iterators] section of the ISO C++ Standard
-* the iterator meets all of the Input iterator requirements described in the [input.iterators] section of the ISO C++ Standard
+* the iterator does not meet all of the `Forward iterator` requirements described in the [forward.iterators] section of the ISO C++ Standard
+* the iterator meets all of the `Input iterator` requirements described in the [input.iterators] section of the ISO C++ Standard
 
 .. caution::
 


### PR DESCRIPTION
Now the `parallel_for_each` algorithm body named requirements contain unclear and incorrect formulation. This patch fixes it and makes it more clear.

Signed-off-by: Kochin, Ivan <kochin.ivan@intel.com>