### PR TITLE
[oneTBB] - fix task_group_context argument description

### DIFF
--- a/source/elements/oneTBB/source/algorithms/functions/parallel_deterministic_reduce_func.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/parallel_deterministic_reduce_func.rst
@@ -17,20 +17,20 @@ Function template that computes reduction over a range, with deterministic split
         namespace tbb {
 
             template<typename Range, typename Value, typename Func, typename Reduction>
-            Value parallel_deterministic_reduce( const Range& range, const Value& identity, const Func& func, const Reduction& reduction, /* see-below */ partitioner, task_group_context& group);
+            Value parallel_deterministic_reduce( const Range& range, const Value& identity, const Func& func, const Reduction& reduction, /* see-below */ partitioner, task_group_context& context);
             template<typename Range, typename Value, typename Func, typename Reduction>
             Value parallel_deterministic_reduce( const Range& range, const Value& identity, const Func& func, const Reduction& reduction, /* see-below */ partitioner);
             template<typename Range, typename Value, typename Func, typename Reduction>
-            Value parallel_deterministic_reduce( const Range& range, const Value& identity, const Func& func, const Reduction& reduction, task_group_context& group);
+            Value parallel_deterministic_reduce( const Range& range, const Value& identity, const Func& func, const Reduction& reduction, task_group_context& context);
             template<typename Range, typename Value, typename Func, typename Reduction>
             Value parallel_deterministic_reduce( const Range& range, const Value& identity, const Func& func, const Reduction& reduction);
 
             template<typename Range, typename Body>
-            void parallel_deterministic_reduce( const Range& range, Body& body, /* see-below */ partitioner, task_group_context& group);
+            void parallel_deterministic_reduce( const Range& range, Body& body, /* see-below */ partitioner, task_group_context& context);
             template<typename Range, typename Body>
             void parallel_deterministic_reduce( const Range& range, Body& body, /* see-below */ partitioner);
             template<typename Range, typename Body>
-            void parallel_deterministic_reduce( const Range& range, Body& body, task_group_context& group);
+            void parallel_deterministic_reduce( const Range& range, Body& body, task_group_context& context);
             template<typename Range, typename Body>
             void parallel_deterministic_reduce( const Range& range, Body& body);
 

--- a/source/elements/oneTBB/source/algorithms/functions/parallel_for_each_func.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/parallel_for_each_func.rst
@@ -19,17 +19,17 @@ Function template that processes work items in parallel.
             template<typename InputIterator, typename Body>
             void parallel_for_each( InputIterator first, InputIterator last, Body body );
             template<typename InputIterator, typename Body>
-            void parallel_for_each( InputIterator first, InputIterator last, Body body, task_group_context& group );
+            void parallel_for_each( InputIterator first, InputIterator last, Body body, task_group_context& context );
 
             template<typename Container, typename Body>
             void parallel_for_each( Container& c, Body body );
             template<typename Container, typename Body>
-            void parallel_for_each( Container& c, Body body, task_group_context& group );
+            void parallel_for_each( Container& c, Body body, task_group_context& context );
 
             template<typename Container, typename Body>
             void parallel_for_each( const Container& c, Body body );
             template<typename Container, typename Body>
-            void parallel_for_each( const Container& c, Body body, task_group_context& group );
+            void parallel_for_each( const Container& c, Body body, task_group_context& context );
 
         } // namespace tbb
     } // namespace oneapi
@@ -48,7 +48,7 @@ sequence [``first,last``). Items may be processed in parallel.
 The container form ``parallel_for_each(c, body)`` is equivalent to ``parallel_for_each(std::begin(c), std::end(c), body)``.
 
 All overloads can accept a :doc:`task_group_context <../../task_scheduler/scheduling_controls/task_group_context_cls>` object
-so that the algorithm’s tasks are executed in this group. By default, the algorithm is executed in a bound group of its own.
+so that the algorithm’s tasks are executed in this context. By default, the algorithm is executed in a bound context of its own.
 
 feeder Class
 ------------

