### PR TITLE
[oneTBB] Add task_scheduler_handle

### DIFF
--- a/source/elements/oneTBB/source/deprecated/task_arena_attach_tag.rst
+++ b/source/elements/oneTBB/source/deprecated/task_arena_attach_tag.rst
@@ -3,7 +3,7 @@
 .. SPDX-License-Identifier: CC-BY-4.0
 
 ==================
-task_arena::attach 
+task_arena::attach
 ==================
 **[deprecated.task_arena_attach_tag]**
 
@@ -15,23 +15,25 @@ A set of methods for constructing a ``task_arena`` with ``attach``.
 
 .. code:: cpp
 
-    // Defined in header <tbb/task_arena.h>
+    // Defined in header <oneapi/tbb/task_arena.h>
 
-    namespace tbb {
+    namespace oneapi {
+        namespace tbb {
 
-        class task_arena {
-        public:
-            // ...
-            struct attach {};
+            class task_arena {
+            public:
+                // ...
+                struct attach {};
 
-            explicit task_arena(task_arena::attach);
-            void initialize(task_arena::attach);
-            // ...
-        };
+                explicit task_arena(task_arena::attach);
+                void initialize(task_arena::attach);
+                // ...
+            };
 
-    } // namespace tbb
+        } // namespace tbb
+    } // namespace oneapi
 
-    
+
 Member types and constants
 --------------------------
 
@@ -52,7 +54,7 @@ Member functions
         Unlike other ``task_arena`` constructors, this one automatically initializes
         the new ``task_arena`` when connecting to an already existing arena.
 
-        
+
 .. cpp:function:: void initialize(task_arena::attach)
 
     If an internal task arena representation currently used by the calling thread, the method ignores arena

--- a/source/elements/oneTBB/source/deprecated/task_arena_attach_tag.rst
+++ b/source/elements/oneTBB/source/deprecated/task_arena_attach_tag.rst
@@ -49,7 +49,7 @@ Member functions
 
     .. note::
 
-        Unlike other constructors, this one automatically initializes
+        Unlike other ``task_arena`` constructors, this one automatically initializes
         the new ``task_arena`` when connecting to an already existing arena.
 
         

--- a/source/elements/oneTBB/source/deprecated/task_arena_attach_tag.rst
+++ b/source/elements/oneTBB/source/deprecated/task_arena_attach_tag.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 
@@ -9,9 +9,9 @@ task_arena::attach
 
     .. caution::
 
-        Deprecated in oneTBB Specification 1.1
+        Deprecated in oneTBB Specification 1.1.
 
-A set of methods for constructing a task_arena with attach.
+A set of methods for constructing a ``task_arena`` with ``attach``.
 
 .. code:: cpp
 
@@ -37,7 +37,7 @@ Member types and constants
 
 .. cpp:struct:: attach
 
-    A tag for constructing a task_arena with attach.
+    A tag for constructing a ``task_arena`` with ``attach``.
 
 Member functions
 ----------------

--- a/source/elements/oneTBB/source/deprecated/task_arena_attach_tag.rst
+++ b/source/elements/oneTBB/source/deprecated/task_arena_attach_tag.rst
@@ -1,0 +1,64 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+==================
+task_arena::attach 
+==================
+**[deprecated.task_arena_attach_tag]**
+
+    .. caution::
+
+        Deprecated in oneTBB Specification 1.1
+
+A set of methods for constructing a task_arena with attach.
+
+.. code:: cpp
+
+    // Defined in header <tbb/task_arena.h>
+
+    namespace tbb {
+
+        class task_arena {
+        public:
+            // ...
+            struct attach {};
+
+            explicit task_arena(task_arena::attach);
+            void initialize(task_arena::attach);
+            // ...
+        };
+
+    } // namespace tbb
+
+    
+Member types and constants
+--------------------------
+
+.. cpp:struct:: attach
+
+    A tag for constructing a task_arena with attach.
+
+Member functions
+----------------
+
+.. cpp:function:: explicit task_arena(task_arena::attach)
+
+    Creates an instance of ``task_arena`` that is connected to the internal task arena representation currently used by the calling thread.
+    If no such arena exists yet, creates a ``task_arena`` with default parameters.
+
+    .. note::
+
+        Unlike other constructors, this one automatically initializes
+        the new ``task_arena`` when connecting to an already existing arena.
+
+        
+.. cpp:function:: void initialize(task_arena::attach)
+
+    If an internal task arena representation currently used by the calling thread, the method ignores arena
+    parameters and connects ``task_arena`` to that internal task arena representation.
+    The method has no effect when called for an already initialized ``task_arena``.
+
+See also:
+
+* :doc:`attach <../task_scheduler/attach_tag_type>`

