### PR TITLE
[oneTBB] Pass range to the parallel_sort algorithm by forwarding reference

### DIFF
--- a/source/elements/oneTBB/source/algorithms/functions/parallel_sort_func.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/parallel_sort_func.rst
@@ -32,7 +32,7 @@ Function template that sorts a sequence.
 Requirements:
 
 * The ``RandomAccessIterator`` type must meet the `Random Access Iterators` requirements from
-  [random.access.iterators]  and `Swappable` requirements from the [swappable.requirements] ISO C++ Standard section.
+  [random.access.iterators]  and `ValueSwappable` requirements from the [swappable.requirements] ISO C++ Standard section.
 * The ``Compare`` type must meet the `Compare` type requirements from the [alg.sorting] ISO C++ Standard section.
 * The ``Container`` type must meet the :doc:`ContainerBasedSequence requirements <../../named_requirements/algorithms/container_based_sequence>` 
   which iterators must meet the `Random Access Iterators` requirements from [random.access.iterators]  


### PR DESCRIPTION
Passing range by forwarding reference to support std::span and other view containers which may be passed as an rvalue or const, but provide the non-const access to data.

Signed-off-by: Kochin Ivan <kochin.ivan@intel.com>