--- a/source/elements/oneTBB/source/algorithms/functions/parallel_for_func.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/parallel_for_func.rst
@@ -17,27 +17,27 @@ Function template that performs parallel iteration over a range of values.
         namespace tbb {
 
             template<typename Index, typename Func>
-            void parallel_for(Index first, Index last, const Func& f, /* see-below */ partitioner, task_group_context& group);
+            void parallel_for(Index first, Index last, const Func& f, /* see-below */ partitioner, task_group_context& context);
             template<typename Index, typename Func>
-            void parallel_for(Index first, Index last, const Func& f, task_group_context& group);
+            void parallel_for(Index first, Index last, const Func& f, task_group_context& context);
             template<typename Index, typename Func>
             void parallel_for(Index first, Index last, const Func& f, /* see-below */ partitioner);
             template<typename Index, typename Func>
             void parallel_for(Index first, Index last, const Func& f);
 
             template<typename Index, typename Func>
-            void parallel_for(Index first, Index last, Index step, const Func& f, /* see-below */ partitioner, task_group_context& group);
+            void parallel_for(Index first, Index last, Index step, const Func& f, /* see-below */ partitioner, task_group_context& context);
             template<typename Index, typename Func>
-            void parallel_for(Index first, Index last, Index step, const Func& f, task_group_context& group);
+            void parallel_for(Index first, Index last, Index step, const Func& f, task_group_context& context);
             template<typename Index, typename Func>
             void parallel_for(Index first, Index last, Index step, const Func& f, /* see-below */ partitioner);
             template<typename Index, typename Func>
             void parallel_for(Index first, Index last, Index step, const Func& f);
 
             template<typename Range, typename Body>
-            void parallel_for(const Range& range, const Body& body, /* see-below */ partitioner, task_group_context& group);
+            void parallel_for(const Range& range, const Body& body, /* see-below */ partitioner, task_group_context& context);
             template<typename Range, typename Body>
-            void parallel_for(const Range& range, const Body& body, task_group_context& group);
+            void parallel_for(const Range& range, const Body& body, task_group_context& context);
             template<typename Range, typename Body>
             void parallel_for(const Range& range, const Body& body, /* see-below */ partitioner);
             template<typename Range, typename Body>
@@ -90,7 +90,7 @@ Do not rely on any particular execution order for correctness. However, for effi
 In case of serial execution, ``parallel_for`` performs iterations from left to right in the following sense.
 
 All overloads can accept a :doc:`task_group_context <../../task_scheduler/scheduling_controls/task_group_context_cls>` object
-so that the algorithm’s tasks are executed in this group. By default, the algorithm is executed in a bound group of its own.
+so that the algorithm’s tasks are executed in this context. By default, the algorithm is executed in a bound context of its own.
 
 **Complexity**
 

--- a/source/elements/oneTBB/source/algorithms/functions/parallel_invoke_func.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/parallel_invoke_func.rst
@@ -32,7 +32,7 @@ Requirements:
 Evaluates each member passed to ``parallel_invoke`` possibly in parallel. Return values are ignored.
 
 The algorithm can accept a :doc:`task_group_context <../../task_scheduler/scheduling_controls/task_group_context_cls>` object
-so that the algorithm’s tasks are executed in this group. By default, the algorithm is executed in a bound group of its own.
+so that the algorithm’s tasks are executed in this context. By default, the algorithm is executed in a bound context of its own.
 
 Example
 -------

--- a/source/elements/oneTBB/source/algorithms/functions/parallel_pipeline_func.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/parallel_pipeline_func.rst
@@ -17,7 +17,7 @@ Strongly-typed interface for pipelined execution.
         namespace tbb {
 
             void parallel_pipeline( size_t max_number_of_live_tokens, const filter<void,void>& filter_chain );
-            void parallel_pipeline( size_t max_number_of_live_tokens, const filter<void,void>& filter_chain, task_group_context& group );
+            void parallel_pipeline( size_t max_number_of_live_tokens, const filter<void,void>& filter_chain, task_group_context& context );
 
         } // namespace tbb
     } // namespace oneapi
