### PR TITLE
[oneTBB] Changing description for containers deduction guides

### DIFF
--- a/source/elements/oneTBB/source/containers/concurrent_bounded_queue_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_bounded_queue_cls/deduction_guides.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_bounded_queue_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_bounded_queue_cls/deduction_guides.rst
@@ -9,7 +9,7 @@ Deduction guides
 If possible, ``concurrent_bounded_queue`` constructors support class template argument deduction (since C++17).
 Copy and move constructors, including constructors with an explicit ``allocator_type`` argument,
 provide implicitly-generated deduction guides.
-In addition, the following explicit deduction guides are provided:
+In addition, the following explicit deduction guide is provided:
 
 .. code:: cpp
 
@@ -27,7 +27,7 @@ Where the type alias ``iterator_value_t`` is defined as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
-These deduction guides only participate in the overload resolution if all of the following are ``true``:
+This deduction guides only participate in the overload resolution if the following requirements are met:
 
 * The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
 * The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.

--- a/source/elements/oneTBB/source/containers/concurrent_bounded_queue_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_bounded_queue_cls/deduction_guides.rst
@@ -7,14 +7,18 @@ Deduction guides
 ================
 
 Where possible, constructors of ``tbb::concurrent_bounded_queue`` support class template argument
-deduction (since C++17):
+deduction (since C++17). Copy and move constructors (including constructors with explicit
+``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
+deduction guides are provided:
 
 .. code:: cpp
 
     template <typename InputIterator,
-              typename Allocator = cache_aligned_allocator<iterator_value_t<InputIterator>>
-    concurrent_bounded_queue( InputIterator, InputIterator, const Allocator& = Allocator() )
-    -> concurrent_bounded_queue<iterator_value_t<InputIterator>, Allocator>;
+              typename Allocator = tbb::cache_aligned_allocator<iterator_value_t<InputIterator>>
+    concurrent_bounded_queue( InputIterator, InputIterator,
+                              Allocator = Allocator() )
+    -> concurrent_bounded_queue<iterator_value_t<InputIterator>,
+                                Allocator>;
 
 Where the type alias ``iterator_value_t`` is defined as follows:
 
@@ -22,6 +26,11 @@ Where the type alias ``iterator_value_t`` is defined as follows:
 
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
+
+These deduction guides only participates in overload resolution if all of the following are ``true``:
+
+* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
+* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_bounded_queue_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_bounded_queue_cls/deduction_guides.rst
@@ -6,10 +6,10 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``tbb::concurrent_bounded_queue`` support class template argument
-deduction (since C++17). Copy and move constructors (including constructors with explicit
-``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
-deduction guides are provided:
+If possible, ``concurrent_bounded_queue`` constructors support class template argument deduction (since C++17).
+Copy and move constructors, including constructors with an explicit ``allocator_type`` argument,
+provide implicitly-generated deduction guides.
+In addition, the following explicit deduction guides are provided:
 
 .. code:: cpp
 
@@ -27,10 +27,10 @@ Where the type alias ``iterator_value_t`` is defined as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
-These deduction guides only participates in overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if all of the following are ``true``:
 
-* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
-* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
+* The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
+* The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_hash_map_cls.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_hash_map_cls.rst
@@ -33,6 +33,7 @@ Class Template Synopsis
                using pointer = typename std::allocator_traits<Allocator>::pointer;
                using const_pointer = typename std::allocator_traits<Allocator>::const_pointer;
 
+               using hash_compare_type = HashCompare;
                using allocator_type = Allocator;
 
                using size_type = <implementation-defined unsigned integer type>;
@@ -50,19 +51,19 @@ Class Template Synopsis
                // Construction, destruction, copying
                concurrent_hash_map();
 
-               explicit concurrent_hash_map( const HashCompare& compare,
+               explicit concurrent_hash_map( const hash_compare_type& compare,
                                              const allocator_type& alloc = allocator_type() );
 
                explicit concurrent_hash_map( const allocator_type& alloc );
 
-               concurrent_hash_map( size_type n, const HashCompare& compare,
+               concurrent_hash_map( size_type n, const hash_compare_type& compare,
                                     const allocator_type& alloc = allocator_type() );
 
                concurrent_hash_map( size_type n, const allocator_type& alloc = allocator_type() );
 
                template <typename InputIterator>
                concurrent_hash_map( InputIterator first, InputIterator last,
-                                    const HashCompare& compare,
+                                    const hash_compare_type& compare,
                                     const allocator_type& alloc = allocator_type() );
 
                template <typename InputIterator>
@@ -70,11 +71,11 @@ Class Template Synopsis
                                     const allocator_type& alloc = allocator_type() );
 
                concurrent_hash_map( std::initializer_list<value_type> init,
-                                    const HashCompare& compare,
+                                    const hash_compare_type& compare = hash_compare_type(),
                                     const allocator_type& alloc = allocator_type() );
 
                concurrent_hash_map( std::initializer_list<value_type> init,
-                                    const allocator_type& alloc = allocator_type() );
+                                    const allocator_type& alloc );
 
                concurrent_hash_map( const concurrent_hash_map& other );
                concurrent_hash_map( const concurrent_hash_map& other,

--- a/source/elements/oneTBB/source/containers/concurrent_hash_map_cls.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_hash_map_cls.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_hash_map_cls/construct_destroy_copy.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_hash_map_cls/construct_destroy_copy.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_hash_map_cls/construct_destroy_copy.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_hash_map_cls/construct_destroy_copy.rst
@@ -13,7 +13,7 @@ Empty container constructors
 
         concurrent_hash_map();
 
-        explicit concurrent_hash_map( const HashCompare& compare,
+        explicit concurrent_hash_map( const hash_compare_type& compare,
                                       const allocator_type& alloc = allocator_type() );
 
         explicit concurrent_hash_map( const allocator_type& alloc );
@@ -28,7 +28,7 @@ Empty container constructors
 
     .. code:: cpp
 
-        concurrent_hash_map( size_type n, const HashCompare& compare,
+        concurrent_hash_map( size_type n, const hash_compare_type& compare,
                              const allocator_type& alloc = allocator_type() );
 
         concurrent_hash_map( size_type n, const allocator_type& alloc = allocator_type() );
@@ -45,7 +45,7 @@ Constructors from the sequence of elements
 
         template <typename InputIterator>
         concurrent_hash_map( InputIterator first, InputIterator last,
-                             const HashCompare& compare,
+                             const hash_compare_type& compare,
                              const allocator_type& alloc = allocator_type() );
 
         template <typename InputIterator>
@@ -70,7 +70,7 @@ Constructors from the sequence of elements
     .. code:: cpp
 
         concurrent_hash_map( std::initializer_list<value_type> init,
-                             const HashCompare& compare,
+                             const hash_compare_type& compare = hash_compare_type(),
                              const allocator_type& alloc = allocator_type() );
 
     Equivalent to ``concurrent_hash_map(init.begin(), init.end(), compare, alloc)``.
@@ -80,7 +80,7 @@ Constructors from the sequence of elements
     .. code:: cpp
 
         concurrent_hash_map( std::initializer_list<value_type> init,
-                             const allocator_type& alloc = allocator_type() );
+                             const allocator_type& alloc );
 
     Equivalent to ``concurrent_hash_map(init.begin(), init.end(), alloc)``.
 

--- a/source/elements/oneTBB/source/containers/concurrent_hash_map_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_hash_map_cls/deduction_guides.rst
@@ -7,51 +7,50 @@ Deduction guides
 ================
 
 Where possible, constructors of ``concurrent_hash_map`` support
-class template argument deduction (since C++17):
+class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
+``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
+deduction guides are provided:
 
 .. code:: cpp
 
     template <typename InputIterator,
-              typename HashCompare,
-              typename Allocator = tbb_allocator<iterator_alloc_value_t<InputIterator>>>
+              typename HashCompare = tbb_hash_compare<iterator_key_t<InputIterator>>,
+              typename Alloc = tbb_allocator<iterator_alloc_value_t<InputIterator>>>
     concurrent_hash_map( InputIterator, InputIterator,
-                         const HashCompare&,
-                         const Allocator& = Allocator() )
+                         HashCompare = HashCompare(),
+                         Alloc = Alloc() )
     -> concurrent_hash_map<iterator_key_t<InputIterator>,
                            iterator_mapped_t<InputIterator>,
                            HashCompare,
-                           Allocator>;
+                           Alloc>;
 
     template <typename InputIterator,
-              typename Allocator = tbb_allocator<iterator_alloc_value_t<InputIterator>>>
-    concurrent_hash_map( InputIterator, InputIterator,
-                         const Allocator& = Allocator() )
+              typename Alloc>
+    concurrent_hash_map( InputIterator, InputIterator, Alloc )
     -> concurrent_hash_map<iterator_key_t<InputIterator>,
                            iterator_mapped_t<InputIterator>,
                            tbb_hash_compare<iterator_key_t<InputIterator>>,
-                           Allocator>;
+                           Alloc>;
 
-    template <typename Key,
-              typename T,
-              typename HashCompare,
-              typename Allocator = tbb_allocator<std::pair<const Key, T>>>
-    concurrent_hash_map( std::initializer_list<std::pair<const Key, T>>,
-                         const HashCompare&,
-                         const Allocator& = Allocator() )
-    -> concurrent_hash_map<Key,
+    template <typename Key, typename T,
+              typename HashCompare = tbb_hash_compare<std::remove_const_t<Key>>,
+              typename Alloc = tbb_allocator<std::pair<const Key, T>>>
+    concurrent_hash_map( std::initializer_list<std::pair<Key, T>>,
+                         HashCompare = HashCompare(),
+                         Alloc = Alloc() )
+    -> concurrent_hash_map<std::remove_const_t<Key>,
                            T,
                            HashCompare,
-                           Allocator>;
+                           Alloc>;
 
-    template <typename Key,
-              typename T,
-              typename Allocator = tbb_allocator<std::pair<const Key, T>>>
-    concurrent_hash_map( std::initializer_list<std::pair<const Key, T>>,
-                         const Allocator& = Allocator() )
-    -> concurrent_hash_map<Key,
+    template <typename Key, typename T,
+              typename Alloc>
+    concurrent_hash_map( std::initializer_list<std::pair<Key, T>>,
+                         Alloc )
+    -> concurrent_hash_map<std::remove_const_t<Key>,
                            T,
-                           tbb_hash_compare<Key>,
-                           Allocator>;
+                           tbb_hash_compare<std::remove_const_t<Key>>,
+                           Alloc>;
 
 Where the type aliases ``iterator_key_t``, ``iterator_mapped_t``, and ``iterator_alloc_value_t``
 are defined as follows:
@@ -67,6 +66,12 @@ are defined as follows:
     template <typename InputIterator>
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>,
                                              iterator_mapped_t<InputIterator>>>;
+
+These deduction guides only participates in overload resolution if all of the following are ``true``:
+
+* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
+* The type ``Alloc`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
+* The type ``HashCompare`` does not meet the requirements of ``Allocator``.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_hash_map_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_hash_map_cls/deduction_guides.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_hash_map_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_hash_map_cls/deduction_guides.rst
@@ -6,51 +6,51 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``concurrent_hash_map`` support
-class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
-``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
-deduction guides are provided:
+If possible, ``concurrent_hash_map`` constructors support class template argument deduction (since C++17).
+Copy and move constructors, including constructors with an explicit ``allocator_type`` argument,
+provide implicitly-generated deduction guides.
+In addition, the following explicit deduction guides are provided:
 
 .. code:: cpp
 
     template <typename InputIterator,
               typename HashCompare = tbb_hash_compare<iterator_key_t<InputIterator>>,
-              typename Alloc = tbb_allocator<iterator_alloc_value_t<InputIterator>>>
+              typename Allocator = tbb_allocator<iterator_alloc_value_t<InputIterator>>>
     concurrent_hash_map( InputIterator, InputIterator,
                          HashCompare = HashCompare(),
-                         Alloc = Alloc() )
+                         Allocator = Allocator() )
     -> concurrent_hash_map<iterator_key_t<InputIterator>,
                            iterator_mapped_t<InputIterator>,
                            HashCompare,
-                           Alloc>;
+                           Allocator>;
 
     template <typename InputIterator,
-              typename Alloc>
-    concurrent_hash_map( InputIterator, InputIterator, Alloc )
+              typename Allocator>
+    concurrent_hash_map( InputIterator, InputIterator, Allocator )
     -> concurrent_hash_map<iterator_key_t<InputIterator>,
                            iterator_mapped_t<InputIterator>,
                            tbb_hash_compare<iterator_key_t<InputIterator>>,
-                           Alloc>;
+                           Allocator>;
 
     template <typename Key, typename T,
               typename HashCompare = tbb_hash_compare<std::remove_const_t<Key>>,
-              typename Alloc = tbb_allocator<std::pair<const Key, T>>>
+              typename Allocator = tbb_allocator<std::pair<const Key, T>>>
     concurrent_hash_map( std::initializer_list<std::pair<Key, T>>,
                          HashCompare = HashCompare(),
-                         Alloc = Alloc() )
+                         Allocator = Allocator() )
     -> concurrent_hash_map<std::remove_const_t<Key>,
                            T,
                            HashCompare,
-                           Alloc>;
+                           Allocator>;
 
     template <typename Key, typename T,
-              typename Alloc>
+              typename Allocator>
     concurrent_hash_map( std::initializer_list<std::pair<Key, T>>,
-                         Alloc )
+                         Allocator )
     -> concurrent_hash_map<std::remove_const_t<Key>,
                            T,
                            tbb_hash_compare<std::remove_const_t<Key>>,
-                           Alloc>;
+                           Allocator>;
 
 Where the type aliases ``iterator_key_t``, ``iterator_mapped_t``, and ``iterator_alloc_value_t``
 are defined as follows:
@@ -67,11 +67,11 @@ are defined as follows:
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>,
                                              iterator_mapped_t<InputIterator>>>;
 
-These deduction guides only participates in overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if all of the following are ``true``:
 
-* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
-* The type ``Alloc`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
-* The type ``HashCompare`` does not meet the requirements of ``Allocator``.
+* The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
+* The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.
+* The ``HashCompare`` type does not meet the ``Allocator`` requirements.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_hash_map_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_hash_map_cls/deduction_guides.rst
@@ -67,7 +67,7 @@ are defined as follows:
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>,
                                              iterator_mapped_t<InputIterator>>>;
 
-These deduction guides only participate in the overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if the following requirements are met:
 
 * The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
 * The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.

--- a/source/elements/oneTBB/source/containers/concurrent_map_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_map_cls/deduction_guides.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_map_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_map_cls/deduction_guides.rst
@@ -6,10 +6,10 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``concurrent_map`` support
-class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
-``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
-deduction guides are provided:
+If possible, ``concurrent_map`` constructors support class template argument deduction (since C++17).
+Copy and move constructors, including constructors with an explicit ``allocator_type`` argument,
+provide implicitly-generated deduction guides.
+In addition, the following explicit deduction guides are provided:
 
 .. code:: cpp
 
@@ -66,11 +66,11 @@ where the type aliases ``iterator_key_t``, ``iterator_mapped_t``, ``iterator_all
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>>,
                                              iterator_mapped_t<InputIterator>>;
 
-These deduction guides only participates in overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if all of the following are ``true``:
 
-* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
-* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
-* The type ``Compare`` does not meet the requirements of ``Allocator``.
+* The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
+* The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.
+* The ``Compare`` type does not meet the ``Allocator`` requirements.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_map_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_map_cls/deduction_guides.rst
@@ -6,15 +6,19 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``concurrent_map`` support class template argument
-deduction (since C++17):
+Where possible, constructors of ``concurrent_map`` support
+class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
+``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
+deduction guides are provided:
 
 .. code:: cpp
 
     template <typename InputIterator,
               typename Compare = std::less<iterator_key_t<InputIterator>>,
               typename Allocator = tbb_allocator<iterator_alloc_value_t<InputIterator>>>
-    concurrent_map( InputIterator, InputIterator, Compare = Compare(), Allocator = Allocator() )
+    concurrent_map( InputIterator, InputIterator,
+                    Compare = Compare(),
+                    Allocator = Allocator() )
     -> concurrent_map<iterator_key_t<InputIterator>,
                       iterator_mapped_t<InputIterator>,
                       Compare,
@@ -22,24 +26,31 @@ deduction (since C++17):
 
     template <typename InputIterator,
               typename Allocator>
-    concurrent_map( InputIterator, InputIterator, Allocator )
+    concurrent_map( InputIterator, InputIterator,
+                    Allocator )
     -> concurrent_map<iterator_key_t<InputIterator>,
                       iterator_mapped_t<InputIterator>,
                       std::less<iterator_key_t<InputIterator>>,
                       Allocator>;
 
-    template <typename Key,
-              typename T,
-              typename Compare = std::less<Key>,
+    template <typename Key, typename T,
+              typename Compare = std::less<std::remove_const_t<Key>>,
               typename Allocator = tbb_allocator<std::pair<const Key, T>>>
-    concurrent_map( std::initializer_list<std::pair<Key, T>>, Compare = Compare(), Allocator = Allocator() )
-    -> concurrent_map<Key, T, Compare, Allocator>;
+    concurrent_map( std::initializer_list<std::pair<Key, T>>,
+                    Compare = Compare(),
+                    Allocator = Allocator() )
+    -> concurrent_map<std::remove_const_t<Key>,
+                      T,
+                      Compare,
+                      Allocator>;
 
-    template <typename Key,
-              typename T,
+    template <typename Key, typename T,
               typename Allocator>
     concurrent_map( std::initializer_list<std::pair<Key, T>>, Allocator )
-    -> concurrent_map<Key, T, std::less<Key>, Allocator>;
+    -> concurrent_map<std::remove_const_t<Key>,
+                      T,
+                      std::less<std::remove_const_t<Key>>,
+                      Allocator>;
 
 where the type aliases ``iterator_key_t``, ``iterator_mapped_t``, ``iterator_alloc_value_t`` are defined as follows:
 
@@ -54,6 +65,12 @@ where the type aliases ``iterator_key_t``, ``iterator_mapped_t``, ``iterator_all
     template <typename InputIterator>
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>>,
                                              iterator_mapped_t<InputIterator>>;
+
+These deduction guides only participates in overload resolution if all of the following are ``true``:
+
+* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
+* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
+* The type ``Compare`` does not meet the requirements of ``Allocator``.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_map_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_map_cls/deduction_guides.rst
@@ -66,7 +66,7 @@ where the type aliases ``iterator_key_t``, ``iterator_mapped_t``, ``iterator_all
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>>,
                                              iterator_mapped_t<InputIterator>>;
 
-These deduction guides only participate in the overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if the following requirements are met:
 
 * The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
 * The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.

--- a/source/elements/oneTBB/source/containers/concurrent_multimap_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_multimap_cls/deduction_guides.rst
@@ -6,15 +6,19 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``concurrent_multimap`` support class template argument
-deduction (since C++17):
+Where possible, constructors of ``concurrent_multimap`` support
+class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
+``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
+deduction guides are provided:
 
 .. code:: cpp
 
     template <typename InputIterator,
               typename Compare = std::less<iterator_key_t<InputIterator>>,
               typename Allocator = tbb_allocator<iterator_alloc_value_t<InputIterator>>>
-    concurrent_multimap( InputIterator, InputIterator, Compare = Compare(), Allocator = Allocator() )
+    concurrent_multimap( InputIterator, InputIterator,
+                         Compare = Compare(),
+                         Allocator = Allocator() )
     -> concurrent_multimap<iterator_key_t<InputIterator>,
                            iterator_mapped_t<InputIterator>,
                            Compare,
@@ -22,24 +26,31 @@ deduction (since C++17):
 
     template <typename InputIterator,
               typename Allocator>
-    concurrent_multimap( InputIterator, InputIterator, Allocator )
+    concurrent_multimap( InputIterator, InputIterator,
+                         Allocator )
     -> concurrent_multimap<iterator_key_t<InputIterator>,
                            iterator_mapped_t<InputIterator>,
                            std::less<iterator_key_t<InputIterator>>,
                            Allocator>;
 
-    template <typename Key,
-              typename T,
-              typename Compare = std::less<Key>,
+    template <typename Key, typename T,
+              typename Compare = std::less<std::remove_const_t<Key>>,
               typename Allocator = tbb_allocator<std::pair<const Key, T>>>
-    concurrent_multimap( std::initializer_list<std::pair<Key, T>>, Compare = Compare(), Allocator = Allocator() )
-    -> concurrent_multimap<Key, T, Compare, Allocator>;
+    concurrent_multimap( std::initializer_list<std::pair<Key, T>>,
+                         Compare = Compare(),
+                         Allocator = Allocator() )
+    -> concurrent_multimap<std::remove_const_t<Key>,
+                           T,
+                           Compare,
+                           Allocator>;
 
-    template <typename Key,
-              typename T,
+    template <typename Key, typename T,
               typename Allocator>
     concurrent_multimap( std::initializer_list<std::pair<Key, T>>, Allocator )
-    -> concurrent_multimap<Key, T, std::less<Key>, Allocator>;
+    -> concurrent_multimap<std::remove_const_t<Key>,
+                           T,
+                           std::less<std::remove_const_t<Key>>,
+                           Allocator>;
 
 where the type aliases ``iterator_key_t``, ``iterator_mapped_t``, ``iterator_alloc_value_t`` are defined as follows:
 
@@ -54,6 +65,12 @@ where the type aliases ``iterator_key_t``, ``iterator_mapped_t``, ``iterator_all
     template <typename InputIterator>
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>>,
                                              iterator_mapped_t<InputIterator>>;
+
+These deduction guides only participates in overload resolution if all of the following are ``true``:
+
+* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
+* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
+* The type ``Compare`` does not meet the requirements of ``Allocator``.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_multimap_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_multimap_cls/deduction_guides.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_multimap_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_multimap_cls/deduction_guides.rst
@@ -66,7 +66,7 @@ where the type aliases ``iterator_key_t``, ``iterator_mapped_t``, ``iterator_all
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>>,
                                              iterator_mapped_t<InputIterator>>;
 
-These deduction guides only participate in the overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if the following requirements are met:
 
 * The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
 * The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.

--- a/source/elements/oneTBB/source/containers/concurrent_multimap_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_multimap_cls/deduction_guides.rst
@@ -6,10 +6,10 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``concurrent_multimap`` support
-class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
-``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
-deduction guides are provided:
+If possible, ``concurrent_multimap`` constructors support class template argument deduction (since C++17).
+Copy and move constructors, including constructors with an explicit ``allocator_type`` argument,
+provide implicitly-generated deduction guides.
+In addition, the following explicit deduction guides are provided:
 
 .. code:: cpp
 
@@ -66,11 +66,11 @@ where the type aliases ``iterator_key_t``, ``iterator_mapped_t``, ``iterator_all
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>>,
                                              iterator_mapped_t<InputIterator>>;
 
-These deduction guides only participates in overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if all of the following are ``true``:
 
-* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
-* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
-* The type ``Compare`` does not meet the requirements of ``Allocator``.
+* The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
+* The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.
+* The ``Compare`` type does not meet the ``Allocator`` requirements.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_multiset_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_multiset_cls/deduction_guides.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_multiset_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_multiset_cls/deduction_guides.rst
@@ -7,35 +7,47 @@ Deduction guides
 ================
 
 Where possible, constructors of ``concurrent_multiset`` support class template argument
-deduction (since C++17):
+deduction (since C++17). Copy and move constructors (including constructors with explicit
+``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
+deduction guides are provided:
 
 .. code:: cpp
 
     template <typename InputIterator,
               typename Compare = std::less<iterator_value_t<InputIterator>>,
-              typename Allocator = tbb_allocator<iterator_value_t<InputIterator>>>
-    concurrent_multiset( InputIterator, InputIterator, Compare = Compare(), Allocator = Allocator() )
+              typename Allocator = tbb::tbb_allocator<iterator_value_t<InputIterator>>>
+    concurrent_multiset( InputIterator, InputIterator,
+                         Compare = Compare(),
+                         Allocator = Allocator() )
     -> concurrent_multiset<iterator_value_t<InputIterator>,
                            Compare,
                            Allocator>;
 
     template <typename InputIterator,
               typename Allocator>
-    concurrent_multiset( InputIterator, InputIterator, Allocator )
+    concurrent_multiset( InputIterator, InputIterator,
+                         Allocator )
     -> concurrent_multiset<iterator_value_t<InputIterator>,
-                           std::less<iterator_key_t<InputIterator>>,
+                           std::less<iterator_value_t<InputIterator>>,
                            Allocator>;
 
-    template <typename T,
-              typename Compare = std::less<T>,
-              typename Allocator = tbb_allocator<T>>
-    concurrent_multiset( std::initializer_list<T>, Compare = Compare(), Allocator = Allocator() )
-    -> concurrent_multiset<T, Compare, Allocator>;
+    template <typename Key,
+              typename Compare = std::less<Key>,
+              typename Allocator = tbb::tbb_allocator<Key>>
+    concurrent_multiset( std::initializer_list<Key>,
+                         Compare = Compare(),
+                         Allocator = Allocator() )
+    -> concurrent_multiset<Key,
+                           Compare,
+                           Allocator>;
 
-    template <typename T,
+    template <typename Key,
               typename Allocator>
-    concurrent_multiset( std::initializer_list<T>, Allocator )
-    -> concurrent_multiset<T, std::less<Key>, Allocator>;
+    concurrent_multiset( std::initializer_list<Key>,
+                         Allocator )
+    -> concurrent_multiset<Key,
+                           std::less<Key>,
+                           Allocator>;
 
 Where the type alias ``iterator_value_t`` is defined as follows:
 
@@ -43,6 +55,12 @@ Where the type alias ``iterator_value_t`` is defined as follows:
 
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
+
+These deduction guides only participates in overload resolution if all of the following are ``true``:
+
+* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
+* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
+* The type ``Compare`` does not meet the requirements of ``Allocator``.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_multiset_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_multiset_cls/deduction_guides.rst
@@ -56,7 +56,7 @@ Where the type alias ``iterator_value_t`` is defined as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
-These deduction guides only participate in the overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if the following requirements are met:
 
 * The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
 * The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.

--- a/source/elements/oneTBB/source/containers/concurrent_multiset_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_multiset_cls/deduction_guides.rst
@@ -6,10 +6,10 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``concurrent_multiset`` support class template argument
-deduction (since C++17). Copy and move constructors (including constructors with explicit
-``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
-deduction guides are provided:
+If possible, ``concurrent_multiset`` constructors support class template argument deduction (since C++17).
+Copy and move constructors, including constructors with an explicit ``allocator_type`` argument,
+provide implicitly-generated deduction guides.
+In addition, the following explicit deduction guides are provided:
 
 .. code:: cpp
 
@@ -56,11 +56,11 @@ Where the type alias ``iterator_value_t`` is defined as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
-These deduction guides only participates in overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if all of the following are ``true``:
 
-* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
-* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
-* The type ``Compare`` does not meet the requirements of ``Allocator``.
+* The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
+* The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.
+* The ``Compare`` type does not meet the ``Allocator`` requirements.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_priority_queue_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_priority_queue_cls/deduction_guides.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_priority_queue_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_priority_queue_cls/deduction_guides.rst
@@ -7,46 +7,47 @@ Deduction guides
 ================
 
 Where possible, constructors of ``tbb::concurrent_priority_queue`` support class template argument
-deduction (since C++17):
+deduction (since C++17). Copy and move constructors (including constructors with explicit
+``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
+deduction guides are provided:
 
 .. code:: cpp
 
-    template <typename InputIterator>
-    concurrent_priority_queue( InputIterator, InputIterator)
-    -> concurrent_priority_queue<iterator_value_t<InputIterator>>>;
-
-    template <typename InputIterator, typename Compare>
-    concurrent_priority_queue( InputIterator, InputIterator, const Compare& )
+    template <typename InputIterator,
+              typename Compare = std::less<iterator_value_t<InputIterator>>,
+              typename Allocator = tbb::cache_aligned_allocator<iterator_value_t<InputIterator>>>
+    concurrent_priority_queue( InputIterator, InputIterator,
+                               Compare = Compare(),
+                               Allocator = Allocator() )
     -> concurrent_priority_queue<iterator_value_t<InputIterator>,
-                                 Compare>;
-
-    template <typename InputIterator, typename Allocator>
-    concurrent_priority_queue( InputIterator, InputIterator, const Allocator& alloc )
-    -> concurrent_priority_queue<iterator_value_t<InputIterator>,
-                                 std::less<iterator_value_t<InputIterator>,
+                                 Compare,
                                  Allocator>;
 
-    template <typename InputIterator, typename Compare, typename Allocator>
-    concurrent_priority_queue( InputIterator, InputIterator, const Compare&,
-                               const Allocator& )
+    template <typename InputIterator,
+              typename Allocator>
+    concurrent_priority_queue( InputIterator, InputIterator,
+                               Allocator )
     -> concurrent_priority_queue<iterator_value_t<InputIterator>,
-                                 Compare, Allocator>;
+                                 std::less<iterator_value_t<InputIterator>>,
+                                 Allocator>;
 
-    template <typename T>
-    concurrent_priority_queue( std::initializer_list<T> )
-    -> concurrent_priority_queue<T>;
+    template <typename T,
+              typename Compare = std::less<T>,
+              typename Allocator = tbb::cache_aligned_allocator<T>>
+    concurrent_priority_queue( std::initializer_list<T>,
+                               Compare = Compare(),
+                               Allocator = Allocator() )
+    -> concurrent_priority_queue<T,
+                                 Compare,
+                                 Allocator>;
 
-    template <typename T, typename Compare>
-    concurrent_priority_queue( std::initializer_list<T>, const Compare& )
-    -> concurrent_priority_queue<T, Compare>;
-
-    template <typename T, typename Allocator>
-    concurrent_priority_queue( std::initializer_list<T>, const Allocator& )
-    -> concurrent_priority_queue<T, std::less<T>, Allocator>;
-
-    template <typename T, typename Compare, typename Allocator>
-    concurrent_priority_queue( std::initializer_list<T>, const Compare&, const Allocator& )
-    -> concurrent_priority_queue<T, Compare, Allocator>;
+    template <typename T,
+              typename Allocator>
+    concurrent_priority_queue( std::initializer_list<T>,
+                               Allocator )
+    -> concurrent_priority_queue<T,
+                                 std::less<T>,
+                                 Allocator>;
 
 Where the type alias ``iterator_value_t`` is defined as follows:
 
@@ -55,6 +56,12 @@ Where the type alias ``iterator_value_t`` is defined as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
+These deduction guides only participates in overload resolution if all of the following are ``true``:
+
+* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
+* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
+* The type ``Compare`` does not meet the requirements of ``Allocator``.
+
 **Example**
 
 .. code:: cpp
@@ -62,13 +69,13 @@ Where the type alias ``iterator_value_t`` is defined as follows:
     #include <tbb/concurrent_priority_queue.h>
     #include <vector>
     #include <functional>
-    
+
     int main() {
         std::vector<int> vec;
-        
+
         // Deduces cpq1 as tbb::concurrent_priority_queue<int>
         tbb::concurrent_priority_queue cpq1(vec.begin(), vec.end());
-        
+
         // Deduces cpq2 as tbb::concurrent_priority_queue<int, std::greater>
         tbb::concurrent_priority_queue cpq2(vec.begin(), vec.end(), std::greater{});
     }

--- a/source/elements/oneTBB/source/containers/concurrent_priority_queue_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_priority_queue_cls/deduction_guides.rst
@@ -6,10 +6,10 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``tbb::concurrent_priority_queue`` support class template argument
-deduction (since C++17). Copy and move constructors (including constructors with explicit
-``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
-deduction guides are provided:
+If possible, ``concurrent_priority_queue`` constructors support class template argument deduction (since C++17).
+Copy and move constructors, including constructors with an explicit ``allocator_type`` argument,
+provide implicitly-generated deduction guides.
+In addition, the following explicit deduction guides are provided:
 
 .. code:: cpp
 
@@ -56,11 +56,11 @@ Where the type alias ``iterator_value_t`` is defined as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
-These deduction guides only participates in overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if all of the following are ``true``:
 
-* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
-* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
-* The type ``Compare`` does not meet the requirements of ``Allocator``.
+* The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
+* The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.
+* The ``Compare`` type does not meet the ``Allocator`` requirements.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_priority_queue_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_priority_queue_cls/deduction_guides.rst
@@ -56,7 +56,7 @@ Where the type alias ``iterator_value_t`` is defined as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
-These deduction guides only participate in the overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if the following requirements are met:
 
 * The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
 * The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.

--- a/source/elements/oneTBB/source/containers/concurrent_queue_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_queue_cls/deduction_guides.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_queue_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_queue_cls/deduction_guides.rst
@@ -7,14 +7,18 @@ Deduction guides
 ================
 
 Where possible, constructors of ``tbb::concurrent_queue`` support class template argument
-deduction (since C++17):
+deduction (since C++17). Copy and move constructors (including constructors with explicit
+``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
+deduction guides are provided:
 
 .. code:: cpp
 
     template <typename InputIterator,
-              typename Allocator = cache_aligned_allocator<iterator_value_t<InputIterator>>
-    concurrent_queue( InputIterator, InputIterator, const Allocator& = Allocator() )
-    -> concurrent_queue<iterator_value_t<InputIterator>, Allocator>;
+              typename Allocator = tbb::cache_aligned_allocator<iterator_value_t<InputIterator>>
+    concurrent_queue( InputIterator, InputIterator,
+                      Allocator = Allocator() )
+    -> concurrent_queue<iterator_value_t<InputIterator>,
+                        Allocator>;
 
 Where the type alias ``iterator_value_t`` is defined as follows:
 
@@ -22,6 +26,11 @@ Where the type alias ``iterator_value_t`` is defined as follows:
 
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
+
+These deduction guides only participates in overload resolution if all of the following are ``true``:
+
+* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
+* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_queue_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_queue_cls/deduction_guides.rst
@@ -27,7 +27,7 @@ Where the type alias ``iterator_value_t`` is defined as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
-This deduction guide only participates in the overload resolution if all of the following are ``true``:
+This deduction guide only participates in the overload resolution if the following requirements are met:
 
 * The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
 * The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.

--- a/source/elements/oneTBB/source/containers/concurrent_queue_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_queue_cls/deduction_guides.rst
@@ -6,10 +6,10 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``tbb::concurrent_queue`` support class template argument
-deduction (since C++17). Copy and move constructors (including constructors with explicit
-``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
-deduction guides are provided:
+If possible, ``concurrent_queue`` constructors support class template argument deduction (since C++17).
+Copy and move constructors, including constructors with an explicit ``allocator_type`` argument,
+provide implicitly-generated deduction guides.
+In addition, the following explicit deduction guide is provided:
 
 .. code:: cpp
 
@@ -27,10 +27,10 @@ Where the type alias ``iterator_value_t`` is defined as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
-These deduction guides only participates in overload resolution if all of the following are ``true``:
+This deduction guide only participates in the overload resolution if all of the following are ``true``:
 
-* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
-* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
+* The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
+* The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_set_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_set_cls/deduction_guides.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_set_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_set_cls/deduction_guides.rst
@@ -7,35 +7,47 @@ Deduction guides
 ================
 
 Where possible, constructors of ``concurrent_set`` support class template argument
-deduction (since C++17):
+deduction (since C++17). Copy and move constructors (including constructors with explicit
+``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
+deduction guides are provided:
 
 .. code:: cpp
 
     template <typename InputIterator,
               typename Compare = std::less<iterator_value_t<InputIterator>>,
-              typename Allocator = tbb_allocator<iterator_value_t<InputIterator>>>
-    concurrent_set( InputIterator, InputIterator, Compare = Compare(), Allocator = Allocator() )
+              typename Allocator = tbb::tbb_allocator<iterator_value_t<InputIterator>>>
+    concurrent_set( InputIterator, InputIterator,
+                    Compare = Compare(),
+                    Allocator = Allocator() )
     -> concurrent_set<iterator_value_t<InputIterator>,
                       Compare,
                       Allocator>;
 
     template <typename InputIterator,
               typename Allocator>
-    concurrent_set( InputIterator, InputIterator, Allocator )
+    concurrent_set( InputIterator, InputIterator,
+                    Allocator )
     -> concurrent_set<iterator_value_t<InputIterator>,
-                      std::less<iterator_key_t<InputIterator>>,
+                      std::less<iterator_value_t<InputIterator>>,
                       Allocator>;
 
-    template <typename T,
-              typename Compare = std::less<T>,
-              typename Allocator = tbb_allocator<T>>
-    concurrent_set( std::initializer_list<T>, Compare = Compare(), Allocator = Allocator() )
-    -> concurrent_set<T, Compare, Allocator>;
+    template <typename Key,
+              typename Compare = std::less<Key>,
+              typename Allocator = tbb::tbb_allocator<Key>>
+    concurrent_set( std::initializer_list<Key>,
+                    Compare = Compare(),
+                    Allocator = Allocator() )
+    -> concurrent_set<Key,
+                      Compare,
+                      Allocator>;
 
-    template <typename T,
+    template <typename Key,
               typename Allocator>
-    concurrent_set( std::initializer_list<T>, Allocator )
-    -> concurrent_set<T, std::less<Key>, Allocator>;
+    concurrent_set( std::initializer_list<Key>,
+                    Allocator )
+    -> concurrent_set<Key,
+                      std::less<Key>,
+                      Allocator>;
 
 Where the type alias ``iterator_value_t`` is defined as follows:
 
@@ -43,6 +55,12 @@ Where the type alias ``iterator_value_t`` is defined as follows:
 
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
+
+These deduction guides only participates in overload resolution if all of the following are ``true``:
+
+* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
+* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
+* The type ``Compare`` does not meet the requirements of ``Allocator``.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_set_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_set_cls/deduction_guides.rst
@@ -6,10 +6,10 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``concurrent_set`` support class template argument
-deduction (since C++17). Copy and move constructors (including constructors with explicit
-``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
-deduction guides are provided:
+If possible, ``concurrent_set`` constructors support class template argument deduction (since C++17).
+Copy and move constructors, including constructors with an explicit ``allocator_type`` argument,
+provide implicitly-generated deduction guides.
+In addition, the following explicit deduction guides are provided:
 
 .. code:: cpp
 
@@ -58,9 +58,9 @@ Where the type alias ``iterator_value_t`` is defined as follows:
 
 These deduction guides only participates in overload resolution if all of the following are ``true``:
 
-* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
-* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
-* The type ``Compare`` does not meet the requirements of ``Allocator``.
+* The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
+* The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.
+* The ``Compare`` type does not meet the ``Allocator`` requirements.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_set_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_set_cls/deduction_guides.rst
@@ -56,7 +56,7 @@ Where the type alias ``iterator_value_t`` is defined as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
-These deduction guides only participates in overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if the following requirements are met:
 
 * The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
 * The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_map_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_map_cls/deduction_guides.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_map_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_map_cls/deduction_guides.rst
@@ -56,7 +56,7 @@ In addition, the following explicit deduction guides are provided:
               typename T,
               typename Hash = std::hash<std::remove_const_t<Key>>,
               typename KeyEqual = std::equal_to<std::remove_const_t<Key>>,
-              typename Allocator>
+              typename Allocator = tbb::tbb_allocator<std::pair<const Key, T>>>
     concurrent_unordered_map( std::initializer_list<std::pair<Key, T>>,
                               map_size_type = {},
                               Hash = Hash(),

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_map_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_map_cls/deduction_guides.rst
@@ -6,10 +6,10 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``concurrent_unordered_map`` support
-class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
-``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
-deduction guides are provided:
+If possible, ``concurrent_unordered_map`` constructors support class template argument deduction (since C++17).
+Copy and move constructors, including constructors with an explicit ``allocator_type`` argument,
+provide implicitly-generated deduction guides.
+In addition, the following explicit deduction guides are provided:
 
 .. code:: cpp
 
@@ -105,7 +105,7 @@ deduction guides are provided:
                                 std::equal_to<std::remove_const_t<Key>>,
                                 Allocator>;
 
-where the type ``map_size_type`` refers to the ``size_type`` member type of the deduced ``concurrent_unordered_map``
+Where the ``map_size_type`` type refers to the ``size_type`` member type of the deduced ``concurrent_unordered_map``
 and the type aliases ``iterator_key_t``, ``iterator_mapped_t``, and ``iterator_alloc_value_t``
 are defined as follows:
 
@@ -121,12 +121,12 @@ are defined as follows:
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>,
                                              iterator_mapped_t<InputIterator>>>;
 
-These deduction guides only participates in overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if all of the following are ``true``:
 
-* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
-* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
-* The type ``Hash`` does not meet the requirements of ``Allocator``.
-* The type ``KeyEqual`` does not meet the requirements of ``Allocator``.
+* The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
+* The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.
+* The ``Hash`` type does not meet the ``Allocator`` requirements.
+* The ``KeyEqual`` type does not meet the ``Allocator`` requirements.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_map_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_map_cls/deduction_guides.rst
@@ -121,7 +121,7 @@ are defined as follows:
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>,
                                              iterator_mapped_t<InputIterator>>>;
 
-These deduction guides only participate in the overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if the following requirements are met:
 
 * The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
 * The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_map_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_map_cls/deduction_guides.rst
@@ -7,21 +7,39 @@ Deduction guides
 ================
 
 Where possible, constructors of ``concurrent_unordered_map`` support
-class template argument deduction (since C++17):
+class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
+``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
+deduction guides are provided:
 
 .. code:: cpp
 
     template <typename InputIterator,
               typename Hash = std::hash<iterator_key_t<InputIterator>>,
               typename KeyEqual = std::equal_to<iterator_key_t<InputIterator>>,
-              typename Allocator = tbb_allocator<iterator_alloc_value_t<InputIterator>>>
+              typename Allocator = tbb::tbb_allocator<iterator_alloc_value_t<InputIterator>>>
     concurrent_unordered_map( InputIterator, InputIterator,
-                              map_size_type = /*implementation_defined*/,
-                              Hash = Hash(), KeyEqual = KeyEqual(),
+                              map_size_type = {},
+                              Hash = Hash(),
+                              KeyEqual = KeyEqual(),
                               Allocator = Allocator() )
     -> concurrent_unordered_map<iterator_key_t<InputIterator>,
                                 iterator_mapped_t<InputIterator>,
-                                Hash, KeyEqual, Allocator>;
+                                Hash,
+                                KeyEqual,
+                                Allocator>;
+
+    template <typename InputIterator,
+              typename Hash,
+              typename Allocator>
+    concurrent_unordered_map( InputIterator, InputIterator,
+                              map_size_type,
+                              Hash,
+                              Allocator )
+    -> concurrent_unordered_map<iterator_key_t<InputIterator>,
+                                iterator_mapped_t<InputIterator>,
+                                Hash,
+                                std::equal_to<iterator_key_t<InputIterator>>,
+                                Allocator>;
 
     template <typename InputIterator,
               typename Allocator>
@@ -34,37 +52,18 @@ class template argument deduction (since C++17):
                                 std::equal_to<iterator_key_t<InputIterator>>,
                                 Allocator>;
 
-    template <typename InputIterator,
-              typename Allocator>
-    concurrent_unordered_map( InputIterator, InputIterator, Allocator )
-    -> concurrent_unordered_map<iterator_key_t<InputIterator>,
-                                iterator_mapped_t<InputIterator>,
-                                std::hash<iterator_key_t<InputIterator>>,
-                                std::equal_to<iterator_key_t<InputIterator>>,
-                                Allocator>;
-
-    template <typename InputIterator,
-              typename Hash,
-              typename Allocator>
-    concurrent_unordered_map( InputIterator, InputIterator,
-                              Hash, Allocator )
-    -> concurrent_unordered_map<iterator_key_t<InputIterator>,
-                                iterator_mapped_t<InputIterator>,
-                                Hash,
-                                std::equal_to<iterator_key_t<InputIterator>>,
-                                Allocator>;
-
     template <typename Key,
               typename T,
-              typename Hash = std::hash<Key>,
-              typename KeyEqual = std::equal_to<Key>,
-              typename Allocator = tbb_allocator<std::pair<Key, T>>>
-    concurrent_unordered_map( std::initializer_list<value_type>,
-                              map_size_type = /*implementation-defined*/,
+              typename Hash = std::hash<std::remove_const_t<Key>>,
+              typename KeyEqual = std::equal_to<std::remove_const_t<Key>>,
+              typename Allocator>
+    concurrent_unordered_map( std::initializer_list<std::pair<Key, T>>,
+                              map_size_type = {},
                               Hash = Hash(),
                               KeyEqual = KeyEqual(),
                               Allocator = Allocator() )
-    -> concurrent_unordered_map<Key, T,
+    -> concurrent_unordered_map<std::remove_const_t<Key>,
+                                T,
                                 Hash,
                                 KeyEqual,
                                 Allocator>;
@@ -72,22 +71,38 @@ class template argument deduction (since C++17):
     template <typename Key,
               typename T,
               typename Allocator>
-    concurrent_unordered_map( std::initializer_list<value_type>,
-                              map_size_type, Allocator )
-    -> concurrent_unordered_map<Key, T,
-                                std::hash<Key>,
-                                std::equal_to<Key>,
+    concurrent_unordered_map( std::initializer_list<std::pair<Key, T>>,
+                              map_size_type,
+                              Allocator )
+    -> concurrent_unordered_map<std::remove_const_t<Key>,
+                                T,
+                                std::hash<std::remove_const_t<Key>>,
+                                std::equal_to<std::remove_const_t<Key>>,
+                                Allocator>;
+
+    template <typename Key,
+              typename T,
+              typename Allocator>
+    concurrent_unordered_map( std::initializer_list<std::pair<Key, T>>,
+                              Allocator )
+    -> concurrent_unordered_map<std::remove_const_t<Key>,
+                                T,
+                                std::hash<std::remove_const_t<Key>>,
+                                std::equal_to<std::remove_const_t<Key>>,
                                 Allocator>;
 
     template <typename Key,
               typename T,
               typename Hash,
               typename Allocator>
-    concurrent_unordered_map( std::initializer_list<value_type>,
-                              map_size_type, Hash, Allocator )
-    -> concurrent_unordered_map<Key, T,
+    concurrent_unordered_map( std::initializer_list<std::pair<Key, T>>,
+                              map_size_type,
+                              Hash,
+                              Allocator )
+    -> concurrent_unordered_map<std::remove_const_t<Key>,
+                                T,
                                 Hash,
-                                std::equal_to<Key>,
+                                std::equal_to<std::remove_const_t<Key>>,
                                 Allocator>;
 
 where the type ``map_size_type`` refers to the ``size_type`` member type of the deduced ``concurrent_unordered_map``
@@ -105,6 +120,13 @@ are defined as follows:
     template <typename InputIterator>
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>,
                                              iterator_mapped_t<InputIterator>>>;
+
+These deduction guides only participates in overload resolution if all of the following are ``true``:
+
+* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
+* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
+* The type ``Hash`` does not meet the requirements of ``Allocator``.
+* The type ``KeyEqual`` does not meet the requirements of ``Allocator``.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_multimap_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_multimap_cls/deduction_guides.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_multimap_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_multimap_cls/deduction_guides.rst
@@ -6,10 +6,10 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``concurrent_unordered_multimap`` support
-class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
-``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
-deduction guides are provided:
+If possible, ``concurrent_unordered_multimap`` constructors support class template argument deduction (since C++17).
+Copy and move constructors, including constructors with an explicit ``allocator_type`` argument,
+provide implicitly-generated deduction guides.
+In addition, the following explicit deduction guides are provided:
 
 .. code:: cpp
 
@@ -105,7 +105,7 @@ deduction guides are provided:
                                      std::equal_to<std::remove_const_t<Key>>,
                                      Allocator>;
 
-where the type ``map_size_type`` refers to the ``size_type`` member type of the deduced ``concurrent_unordered_multimap``
+Where the ``map_size_type`` type refers to the ``size_type`` member type of the deduced ``concurrent_unordered_multimap``
 and the type aliases ``iterator_key_t``, ``iterator_mapped_t``, and ``iterator_alloc_value_t``
 are defined as follows:
 
@@ -121,12 +121,12 @@ are defined as follows:
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>,
                                              iterator_mapped_t<InputIterator>>>;
 
-These deduction guides only participates in overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if all of the following are ``true``:
 
-* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
-* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
-* The type ``Hash`` does not meet the requirements of ``Allocator``.
-* The type ``KeyEqual`` does not meet the requirements of ``Allocator``.
+* The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
+* The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.
+* The ``Hash`` type does not meet the ``Allocator`` requirements.
+* The ``KeyEqual`` type does not meet the ``Allocator`` requirements.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_multimap_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_multimap_cls/deduction_guides.rst
@@ -56,7 +56,7 @@ In addition, the following explicit deduction guides are provided:
               typename T,
               typename Hash = std::hash<std::remove_const_t<Key>>,
               typename KeyEqual = std::equal_to<std::remove_const_t<Key>>,
-              typename Allocator>
+              typename Allocator = tbb::tbb_allocator<std::pair<const Key, T>>>
     concurrent_unordered_multimap( std::initializer_list<std::pair<Key, T>>,
                                    map_size_type = {},
                                    Hash = Hash(),

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_multimap_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_multimap_cls/deduction_guides.rst
@@ -121,7 +121,7 @@ are defined as follows:
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>,
                                              iterator_mapped_t<InputIterator>>>;
 
-These deduction guides only participate in the overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if the following requirements are met:
 
 * The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
 * The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_multimap_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_multimap_cls/deduction_guides.rst
@@ -7,64 +7,63 @@ Deduction guides
 ================
 
 Where possible, constructors of ``concurrent_unordered_multimap`` support
-class template argument deduction (since C++17):
+class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
+``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
+deduction guides are provided:
 
 .. code:: cpp
 
     template <typename InputIterator,
               typename Hash = std::hash<iterator_key_t<InputIterator>>,
               typename KeyEqual = std::equal_to<iterator_key_t<InputIterator>>,
-              typename Allocator = tbb_allocator<iterator_alloc_value_t<InputIterator>>>
+              typename Allocator = tbb::tbb_allocator<iterator_alloc_value_t<InputIterator>>>
     concurrent_unordered_multimap( InputIterator, InputIterator,
-                                   map_size_type = /*implementation_defined*/,
-                                   Hash = Hash(), KeyEqual = KeyEqual(),
+                                   map_size_type = {},
+                                   Hash = Hash(),
+                                   KeyEqual = KeyEqual(),
                                    Allocator = Allocator() )
     -> concurrent_unordered_multimap<iterator_key_t<InputIterator>,
                                      iterator_mapped_t<InputIterator>,
-                                     Hash, KeyEqual, Allocator>;
-
-    template <typename InputIterator,
-              typename Allocator>
-    concurrent_unordered_multimap( InputIterator, InputIterator,
-                              map_size_type,
-                              Allocator )
-    -> concurrent_unordered_multimap<iterator_key_t<InputIterator>,
-                                     iterator_mapped_t<InputIterator>,
-                                     std::hash<iterator_key_t<InputIterator>>,
-                                     std::equal_to<iterator_key_t<InputIterator>>,
-                                     Allocator>;
-
-    template <typename InputIterator,
-              typename Allocator>
-    concurrent_unordered_multimap( InputIterator, InputIterator, Allocator )
-    -> concurrent_unordered_multimap<iterator_key_t<InputIterator>,
-                                     iterator_mapped_t<InputIterator>,
-                                     std::hash<iterator_key_t<InputIterator>>,
-                                     std::equal_to<iterator_key_t<InputIterator>>,
+                                     Hash,
+                                     KeyEqual,
                                      Allocator>;
 
     template <typename InputIterator,
               typename Hash,
               typename Allocator>
     concurrent_unordered_multimap( InputIterator, InputIterator,
-                              Hash, Allocator )
+                                   map_size_type,
+                                   Hash,
+                                   Allocator )
     -> concurrent_unordered_multimap<iterator_key_t<InputIterator>,
                                      iterator_mapped_t<InputIterator>,
                                      Hash,
                                      std::equal_to<iterator_key_t<InputIterator>>,
                                      Allocator>;
 
+    template <typename InputIterator,
+              typename Allocator>
+    concurrent_unordered_multimap( InputIterator, InputIterator,
+                                   map_size_type,
+                                   Allocator )
+    -> concurrent_unordered_multimap<iterator_key_t<InputIterator>,
+                                     iterator_mapped_t<InputIterator>,
+                                     std::hash<iterator_key_t<InputIterator>>,
+                                     std::equal_to<iterator_key_t<InputIterator>>,
+                                     Allocator>;
+
     template <typename Key,
               typename T,
-              typename Hash = std::hash<Key>,
-              typename KeyEqual = std::equal_to<Key>,
-              typename Allocator = tbb_allocator<std::pair<Key, T>>>
-    concurrent_unordered_multimap( std::initializer_list<value_type>,
-                                   map_size_type = /*implementation-defined*/,
+              typename Hash = std::hash<std::remove_const_t<Key>>,
+              typename KeyEqual = std::equal_to<std::remove_const_t<Key>>,
+              typename Allocator>
+    concurrent_unordered_multimap( std::initializer_list<std::pair<Key, T>>,
+                                   map_size_type = {},
                                    Hash = Hash(),
                                    KeyEqual = KeyEqual(),
                                    Allocator = Allocator() )
-    -> concurrent_unordered_multimap<Key, T,
+    -> concurrent_unordered_multimap<std::remove_const_t<Key>,
+                                     T,
                                      Hash,
                                      KeyEqual,
                                      Allocator>;
@@ -72,26 +71,42 @@ class template argument deduction (since C++17):
     template <typename Key,
               typename T,
               typename Allocator>
-    concurrent_unordered_multimap( std::initializer_list<value_type>,
-                                   map_size_type, Allocator )
-    -> concurrent_unordered_multimap<Key, T,
-                                     std::hash<Key>,
-                                     std::equal_to<Key>,
+    concurrent_unordered_multimap( std::initializer_list<std::pair<Key, T>>,
+                                   map_size_type,
+                                   Allocator )
+    -> concurrent_unordered_multimap<std::remove_const_t<Key>,
+                                     T,
+                                     std::hash<std::remove_const_t<Key>>,
+                                     std::equal_to<std::remove_const_t<Key>>,
+                                     Allocator>;
+
+    template <typename Key,
+              typename T,
+              typename Allocator>
+    concurrent_unordered_multimap( std::initializer_list<std::pair<Key, T>>,
+                                   Allocator )
+    -> concurrent_unordered_multimap<std::remove_const_t<Key>,
+                                     T,
+                                     std::hash<std::remove_const_t<Key>>,
+                                     std::equal_to<std::remove_const_t<Key>>,
                                      Allocator>;
 
     template <typename Key,
               typename T,
               typename Hash,
               typename Allocator>
-    concurrent_unordered_multimap( std::initializer_list<value_type>,
-                                   map_size_type, Hash, Allocator )
-    -> concurrent_unordered_multimap<Key, T,
+    concurrent_unordered_multimap( std::initializer_list<std::pair<Key, T>>,
+                                   map_size_type,
+                                   Hash,
+                                   Allocator )
+    -> concurrent_unordered_multimap<std::remove_const_t<Key>,
+                                     T,
                                      Hash,
-                                     std::equal_to<Key>,
+                                     std::equal_to<std::remove_const_t<Key>>,
                                      Allocator>;
 
-Where the type ``map_size_type`` refers to the ``size_type`` member type of the deduced ``concurrent_multimap``
-and the type aliases ``iterator_key_t``, ``iterator_mapped_t`` and ``iterator_alloc_value_t``
+where the type ``map_size_type`` refers to the ``size_type`` member type of the deduced ``concurrent_unordered_multimap``
+and the type aliases ``iterator_key_t``, ``iterator_mapped_t``, and ``iterator_alloc_value_t``
 are defined as follows:
 
 .. code:: cpp
@@ -104,7 +119,14 @@ are defined as follows:
 
     template <typename InputIterator>
     using iterator_alloc_value_t = std::pair<std::add_const_t<iterator_key_t<InputIterator>,
-                            iterator_mapped_t<InputIterator>>>;
+                                             iterator_mapped_t<InputIterator>>>;
+
+These deduction guides only participates in overload resolution if all of the following are ``true``:
+
+* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
+* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
+* The type ``Hash`` does not meet the requirements of ``Allocator``.
+* The type ``KeyEqual`` does not meet the requirements of ``Allocator``.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_multiset_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_multiset_cls/deduction_guides.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_multiset_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_multiset_cls/deduction_guides.rst
@@ -6,10 +6,10 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``concurrent_unordered_multiset`` support
-class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
-``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
-deduction guides are provided:
+If possible, ``concurrent_unordered_multiset`` constructors support class template argument deduction (since C++17).
+Copy and move constructors, including constructors with an explicit ``allocator_type`` argument,
+provide implicitly-generated deduction guides.
+In addition, the following explicit deduction guides are provided:
 
 .. code:: cpp
 
@@ -82,7 +82,7 @@ deduction guides are provided:
                                      std::equal_to<T>,
                                      Allocator>;
 
-Where the type ``set_size_type`` refers to the ``size_type`` member type of the deduced ``concurrent_unordered_multiset``
+Where the ``set_size_type`` type refers to the ``size_type`` member type of the deduced ``concurrent_unordered_multiset``
 and the type alias ``iterator_value_t`` is defined as follows:
 
 .. code:: cpp
@@ -90,12 +90,12 @@ and the type alias ``iterator_value_t`` is defined as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
-These deduction guides only participates in overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if all of the following are ``true``:
 
-* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
-* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
-* The type ``Hash`` does not meet the requirements of ``Allocator``.
-* The type ``KeyEqual`` does not meet the requirements of ``Allocator``.
+* The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
+* The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.
+* The ``Hash`` type does not meet the ``Allocator`` requirements.
+* The ``KeyEqual`` type does not meet the ``Allocator`` requirements.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_multiset_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_multiset_cls/deduction_guides.rst
@@ -90,7 +90,7 @@ and the type alias ``iterator_value_t`` is defined as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
-These deduction guides only participate in the overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if the following requirements are met:
 
 * The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
 * The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_multiset_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_multiset_cls/deduction_guides.rst
@@ -7,55 +7,42 @@ Deduction guides
 ================
 
 Where possible, constructors of ``concurrent_unordered_multiset`` support
-class template argument deduction (since C++17):
+class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
+``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
+deduction guides are provided:
 
 .. code:: cpp
 
     template <typename InputIterator,
               typename Hash = std::hash<iterator_value_t<InputIterator>>,
               typename KeyEqual = std::equal_to<iterator_value_t<InputIterator>>,
-              typename Allocator = tbb_allocator<iterator_value_t<InputIterator>>>
+              typename Allocator = tbb::tbb_allocator<iterator_value_t<InputIterator>>>
     concurrent_unordered_multiset( InputIterator, InputIterator,
-                                   map_size_type = /*implementation_defined*/,
-                                   Hash = Hash(), KeyEqual = KeyEqual(),
+                                   set_size_type = {},
+                                   Hash = Hash(),
+                                   KeyEqual = KeyEqual(),
                                    Allocator = Allocator() )
     -> concurrent_unordered_multiset<iterator_value_t<InputIterator>,
-                                     Hash, KeyEqual, Allocator>;
+                                     Hash,
+                                     KeyEqual,
+                                     Allocator>;
 
     template <typename InputIterator,
               typename Allocator>
     concurrent_unordered_multiset( InputIterator, InputIterator,
-                                   map_size_type,
+                                   set_size_type,
                                    Allocator )
     -> concurrent_unordered_multiset<iterator_value_t<InputIterator>,
                                      std::hash<iterator_value_t<InputIterator>>,
                                      std::equal_to<iterator_value_t<InputIterator>>,
                                      Allocator>;
 
-    template <typename InputIterator,
-              typename Allocator>
-    concurrent_unordered_multiset( InputIterator, InputIterator, Allocator )
-    -> concurrent_unordered_multiset<iterator_value_t<InputIterator>,
-                                     std::hash<iterator_value_t<InputIterator>>,
-                                     std::equal_to<iterator_key_t<InputIterator>>,
-                                     Allocator>;
-
-    template <typename InputIterator,
-              typename Hash,
-              typename Allocator>
-    concurrent_unordered_multiset( InputIterator, InputIterator,
-                                   Hash, Allocator )
-    -> concurrent_unordered_multiset<iterator_value_t<InputIterator>,
-                                     Hash,
-                                     std::equal_to<iterator_value_t<InputIterator>>,
-                                     Allocator>;
-
     template <typename T,
-              typename Hash = std::hash<Key>,
-              typename KeyEqual = std::equal_to<Key>,
-              typename Allocator = tbb_allocator<std::pair<Key, T>>>
-    concurrent_unordered_multiset( std::initializer_list<value_type>,
-                                   map_size_type = /*implementation-defined*/,
+              typename Hash = std::hash<T>,
+              typename KeyEqual = std::equal_to<T>,
+              typename Allocator = tbb::tbb_allocator<T>>
+    concurrent_unordered_multiset( std::initializer_list<T>,
+                                   set_size_type = {},
                                    Hash = Hash(),
                                    KeyEqual = KeyEqual(),
                                    Allocator = Allocator() )
@@ -66,30 +53,49 @@ class template argument deduction (since C++17):
 
     template <typename T,
               typename Allocator>
-    concurrent_unordered_multiset( std::initializer_list<value_type>,
-                                   map_size_type, Allocator )
+    concurrent_unordered_multiset( std::initializer_list<T>,
+                                   set_size_type,
+                                   Allocator )
     -> concurrent_unordered_multiset<T,
-                                     std::hash<Key>,
-                                     std::equal_to<Key>,
+                                     std::hash<T>,
+                                     std::equal_to<T>,
+                                     Allocator>;
+
+    template <typename T,
+              typename Allocator>
+    concurrent_unordered_multiset( std::initializer_list<T>,
+                                   Allocator )
+    -> concurrent_unordered_multiset<T,
+                                     std::hash<T>,
+                                     std::equal_to<T>,
                                      Allocator>;
 
     template <typename T,
               typename Hash,
               typename Allocator>
-    concurrent_unordered_multiset( std::initializer_list<value_type>,
-                              map_size_type, Hash, Allocator )
+    concurrent_unordered_multiset( std::initializer_list<T>,
+                                   set_size_type,
+                                   Hash,
+                                   Allocator )
     -> concurrent_unordered_multiset<T,
                                      Hash,
-                                     std::equal_to<Key>,
+                                     std::equal_to<T>,
                                      Allocator>;
 
-where the type ``map_size_type`` refers to the ``size_type`` member type of the deduced ``concurrent_unordered_multiset``
+Where the type ``set_size_type`` refers to the ``size_type`` member type of the deduced ``concurrent_unordered_multiset``
 and the type alias ``iterator_value_t`` is defined as follows:
 
 .. code:: cpp
 
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
+
+These deduction guides only participates in overload resolution if all of the following are ``true``:
+
+* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
+* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
+* The type ``Hash`` does not meet the requirements of ``Allocator``.
+* The type ``KeyEqual`` does not meet the requirements of ``Allocator``.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_set_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_set_cls/deduction_guides.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_set_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_set_cls/deduction_guides.rst
@@ -90,7 +90,7 @@ and the type alias ``iterator_value_t`` is defined as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
-These deduction guides only participates in overload resolution if all of the following are ``true``:
+These deduction guides only participate in the overload resolution if the following requirements are met:
 
 * The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
 * The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_set_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_set_cls/deduction_guides.rst
@@ -7,55 +7,42 @@ Deduction guides
 ================
 
 Where possible, constructors of ``concurrent_unordered_set`` support
-class template argument deduction (since C++17):
+class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
+``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
+deduction guides are provided:
 
 .. code:: cpp
 
     template <typename InputIterator,
               typename Hash = std::hash<iterator_value_t<InputIterator>>,
               typename KeyEqual = std::equal_to<iterator_value_t<InputIterator>>,
-              typename Allocator = tbb_allocator<iterator_value_t<InputIterator>>>
+              typename Allocator = tbb::tbb_allocator<iterator_value_t<InputIterator>>>
     concurrent_unordered_set( InputIterator, InputIterator,
-                              map_size_type = /*implementation_defined*/,
-                              Hash = Hash(), KeyEqual = KeyEqual(),
+                              set_size_type = {},
+                              Hash = Hash(),
+                              KeyEqual = KeyEqual(),
                               Allocator = Allocator() )
     -> concurrent_unordered_set<iterator_value_t<InputIterator>,
-                                Hash, KeyEqual, Allocator>;
+                                Hash,
+                                KeyEqual,
+                                Allocator>;
 
     template <typename InputIterator,
               typename Allocator>
     concurrent_unordered_set( InputIterator, InputIterator,
-                              map_size_type,
+                              set_size_type,
                               Allocator )
     -> concurrent_unordered_set<iterator_value_t<InputIterator>,
                                 std::hash<iterator_value_t<InputIterator>>,
                                 std::equal_to<iterator_value_t<InputIterator>>,
                                 Allocator>;
 
-    template <typename InputIterator,
-              typename Allocator>
-    concurrent_unordered_set( InputIterator, InputIterator, Allocator )
-    -> concurrent_unordered_set<iterator_value_t<InputIterator>,
-                                std::hash<iterator_value_t<InputIterator>>,
-                                std::equal_to<iterator_key_t<InputIterator>>,
-                                Allocator>;
-
-    template <typename InputIterator,
-              typename Hash,
-              typename Allocator>
-    concurrent_unordered_set( InputIterator, InputIterator,
-                              Hash, Allocator )
-    -> concurrent_unordered_set<iterator_value_t<InputIterator>,
-                                Hash,
-                                std::equal_to<iterator_value_t<InputIterator>>,
-                                Allocator>;
-
     template <typename T,
-              typename Hash = std::hash<Key>,
-              typename KeyEqual = std::equal_to<Key>,
-              typename Allocator = tbb_allocator<std::pair<Key, T>>>
-    concurrent_unordered_set( std::initializer_list<value_type>,
-                              map_size_type = /*implementation-defined*/,
+              typename Hash = std::hash<T>,
+              typename KeyEqual = std::equal_to<T>,
+              typename Allocator = tbb::tbb_allocator<T>>
+    concurrent_unordered_set( std::initializer_list<T>,
+                              set_size_type = {},
                               Hash = Hash(),
                               KeyEqual = KeyEqual(),
                               Allocator = Allocator() )
@@ -66,30 +53,49 @@ class template argument deduction (since C++17):
 
     template <typename T,
               typename Allocator>
-    concurrent_unordered_set( std::initializer_list<value_type>,
-                              map_size_type, Allocator )
+    concurrent_unordered_set( std::initializer_list<T>,
+                              set_size_type,
+                              Allocator )
     -> concurrent_unordered_set<T,
-                                std::hash<Key>,
-                                std::equal_to<Key>,
+                                std::hash<T>,
+                                std::equal_to<T>,
+                                Allocator>;
+
+    template <typename T,
+              typename Allocator>
+    concurrent_unordered_set( std::initializer_list<T>,
+                              Allocator )
+    -> concurrent_unordered_set<T,
+                                std::hash<T>,
+                                std::equal_to<T>,
                                 Allocator>;
 
     template <typename T,
               typename Hash,
               typename Allocator>
-    concurrent_unordered_set( std::initializer_list<value_type>,
-                              map_size_type, Hash, Allocator )
+    concurrent_unordered_set( std::initializer_list<T>,
+                              set_size_type,
+                              Hash,
+                              Allocator )
     -> concurrent_unordered_set<T,
                                 Hash,
-                                std::equal_to<Key>,
+                                std::equal_to<T>,
                                 Allocator>;
 
-Where the type ``map_size_type`` refers to the ``size_type`` member type of the deduced ``concurrent_unordered_set``
+Where the type ``set_size_type`` refers to the ``size_type`` member type of the deduced ``concurrent_unordered_set``
 and the type alias ``iterator_value_t`` is defined as follows:
 
 .. code:: cpp
 
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
+
+These deduction guides only participates in overload resolution if all of the following are ``true``:
+
+* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
+* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
+* The type ``Hash`` does not meet the requirements of ``Allocator``.
+* The type ``KeyEqual`` does not meet the requirements of ``Allocator``.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_unordered_set_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_unordered_set_cls/deduction_guides.rst
@@ -6,10 +6,10 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``concurrent_unordered_set`` support
-class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
-``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
-deduction guides are provided:
+If possible, ``concurrent_unordered_set`` constructors support class template argument deduction (since C++17).
+Copy and move constructors, including constructors with an explicit ``allocator_type`` argument,
+provide implicitly-generated deduction guides.
+In addition, the following explicit deduction guides are provided:
 
 .. code:: cpp
 
@@ -82,7 +82,7 @@ deduction guides are provided:
                                 std::equal_to<T>,
                                 Allocator>;
 
-Where the type ``set_size_type`` refers to the ``size_type`` member type of the deduced ``concurrent_unordered_set``
+Where the ``set_size_type`` type refers to the ``size_type`` member type of the deduced ``concurrent_unordered_set``
 and the type alias ``iterator_value_t`` is defined as follows:
 
 .. code:: cpp
@@ -92,10 +92,10 @@ and the type alias ``iterator_value_t`` is defined as follows:
 
 These deduction guides only participates in overload resolution if all of the following are ``true``:
 
-* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
-* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
-* The type ``Hash`` does not meet the requirements of ``Allocator``.
-* The type ``KeyEqual`` does not meet the requirements of ``Allocator``.
+* The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
+* The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.
+* The ``Hash`` type does not meet the ``Allocator`` requirements.
+* The ``KeyEqual`` type does not meet the ``Allocator`` requirements.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_vector_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_vector_cls/deduction_guides.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/containers/concurrent_vector_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_vector_cls/deduction_guides.rst
@@ -6,10 +6,13 @@
 Deduction guides
 ================
 
-Where possible, constructors of ``concurrent_vector`` support
-class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
-``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
-deduction guide is provided:
+If possible, ``concurrent_vector`` constructors support class template argument deduction (since C++17).
+The following constructors provide implicitly-generated deduction guides:
+
+* Copy and move constructors, including constructors with explicit ``allocator_type`` argument
+* Constructors, accepting ``std::initializer_list`` as an argument
+
+In addition, the following explicit deduction guide is provided:
 
 .. code:: cpp
 
@@ -27,10 +30,10 @@ Where type alias ``iterator_value_t`` defines as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
-This deduction guide only participates in overload resolution if all of the following are ``true``:
+This deduction guide only participate in the overload resolution if all of the following are ``true``:
 
-* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
-* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
+* The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
+* The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_vector_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_vector_cls/deduction_guides.rst
@@ -7,14 +7,16 @@ Deduction guides
 ================
 
 Where possible, constructors of ``concurrent_vector`` support
-class template argument deduction (since C++17):
+class template argument deduction (since C++17). Copy and move constructors (including constructors with explicit
+``allocator_type`` argument) provides implicitly generated deduction guides. In addition, the following explicit
+deduction guide is provided:
 
 .. code:: cpp
 
     template <typename InputIterator,
-              typename Allocator = cache_aligned_allocator<iterator_value_t<InputIterator>>>
+              typename Allocator = tbb::cache_aligned_allocator<iterator_value_t<InputIterator>>>
     concurrent_vector( InputIterator, InputIterator,
-                       const Allocator& = Allocator() )
+                       Allocator = Allocator() )
     -> concurrent_vector<iterator_value_t<InputIterator>,
                          Allocator>;
 
@@ -24,6 +26,11 @@ Where type alias ``iterator_value_t`` defines as follows:
 
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
+
+This deduction guide only participates in overload resolution if all of the following are ``true``:
+
+* The type ``InputIterator`` meets the requirements of  ``InputIterator`` from the [input.iterators] ISO C++ Standard section.
+* The type ``Allocator`` meets the requirements of ``Allocator`` from the [allocator.requirements] ISO C++ Standard section.
 
 **Example**
 

--- a/source/elements/oneTBB/source/containers/concurrent_vector_cls/deduction_guides.rst
+++ b/source/elements/oneTBB/source/containers/concurrent_vector_cls/deduction_guides.rst
@@ -30,7 +30,7 @@ Where type alias ``iterator_value_t`` defines as follows:
     template <typename InputIterator>
     using iterator_value_t = typename std::iterator_traits<InputIterator>::value_type;
 
-This deduction guide only participate in the overload resolution if all of the following are ``true``:
+This deduction guide only participate in the overload resolution if the following requirements are met:
 
 * The ``InputIterator`` type meets the ``InputIterator`` requirements described in the [input.iterators] section of the ISO C++ Standard.
 * The ``Allocator`` type meets the ``Allocator`` requirements described in the [allocator.requirements] section of the ISO C++ Standard.


### PR DESCRIPTION
The change was done to clarify the deduction guides description, align it with the STL approach.

Signed-off-by: kboyarinov konstantin.boyarinov@intel.com