### PR TITLE
[oneTBB] Function object iso cpp requirements 

### DIFF
--- a/source/elements/oneTBB/source/algorithms/functions/collaborative_call_once_func.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/collaborative_call_once_func.rst
@@ -24,8 +24,8 @@ Function template that executes function exactly once.
 
 Requirements:
 
-* ``Func`` type must meet the ``Function Objects``
-  requirements from the [function.objects] section of the ISO C++ Standard section.
+* ``Func`` type must meet the `Function Objects` 
+  requirements described in the [function.objects] section of the ISO C++ standard.
 
 Executes the ``Func`` object only once, even if it is called concurrently. It allows other threads
 blocked on the same ``collaborative_once_flag`` to join oneTBB parallel construction called

--- a/source/elements/oneTBB/source/algorithms/functions/parallel_invoke_func.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/parallel_invoke_func.rst
@@ -25,8 +25,8 @@ Function template that evaluates several functions in parallel.
 
 Requirements:
 
-* All members of ``Functions`` parameter pack must meet ``Function Objects``
-  requirements from the [function.objects] ISO C++ Standard section or be a pointer to a function.
+* All members of ``Functions`` parameter pack must meet `Function Objects`
+  requirements described in the [function.objects] section of the ISO C++ standard.
 * Last member of ``Functions`` parameter pack may be a ``task_group_context&`` type.
 
 Evaluates each member passed to ``parallel_invoke`` possibly in parallel. Return values are ignored.

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -8,7 +8,7 @@ ParallelForEachBody
 **[req.parallel_for_each_body]**
 
 A type `Body` satisfies `ParallelForBody` if it meets the `Function Objects`
-requirements from the [function.objects] ISO C++ Standard section.
+requirements described in the [function.objects] section of the ISO C++ standard.
 It should also meet one of the following requirements:
 
 ----------------------------------------------------------------

--- a/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
@@ -214,7 +214,7 @@ Member functions
 .. cpp:function:: template<F> void enqueue(F&& f)
 
     Enqueues a task into the ``task_arena`` to process the specified functor and immediately returns.
-    The ``F`` type must meet the `Function Objects` requirements from the [function.objects] ISO C++ Standard section.
+    The ``F`` type must meet the `Function Objects` requirements described in the [function.objects] section of the ISO C++ standard.
     The task is scheduled for eventual execution by a worker thread even if no thread ever explicitly waits for the task to complete.
     If the total number of worker threads is zero, a special additional worker thread is created to execute enqueued tasks.
 
@@ -235,7 +235,7 @@ Member functions
 .. cpp:function:: template<F> auto execute(F&& f) -> decltype(f())
 
     Executes the specified functor in the ``task_arena`` and returns the value returned by the functor.
-    The ``F`` type must meet the `Function Objects` requirements from [function.objects] ISO C++ Standard section.
+    The ``F`` type must meet the `Function Objects` requirements described in the [function.objects] section of the ISO C++ standard.
 
     The calling thread joins the ``task_arena`` if possible, and executes the functor.
     Upon return it restores the previous task scheduler state and floating-point settings.

--- a/source/elements/oneTBB/source/task_scheduler/task_arena/this_task_arena_ns.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_arena/this_task_arena_ns.rst
@@ -67,7 +67,7 @@ with the ``task_arena`` currently used by the calling thread.
 
     Runs the specified functor in isolation by restricting the calling thread to process only tasks
     scheduled in the scope of the functor (also called the isolation region). The function returns the value returned by the functor.
-    The ``F`` type must meet the `Function Objects` requirements from the [function.objects] ISO C++ Standard section.
+    The ``F`` type must meet the `Function Objects` requirements described in the [function.objects] section of the ISO C++ standard.
 
     .. caution::
 

--- a/source/elements/oneTBB/source/task_scheduler/task_group/task_group_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_group/task_group_cls.rst
@@ -81,7 +81,7 @@ Member functions
 .. cpp:function:: template<typename Func> void run(Func&& f)
 
     Adds a task to compute ``f()`` and returns immediately.