@@ -54,8 +54,8 @@ the first template argument of its second operand.
 The number of items processed in parallel depends on the structure of the pipeline and number of available threads.
 *max_number_of_live_tokens* sets the threshold for concurrently processed items.
 
-If the *group* argument is specified, pipeline's tasks are executed in this group. By default, the algorithm
-is executed in a bound group of its own.
+If the *context* argument is specified, pipeline's tasks are executed in this context. By default, the algorithm
+is executed in a bound context of its own.
 
 Example
 -------

--- a/source/elements/oneTBB/source/algorithms/functions/parallel_reduce_func.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/parallel_reduce_func.rst
@@ -17,20 +17,20 @@ Function template that computes reduction over a range.
         namespace tbb {
 
             template<typename Range, typename Value, typename Func, typename Reduction>
-            Value parallel_reduce(const Range& range, const Value& identity, const Func& func, const Reduction& reduction, /* see-below */ partitioner, task_group_context& group);
+            Value parallel_reduce(const Range& range, const Value& identity, const Func& func, const Reduction& reduction, /* see-below */ partitioner, task_group_context& context);
             template<typename Range, typename Value, typename Func, typename Reduction>
             Value parallel_reduce(const Range& range, const Value& identity, const Func& func, const Reduction& reduction, /* see-below */ partitioner);
             template<typename Range, typename Value, typename Func, typename Reduction>
-            Value parallel_reduce(const Range& range, const Value& identity, const Func& func, const Reduction& reduction, task_group_context& group);
+            Value parallel_reduce(const Range& range, const Value& identity, const Func& func, const Reduction& reduction, task_group_context& context);
             template<typename Range, typename Value, typename Func, typename Reduction>
             Value parallel_reduce(const Range& range, const Value& identity, const Func& func, const Reduction& reduction);
 
             template<typename Range, typename Body>
-            void parallel_reduce(const Range& range, Body& body, /* see-below */ partitioner, task_group_context& group);
+            void parallel_reduce(const Range& range, Body& body, /* see-below */ partitioner, task_group_context& context);
             template<typename Range, typename Body>
             void parallel_reduce(const Range& range, Body& body, /* see-below */ partitioner);
             template<typename Range, typename Body>
-            void parallel_reduce(const Range& range, Body& body, task_group_context& group);
+            void parallel_reduce(const Range& range, Body& body, task_group_context& context);
             template<typename Range, typename Body>
             void parallel_reduce(const Range& range, Body& body);
 
@@ -83,7 +83,7 @@ When executed serially ``parallel_reduce`` run sequentially from left to right i
 Sequential execution never invokes the splitting constructor or method join.
 
 All overloads can accept a :doc:`task_group_context <../../task_scheduler/scheduling_controls/task_group_context_cls>` object
-so that the algorithm’s tasks are executed in this group. By default, the algorithm is executed in a bound group of its own.
+so that the algorithm’s tasks are executed in this context. By default, the algorithm is executed in a bound context of its own.
 
 **Complexity**
 

--- a/source/elements/oneTBB/source/flow_graph/graph_cls.rst
+++ b/source/elements/oneTBB/source/flow_graph/graph_cls.rst
@@ -46,10 +46,10 @@ reset_flags enumeration
 Member functions
 ----------------
 
-.. cpp:function:: graph(task_group_context& group )
+.. cpp:function:: graph(task_group_context& context )
 
-    Constructs a graph with no nodes. If ``group`` is specified, the
-    graph tasks are executed in this group. By default, the graph is
+    Constructs a graph with no nodes. If ``context`` is specified, the
+    graph tasks are executed in this context. By default, the graph is
     executed in a bound context of its own.
 
 .. cpp:function:: ~graph()


### PR DESCRIPTION
- fixed name and description of ``task_grtoup_context`` in the several places 
Signed-off-by: Anton Potapov <anton.potapov@intel.com>