--- a/source/elements/oneTBB/source/index.rst
+++ b/source/elements/oneTBB/source/index.rst
@@ -35,3 +35,9 @@ oneAPI Threading Building Blocks Specification
    mutual_exclusion.rst
    timing.rst
    info_namespace.rst
+
+.. toctree::
+   :maxdepth: 2
+   :caption: oneTBB Deprecated Interfaces:
+
+   deprecated/task_arena_attach_tag.rst

--- a/source/elements/oneTBB/source/index.rst
+++ b/source/elements/oneTBB/source/index.rst
@@ -40,4 +40,4 @@ oneAPI Threading Building Blocks Specification
    :maxdepth: 2
    :caption: oneTBB Deprecated Interfaces:
 
-   deprecated/task_arena_attach_tag.rst
+   task_arena_attach_tag.rst

--- a/source/elements/oneTBB/source/index.rst
+++ b/source/elements/oneTBB/source/index.rst
@@ -40,4 +40,4 @@ oneAPI Threading Building Blocks Specification
    :maxdepth: 2
    :caption: oneTBB Deprecated Interfaces:
 
-   task_arena_attach_tag.rst
+   deprecated/task_arena_attach_tag.rst

--- a/source/elements/oneTBB/source/nested-depr-interfaces.rst
+++ b/source/elements/oneTBB/source/nested-depr-interfaces.rst
@@ -1,0 +1,12 @@
+.. SPDX-FileCopyrightText: 2021 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+=============================
+ oneTBB Deprecated Interfaces
+=============================
+
+.. toctree::
+   :maxdepth: 2
+
+   deprecated/task_arena_attach_tag.rst

--- a/source/elements/oneTBB/source/nested-index.rst
+++ b/source/elements/oneTBB/source/nested-index.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/nested-index.rst
+++ b/source/elements/oneTBB/source/nested-index.rst
@@ -14,3 +14,4 @@ oneTBB
    nested-gen-info
    nested-interfaces
    nested-aux-interfaces
+   nested-depr-interfaces

--- a/source/elements/oneTBB/source/task_scheduler.rst
+++ b/source/elements/oneTBB/source/task_scheduler.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/task_scheduler.rst
+++ b/source/elements/oneTBB/source/task_scheduler.rst
@@ -37,6 +37,7 @@ Scheduling controls
    task_scheduler/scheduling_controls/task_group_context_cls.rst
    task_scheduler/scheduling_controls/global_control_cls.rst
    task_scheduler/scheduling_controls/resumable_tasks.rst
+   task_scheduler/scheduling_controls/task_scheduler_handle_cls.rst
 
 Task Group
 ----------
@@ -56,3 +57,12 @@ Task Arena
    task_scheduler/task_arena/task_arena_cls.rst
    task_scheduler/task_arena/this_task_arena_ns.rst
    task_scheduler/task_arena/task_scheduler_observer_cls.rst
+
+Helper types
+------------
+
+.. toctree::
+   :titlesonly:
+
+   task_scheduler/attach_tag_type.rst
+

--- a/source/elements/oneTBB/source/task_scheduler/attach_tag_type.rst
+++ b/source/elements/oneTBB/source/task_scheduler/attach_tag_type.rst
@@ -1,0 +1,24 @@
+.. SPDX-FileCopyrightText: 2021 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+===============
+attach tag type
+===============
+**[scheduler.attach]**
+
+An ``attach`` tag type is specifically used with ``task_arena`` and 
+``task_scheduler_handle`` interfaces. It is guaranteed to be default constructible.
+
+.. code:: cpp
+
+    namespace oneapi {
+        namespace tbb {
+            using attach = /* unspecified */
+        }
+    }
+
+See also:
+
+* :doc:`task_arena <task_arena/task_arena_cls>`
+* :doc:`task_scheduler_handle <scheduling_controls/task_scheduler_handle_cls>`

--- a/source/elements/oneTBB/source/task_scheduler/attach_tag_type.rst
+++ b/source/elements/oneTBB/source/task_scheduler/attach_tag_type.rst
@@ -8,7 +8,7 @@ attach tag type
 **[scheduler.attach]**
 
 An ``attach`` tag type is specifically used with ``task_arena`` and 
-``task_scheduler_handle`` interfaces. It is guaranteed to be default constructible.
+``task_scheduler_handle`` interfaces. It is guaranteed to be constructible by default.
 
 .. code:: cpp
 