-    The ``Func`` type must meet the `Function Objects` requirements from [function.objects] ISO C++ Standard section.
+    The ``Func`` type must meet the `Function Objects` requirements described in the [function.objects] section of the ISO C++ standard.
     
 .. cpp:function:: void run(task_handle&& h)
    
@@ -95,7 +95,7 @@ Member functions
 .. cpp:function:: template<typename Func> task_group_status run_and_wait(const Func& f)
 
     Equivalent to ``{run(f); return wait();}``.
-    The ``Func`` type must meet the `Function Objects` requirements from the [function.objects] ISO C++ Standard section.
+    The ``Func`` type must meet the `Function Objects` requirements described in the [function.objects] section of the ISO C++ standard.
 
     **Returns**: The status of ``task_group``. See :doc:`task_group_status <task_group_status_enum>`.
 

--- a/source/elements/oneTBB/source/thread_local_storage/combinable_cls.rst
+++ b/source/elements/oneTBB/source/thread_local_storage/combinable_cls.rst
@@ -106,7 +106,7 @@ Member functions
 
 .. cpp:function:: template<typename BinaryFunc> T combine(BinaryFunc f)
 
-    **Requires**: A ``BinaryFunc`` must meet the `Function Objects` requirements from the [function.objects] ISO C++ Standard section.
+    **Requires**: A ``BinaryFunc`` must meet the `Function Objects` requirements described in the [function.objects] section of the ISO C++ standard.
     Specifically, the type should be an associative binary functor with the signature ``T BinaryFunc(T,T)`` or ``T BinaryFunc(const T&,const T&)``.
     A ``T`` type must be the same as a corresponding template parameter for the ``combinable`` object.
 
@@ -118,7 +118,7 @@ Member functions
 
 .. cpp:function:: template<typename UnaryFunc> void combine_each(UnaryFunc f)
 
-    **Requires**: An ``UnaryFunc`` must meet the `Function Objects` requirements from the [function.objects] ISO C++ Standard section.
+    **Requires**: An ``UnaryFunc`` must meet the `Function Objects` requirements described in the [function.objects] section of the ISO C++ standard.
     Specifically, the type should be an unary functor with the one of the signatures: ``void UnaryFunc(T)``, ``void UnaryFunc(T&)``, or ``void UnaryFunc(const T&)``
     A ``T`` type must be the same as a corresponding template parameter for the ``enumerable_thread_specific`` object.
 

--- a/source/elements/oneTBB/source/thread_local_storage/enumerable_thread_specific_cls/combining.rst
+++ b/source/elements/oneTBB/source/thread_local_storage/enumerable_thread_specific_cls/combining.rst
@@ -12,7 +12,7 @@ The member functions in this section iterate across the entire container sequent
 
 .. cpp:function:: template<typename BinaryFunc> T combine(BinaryFunc f)
 
-    **Requires**: A ``BinaryFunc`` must meet the `Function Objects` requirements from the [function.objects] ISO C++ Standard section.
+    **Requires**: A ``BinaryFunc`` must meet the `Function Objects` requirements described in the [function.objects] section of the ISO C++ standard.
     Specifically, the type should be an associative binary functor with the signature ``T BinaryFunc(T,T)`` or ``T BinaryFunc(const T&,const T&)``.
     A ``T`` type must be the same as a corresponding template parameter for ``enumerable_thread_specific`` object.
 
@@ -23,7 +23,7 @@ The member functions in this section iterate across the entire container sequent
 
 .. cpp:function:: template<typename UnaryFunc> void combine_each(UnaryFunc f)
 
-    **Requires**: An ``UnaryFunc`` must meet the `Function Objects` requirements from the [function.objects] ISO C++ Standard section.
+    **Requires**: An ``UnaryFunc`` must meet the `Function Objects` requirements described in the [function.objects] section of the ISO C++ standard.
     Specifically, the type should be an unary functor with one of signatures: ``void UnaryFunc(T)``, ``void UnaryFunc(T&)``, or ``void UnaryFunc(const T&)``
     A ``T`` type must be the same as a corresponding template parameter for the ``enumerable_thread_specific`` object.
 


### PR DESCRIPTION
Fixed wording on user defined function to match ISO c++ standard named requirement `[function.objects]`
@alexandraepan could you please take a look ?