--- a/source/elements/oneTBB/source/task_scheduler/scheduling_controls/task_scheduler_handle_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/scheduling_controls/task_scheduler_handle_cls.rst
@@ -20,8 +20,6 @@ thread until the completion of all worker threads that were implicitly created b
     namespace oneapi {
         namespace tbb {
 
-            using attach = /* unspecified */
-
             class task_scheduler_handle {
             public:
                 task_scheduler_handle() = default;
@@ -49,7 +47,7 @@ Member Functions
 
 .. cpp:function:: task_scheduler_handle()
 
-    **Effects**: Creates an instance of the ``task_scheduler_handle`` class that does not contain any reference to the task scheduler.
+    **Effects**: Creates an empty instance of the ``task_scheduler_handle`` class that does not contain any reference to the task scheduler.
     
 -------------------------------------------------------
 
@@ -63,7 +61,7 @@ Member Functions
 .. cpp:function:: ~task_scheduler_handle()
 
     **Effects**: Destroys an instance of the ``task_scheduler_handle`` class.
-    Releases a reference to the task scheduler and deactivates an instance of the ``task_scheduler_handle`` class.
+    If not empty, releases a reference to the task scheduler and deactivates an instance of the ``task_scheduler_handle`` class.
 
 -------------------------------------------------------
 
@@ -75,31 +73,30 @@ Member Functions
 
 .. cpp:function:: task_scheduler_handle& operator=(task_scheduler_handle&& other) noexcept
 
-    **Effects**: Releases a reference to the task scheduler referenced by ``this``. Adds a reference to the task scheduler referenced by ``other``.
+    **Effects**: If not empty, releases a reference to the task scheduler referenced by ``this``. Adds a reference to the task scheduler referenced by ``other``.
     In turn, ``other`` releases its reference to the task scheduler.
-
-**Returns**: A reference to ``*this``.
+    **Returns**: A reference to ``*this``.
 
 -------------------------------------------------------
 
 .. cpp:function:: explicit operator bool() const noexcept
 
-    **Returns**: ``true`` if ``this`` references any task scheduler; ``false`` otherwise.
+    **Returns**: ``true`` if ``this`` is not empty and references any task scheduler; ``false`` otherwise.
 
 -------------------------------------------------------
 
 .. cpp:function:: void release()
 
-    **Effects**: Releases a reference to the task scheduler and deactivates an instance of the ``task_scheduler_handle``
-    class. Non-blocking method.
+    **Effects**: If not empty, releases a reference to the task scheduler and deactivates an instance of the ``task_scheduler_handle``
+    class; no effect otherwise. Non-blocking method.
 
 Non-member Functions
 --------------------
 
 .. cpp:function:: void finalize(task_scheduler_handle& handle)
 
-    **Effects**: Blocks the program execution until all worker threads have been completed. Throws the ``oneapi::tbb::unsafe_wait``
-    exception if it is not safe to wait for the completion of the worker threads.
+    **Effects**: If ``handle`` is not empty, blocks the program execution until all worker threads have been completed; no effect otherwise.
+    Throws the ``oneapi::tbb::unsafe_wait`` exception if it is not safe to wait for the completion of the worker threads.
 
 The following conditions should be met for finalization to succeed:
 
@@ -124,8 +121,9 @@ If calls are performed simultaneously, more than one call might succeed.
 
 .. cpp:function:: bool finalize(task_scheduler_handle& handle, const std::nothrow_t&) noexcept
 
-    **Effects**: Blocks the program execution until all worker threads have been completed. Same as above, but returns ``true`` if all worker
-    threads have been completed successfully, or ``false`` if it is not safe to wait for the completion of the worker threads.
+    **Effects**: If ``handle`` is not empty, blocks the program execution until all worker threads have been completed; no effect otherwise.
+    Same as above, but returns ``true`` if all worker threads have been completed successfully, or ``false`` if it is not safe to wait for 
+    the completion of the worker threads.
 
 Examples
 --------

--- a/source/elements/oneTBB/source/task_scheduler/scheduling_controls/task_scheduler_handle_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/scheduling_controls/task_scheduler_handle_cls.rst
@@ -7,7 +7,7 @@ task_scheduler_handle
 =====================
 **[scheduler.task_scheduler_handle]**
 
-The ``oneapi::tbb::task_scheduler_handle`` class and the ``oneapi::tbb::finalize`` function allow to wait for completion of worker threads.
+The ``oneapi::tbb::task_scheduler_handle`` class and the ``oneapi::tbb::finalize`` function allow user to wait for completion of worker threads.
 
 When the ``oneapi::tbb::finalize`` function is called with an ``oneapi::tbb::task_scheduler_handle`` instance, it blocks the calling
 thread until the completion of all worker threads that were implicitly created by the library.
@@ -47,7 +47,7 @@ Member Functions
 
 .. cpp:function:: task_scheduler_handle()
 
-    **Effects**: Creates an empty instance of the ``task_scheduler_handle`` class that does not contain any reference to the task scheduler.
+    **Effects**: Creates an empty instance of the ``task_scheduler_handle`` class that does not contain any references to the task scheduler.
     
 -------------------------------------------------------
 
@@ -81,7 +81,7 @@ Member Functions
 
 .. cpp:function:: explicit operator bool() const noexcept
 
-    **Returns**: ``true`` if ``this`` is not empty and references any task scheduler; ``false`` otherwise.
+    **Returns**: ``true`` if ``this`` is not empty and refers to some task scheduler; ``false`` otherwise.
 
 -------------------------------------------------------
 
@@ -100,8 +100,8 @@ Non-member Functions
 
 The following conditions should be met for finalization to succeed:
 
-- No active (not yet terminated) instances of class ``task_arena`` exist in the whole program;
-- ``task_scheduler_handle::release`` is called for each other active instance of class ``task_scheduler_handle``, possibly by different application threads.
+- No active, not yet terminated, instances of ``task_arena`` class exist in the whole program.
+- ``task_scheduler_handle::release`` is called for each other active instance of ``task_scheduler_handle`` class, possibly by different application threads.
 
 Under these conditions, it is guaranteed that at least one ``finalize`` call succeeds,
 at which point all worker threads have been completed.
@@ -109,7 +109,7 @@ If calls are performed simultaneously, more than one call might succeed.
 
 .. note::
 
-    If you know how many active ``task_scheduler_handle`` instances exist in the program,
+    If user knows how many active ``task_scheduler_handle`` instances exist in the program,
     it is necessary to ``release`` all but the last one, then call ``finalize`` for
     the last instance.
 

--- a/source/elements/oneTBB/source/task_scheduler/scheduling_controls/task_scheduler_handle_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/scheduling_controls/task_scheduler_handle_cls.rst
@@ -1,0 +1,156 @@
+.. SPDX-FileCopyrightText: 2021 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+=====================
+task_scheduler_handle
+=====================
+**[scheduler.task_scheduler_handle]**
+
+The ``oneapi::tbb::task_scheduler_handle`` class and the ``oneapi::tbb::finalize`` function allow to wait for completion of worker threads.
+
+When the ``oneapi::tbb::finalize`` function is called with an ``oneapi::tbb::task_scheduler_handle`` instance, it blocks the calling
+thread until the completion of all worker threads that were implicitly created by the library.
+
+
+.. code:: cpp
+
+    // Defined in header <oneapi/tbb/global_control.h>
+
+    namespace oneapi {
+        namespace tbb {
+
+            using attach = /* unspecified */
+
+            class task_scheduler_handle {
+            public:
+                task_scheduler_handle() = default;
+                task_scheduler_handle(oneapi::tbb::attach);
+                ~task_scheduler_handle();
+
+                task_scheduler_handle(const task_scheduler_handle& other) = delete;
+                task_scheduler_handle(task_scheduler_handle&& other) noexcept;
+                task_scheduler_handle& operator=(const task_scheduler_handle& other) = delete;
+                task_scheduler_handle& operator=(task_scheduler_handle&& other) noexcept;
+
+                explicit operator bool() const noexcept;
+
+                void release();
+            };
+
+            void finalize(task_scheduler_handle& handle);
+            bool finalize(task_scheduler_handle& handle, const std::nothrow_t&) noexcept;
+
+        } // namespace tbb
+    } // namespace oneapi
+
+Member Functions
+----------------
+
+.. cpp:function:: task_scheduler_handle()
+
+    **Effects**: Creates an instance of the ``task_scheduler_handle`` class that does not contain any reference to the task scheduler.
+    
+-------------------------------------------------------
+
+.. cpp:function:: task_scheduler_handle(oneapi::tbb::attach)
+
+    **Effects**: Creates an instance of the ``task_scheduler_handle`` class that holds a reference to the task scheduler preventing
+    its premature destruction.
+
+-------------------------------------------------------
+
+.. cpp:function:: ~task_scheduler_handle()
+
+    **Effects**: Destroys an instance of the ``task_scheduler_handle`` class.
+    Releases a reference to the task scheduler and deactivates an instance of the ``task_scheduler_handle`` class.
+
+-------------------------------------------------------
+
+.. cpp:function:: task_scheduler_handle(task_scheduler_handle&& other) noexcept
+
+    **Effects**: Creates an instance of the ``task_scheduler_handle`` class that references the task scheduler referenced by ``other``. In turn, ``other`` releases its reference to the task scheduler.
+
+-------------------------------------------------------
+
+.. cpp:function:: task_scheduler_handle& operator=(task_scheduler_handle&& other) noexcept
+
+    **Effects**: Releases a reference to the task scheduler referenced by ``this``. Adds a reference to the task scheduler referenced by ``other``.
+    In turn, ``other`` releases its reference to the task scheduler.
+
+-------------------------------------------------------
+
+.. cpp:function:: explicit operator bool() const noexcept
+
+    **Returns**: ``true`` if ``this`` references any task scheduler; ``false`` otherwise.
+
+-------------------------------------------------------
+
+.. cpp:function:: void release()
+
+    **Effects**: Releases a reference to the task scheduler and deactivates an instance of the ``task_scheduler_handle``
+    class. Non-blocking method.
+
+Non-member Functions
+--------------------
+
+.. cpp:function:: void finalize(task_scheduler_handle& handle)
+
+    **Effects**: Blocks the program execution until all worker threads have been completed. Throws the ``oneapi::tbb::unsafe_wait``
+    exception if it is not safe to wait for the completion of the worker threads.
+
+The following conditions should be met for finalization to succeed:
+
+- No active (not yet terminated) instances of class ``task_arena`` exist in the whole program;
+- ``task_scheduler_handle::release`` is called for each other active instance of class ``task_scheduler_handle``, possibly by different application threads.
+
+Under these conditions, it is guaranteed that at least one ``finalize`` call succeeds,
+at which point all worker threads have been completed.
+If calls are performed simultaneously, more than one call might succeed.
+
+.. note::
+
+    If you know how many active ``task_scheduler_handle`` instances exist in the program,
+    it is necessary to ``release`` all but the last one, then call ``finalize`` for
+    the last instance.
+
+.. caution::
+
+  The method always fails if called within a task, a parallel algorithm, or a flow graph node.
+
+-------------------------------------------------------
+
+.. cpp:function:: bool finalize(task_scheduler_handle& handle, const std::nothrow_t&) noexcept
+
+    **Effects**: Blocks the program execution until all worker threads have been completed. Same as above, but returns ``true`` if all worker
+    threads have been completed successfully, or ``false`` if it is not safe to wait for the completion of the worker threads.
+
+Examples
+--------
+
+.. code:: cpp
+
+    #include <oneapi/tbb/global_control.h>
+    #include <oneapi/tbb/parallel_for.h>
+
+    #include <iostream>
+
+    int main() {
+        oneapi::tbb::task_scheduler_handle handle;
+
+        handle = oneapi::tbb::task_scheduler_handle{oneapi::tbb::attach{}};
+        
+        // Do some parallel work here, e.g.
+        oneapi::tbb::parallel_for(0, 10000, [](int){});
+        try {
+            oneapi::tbb::finalize(handle);
+            // oneTBB worker threads are terminated at this point.
+        } catch (const oneapi::tbb::unsafe_wait&) {
+            std::cerr << "Failed to terminate the worker threads." << std::endl;
+        }
+        return 0;
+    }
+
+See also:
+
+* :doc:`attach <../attach_tag_type>`

--- a/source/elements/oneTBB/source/task_scheduler/scheduling_controls/task_scheduler_handle_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/scheduling_controls/task_scheduler_handle_cls.rst
@@ -122,8 +122,7 @@ If calls are performed simultaneously, more than one call might succeed.
 .. cpp:function:: bool finalize(task_scheduler_handle& handle, const std::nothrow_t&) noexcept
 
     **Effects**: If ``handle`` is not empty, blocks the program execution until all worker threads have been completed; no effect otherwise.
-    Same as above, but returns ``true`` if all worker threads have been completed successfully, or ``false`` if it is not safe to wait for 
-    the completion of the worker threads.
+    The behavior is the same as finalize(handle); however, ``false`` is returned instead of exception  or ``true`` if no exception.
 
 Examples
 --------

--- a/source/elements/oneTBB/source/task_scheduler/scheduling_controls/task_scheduler_handle_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/scheduling_controls/task_scheduler_handle_cls.rst
@@ -78,6 +78,8 @@ Member Functions
     **Effects**: Releases a reference to the task scheduler referenced by ``this``. Adds a reference to the task scheduler referenced by ``other``.
     In turn, ``other`` releases its reference to the task scheduler.
 
+**Returns**: A reference to ``*this``.
+
 -------------------------------------------------------
 
 .. cpp:function:: explicit operator bool() const noexcept

--- a/source/elements/oneTBB/source/task_scheduler/scheduling_controls/task_scheduler_handle_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/scheduling_controls/task_scheduler_handle_cls.rst
@@ -88,14 +88,14 @@ Member Functions
 .. cpp:function:: void release()
 
     **Effects**: If not empty, releases a reference to the task scheduler and deactivates an instance of the ``task_scheduler_handle``
-    class; no effect otherwise. Non-blocking method.
+    class; otherwise, does nothing. Non-blocking method.
 
 Non-member Functions
 --------------------
 
 .. cpp:function:: void finalize(task_scheduler_handle& handle)
 
-    **Effects**: If ``handle`` is not empty, blocks the program execution until all worker threads have been completed; no effect otherwise.
+    **Effects**: If ``handle`` is not empty, blocks the program execution until all worker threads have been completed; otherwise, does nothing.
     Throws the ``oneapi::tbb::unsafe_wait`` exception if it is not safe to wait for the completion of the worker threads.
 
 The following conditions should be met for finalization to succeed:
@@ -121,7 +121,7 @@ If calls are performed simultaneously, more than one call might succeed.
 
 .. cpp:function:: bool finalize(task_scheduler_handle& handle, const std::nothrow_t&) noexcept
 
-    **Effects**: If ``handle`` is not empty, blocks the program execution until all worker threads have been completed; no effect otherwise.
+    **Effects**: If ``handle`` is not empty, blocks the program execution until all worker threads have been completed; otherwise, does nothing.
     The behavior is the same as finalize(handle); however, ``false`` is returned instead of exception  or ``true`` if no exception.
 
 Examples

--- a/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 

--- a/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
@@ -15,6 +15,8 @@ A class that represents an explicit, user-managed task scheduler arena.
 
     namespace tbb {
 
+        using attach = /* unspecified */
+
         class task_arena {
         public:
             static const int automatic = /* unspecified */;
@@ -24,7 +26,7 @@ A class that represents an explicit, user-managed task scheduler arena.
                 normal = /* unspecified */,
                 high = /* unspecified */
             };
-            struct attach {};
+            struct attach {}; /* Deprecated (compatibility with oneTBB Specification 1.0), use oneapi::tbb::attach */
             struct constraints {
                 numa_node_id numa_node;
                 int max_concurrency;
@@ -38,7 +40,8 @@ A class that represents an explicit, user-managed task scheduler arena.
             task_arena(constraints a_constraints, unsigned reserved_for_masters = 1,
                        priority a_priority = priority::normal);
             task_arena(const task_arena &s);
-            explicit task_arena(task_arena::attach);
+            explicit task_arena(oneapi::tbb::attach);
+            explicit task_arena(task_arena::attach); /* Deprecated (compatibility with oneTBB Specification 1.0), use oneapi::tbb::attach version */
             ~task_arena();
 
             void initialize();
@@ -46,7 +49,9 @@ A class that represents an explicit, user-managed task scheduler arena.
                             priority a_priority = priority::normal);
             void initialize(constraints a_constraints, unsigned reserved_for_masters = 1,
                             priority a_priority = priority::normal);
-            void initialize(task_arena::attach);
+            void initialize(oneapi::tbb::attach);
+            void initialize(task_arena::attach); /* Deprecated (compatibility with oneTBB Specification 1.0), use oneapi::tbb::attach version */
+
             void terminate();
 
             bool is_active() const;
@@ -108,6 +113,10 @@ Member types and constants
 
     A tag for constructing a ``task_arena`` with attach.
 
+    .. caution::
+
+        ``struct attach`` is deprecated (compatibility with oneTBB Specification 1.0), use oneapi::tbb::attach
+
 .. cpp:struct:: constraints
 
     Represents limitations applied to threads within ``task_arena``.
@@ -158,6 +167,16 @@ Member functions
 
     Copies settings from another ``task_arena`` instance.
 
+.. cpp:function:: explicit task_arena(oneapi::tbb::attach)
+
+    Creates an instance of ``task_arena`` that is connected to the internal task arena representation currently used by the calling thread.
+    If no such arena exists yet, creates a ``task_arena`` with default parameters.
+
+    .. note::
+
+        Unlike other constructors, this one automatically initializes
+        the new ``task_arena`` when connecting to an already existing arena.
+
 .. cpp:function:: explicit task_arena(task_arena::attach)
 
     Creates an instance of ``task_arena`` that is connected to the internal task arena representation currently used by the calling thread.
@@ -167,6 +186,10 @@ Member functions
 
         Unlike other constructors, this one automatically initializes
         the new ``task_arena`` when connecting to an already existing arena.
+
+    .. caution::
+
+        ``struct attach`` is deprecated (compatibility with oneTBB Specification 1.0), use oneapi::tbb::attach version
 
 .. cpp:function:: ~task_arena()
 
@@ -190,12 +213,21 @@ Member functions
 
     Same as above.
 
-.. cpp:function:: void initialize(task_arena::attach)
+.. cpp:function:: void initialize(oneapi::tbb::attach)
 
-    If an instance of class ``task_arena::attach`` is specified as the argument, and there is
-    an internal task arena representation currently used by the calling thread, the method ignores arena
+    If an internal task arena representation currently used by the calling thread, the method ignores arena
     parameters and connects ``task_arena`` to that internal task arena representation.
     The method has no effect when called for an already initialized ``task_arena``.
+
+.. cpp:function:: void initialize(task_arena::attach)
+
+    If an internal task arena representation currently used by the calling thread, the method ignores arena
+    parameters and connects ``task_arena`` to that internal task arena representation.
+    The method has no effect when called for an already initialized ``task_arena``.
+
+    .. caution::
+
+        ``struct attach`` is deprecated (compatibility with oneTBB Specification 1.0), use oneapi::tbb::attach version
 
 .. cpp:function:: void terminate()
 
@@ -293,5 +325,6 @@ to the corresponding NUMA node.
 
 See also:
 
+* :doc:`attach <../attach_tag_type>`
 * :doc:`task_group <../task_group/task_group_cls>`
 * :doc:`task_scheduler_observer <task_scheduler_observer_cls>`

--- a/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
@@ -11,53 +11,55 @@ A class that represents an explicit, user-managed task scheduler arena.
 
 .. code:: cpp
 
-    // Defined in header <tbb/task_arena.h>
+    // Defined in header <oneapi/tbb/task_arena.h>
 
-    namespace tbb {
+    namespace oneapi {
+        namespace tbb {
 
-        class task_arena {
-        public:
-            static const int automatic = /* unspecified */;
-            static const int not_initialized = /* unspecified */;
-            enum class priority : /* unspecified type */ {
-                low = /* unspecified */,
-                normal = /* unspecified */,
-                high = /* unspecified */
+            class task_arena {
+            public:
+                static const int automatic = /* unspecified */;
+                static const int not_initialized = /* unspecified */;
+                enum class priority : /* unspecified type */ {
+                    low = /* unspecified */,
+                    normal = /* unspecified */,
+                    high = /* unspecified */
+                };
+
+                struct constraints {
+                    numa_node_id numa_node;
+                    int max_concurrency;
+
+                    constraints(numa_node_id numa_node_       = task_arena::automatic,
+                                int          max_concurrency_ = task_arena::automatic);
+                };
+
+                task_arena(int max_concurrency = automatic, unsigned reserved_for_masters = 1,
+                        priority a_priority = priority::normal);
+                task_arena(constraints a_constraints, unsigned reserved_for_masters = 1,
+                        priority a_priority = priority::normal);
+                task_arena(const task_arena &s);
+                explicit task_arena(oneapi::tbb::attach);
+                ~task_arena();
+
+                void initialize();
+                void initialize(int max_concurrency, unsigned reserved_for_masters = 1,
+                                priority a_priority = priority::normal);
+                void initialize(constraints a_constraints, unsigned reserved_for_masters = 1,
+                                priority a_priority = priority::normal);
+                void initialize(oneapi::tbb::attach);
+
+                void terminate();
+
+                bool is_active() const;
+                int max_concurrency() const;
+
+                template<typename F> auto execute(F&& f) -> decltype(f());
+                template<typename F> void enqueue(F&& f);
             };
 
-            struct constraints {
-                numa_node_id numa_node;
-                int max_concurrency;
-
-                constraints(numa_node_id numa_node_       = task_arena::automatic,
-                            int          max_concurrency_ = task_arena::automatic);
-            };
-
-            task_arena(int max_concurrency = automatic, unsigned reserved_for_masters = 1,
-                       priority a_priority = priority::normal);
-            task_arena(constraints a_constraints, unsigned reserved_for_masters = 1,
-                       priority a_priority = priority::normal);
-            task_arena(const task_arena &s);
-            explicit task_arena(oneapi::tbb::attach);
-            ~task_arena();
-
-            void initialize();
-            void initialize(int max_concurrency, unsigned reserved_for_masters = 1,
-                            priority a_priority = priority::normal);
-            void initialize(constraints a_constraints, unsigned reserved_for_masters = 1,
-                            priority a_priority = priority::normal);
-            void initialize(oneapi::tbb::attach);
-
-            void terminate();
-
-            bool is_active() const;
-            int max_concurrency() const;
-
-            template<typename F> auto execute(F&& f) -> decltype(f());
-            template<typename F> void enqueue(F&& f);
-        };
-
-    } // namespace tbb
+        } // namespace tbb
+    } // namespace oneapi
 
 A ``task_arena`` class represents a place where threads may share and execute tasks.
 

--- a/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
@@ -15,8 +15,6 @@ A class that represents an explicit, user-managed task scheduler arena.
 
     namespace tbb {
 
-        using attach = /* unspecified */
-
         class task_arena {
         public:
             static const int automatic = /* unspecified */;
@@ -26,7 +24,7 @@ A class that represents an explicit, user-managed task scheduler arena.
                 normal = /* unspecified */,
                 high = /* unspecified */
             };
-            struct attach {}; /* Deprecated (compatibility with oneTBB Specification 1.0), use oneapi::tbb::attach */
+
             struct constraints {
                 numa_node_id numa_node;
                 int max_concurrency;
@@ -41,7 +39,6 @@ A class that represents an explicit, user-managed task scheduler arena.
                        priority a_priority = priority::normal);
             task_arena(const task_arena &s);
             explicit task_arena(oneapi::tbb::attach);
-            explicit task_arena(task_arena::attach); /* Deprecated (compatibility with oneTBB Specification 1.0), use oneapi::tbb::attach version */
             ~task_arena();
 
             void initialize();
@@ -50,7 +47,6 @@ A class that represents an explicit, user-managed task scheduler arena.
             void initialize(constraints a_constraints, unsigned reserved_for_masters = 1,
                             priority a_priority = priority::normal);
             void initialize(oneapi::tbb::attach);
-            void initialize(task_arena::attach); /* Deprecated (compatibility with oneTBB Specification 1.0), use oneapi::tbb::attach version */
 
             void terminate();
 
@@ -108,14 +104,6 @@ Member types and constants
 
     When passed to a constructor or the ``initialize`` method, the initialized ``task_arena``
     has a raised priority.
-
-.. cpp:struct:: attach
-
-    A tag for constructing a ``task_arena`` with attach.
-
-    .. caution::
-
-        ``struct attach`` is deprecated (compatibility with oneTBB Specification 1.0), use oneapi::tbb::attach
 
 .. cpp:struct:: constraints
 
@@ -177,20 +165,6 @@ Member functions
         Unlike other constructors, this one automatically initializes
         the new ``task_arena`` when connecting to an already existing arena.
 
-.. cpp:function:: explicit task_arena(task_arena::attach)
-
-    Creates an instance of ``task_arena`` that is connected to the internal task arena representation currently used by the calling thread.
-    If no such arena exists yet, creates a ``task_arena`` with default parameters.
-
-    .. note::
-
-        Unlike other constructors, this one automatically initializes
-        the new ``task_arena`` when connecting to an already existing arena.
-
-    .. caution::
-
-        ``struct attach`` is deprecated (compatibility with oneTBB Specification 1.0), use oneapi::tbb::attach version
-
 .. cpp:function:: ~task_arena()
 
     Destroys the ``task_arena`` instance, but the destruction may not be synchronized with any task execution inside this ``task_arena``.
@@ -218,16 +192,6 @@ Member functions
     If an internal task arena representation currently used by the calling thread, the method ignores arena
     parameters and connects ``task_arena`` to that internal task arena representation.
     The method has no effect when called for an already initialized ``task_arena``.
-
-.. cpp:function:: void initialize(task_arena::attach)
-
-    If an internal task arena representation currently used by the calling thread, the method ignores arena
-    parameters and connects ``task_arena`` to that internal task arena representation.
-    The method has no effect when called for an already initialized ``task_arena``.
-
-    .. caution::
-
-        ``struct attach`` is deprecated (compatibility with oneTBB Specification 1.0), use oneapi::tbb::attach version
 
 .. cpp:function:: void terminate()
 


### PR DESCRIPTION
Add `task_scheduler_handle` description (preview implementation description: https://docs.oneapi.io/versions/latest/onetbb/reference/blocking_terminate.html). There are some changes releated to `get` (removed) and `release` (became a member function) methods.

Additionally, deprecated `task_arena::attach` and introduce `oneapi::tbb::attach`.

Notify: @kboyarinov @anton-potapov
