### PR TITLE
[oneTBB] Add Move semantic requirements to the parallel_sort algorithm

### DIFF
--- a/source/elements/oneTBB/source/algorithms/functions/parallel_sort_func.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/parallel_sort_func.rst
@@ -32,11 +32,13 @@ Function template that sorts a sequence.
 Requirements:
 
 * The ``RandomAccessIterator`` type must meet the `Random Access Iterators` requirements from
-  [random.access.iterators]  and `ValueSwappable` requirements from the [swappable.requirements] ISO C++ Standard section.
+  [random.access.iterators], `ValueSwappable` requirements from the [swappable.requirements] ISO C++ Standard section.
 * The ``Compare`` type must meet the `Compare` type requirements from the [alg.sorting] ISO C++ Standard section.
 * The ``Container`` type must meet the :doc:`ContainerBasedSequence requirements <../../named_requirements/algorithms/container_based_sequence>` 
   which iterators must meet the `Random Access Iterators` requirements from [random.access.iterators]  
   and `Swappable` requirements from the [swappable.requirements] ISO C++ Standard section.
+* The type of dereferenced ``RandomAccessIterator`` or ``Container`` iterator must meet the `MoveAssignable`
+  requirements from [moveassignable] and the `MoveConstructible` requirements from [moveconstructible] ISO C++ Standard sections.
 
 Sorts a sequence or a container. The sort is neither stable nor deterministic: relative
 ordering of elements with equal keys is not preserved and not guaranteed to repeat if the same

--- a/source/elements/oneTBB/source/algorithms/functions/parallel_sort_func.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/parallel_sort_func.rst
@@ -37,8 +37,7 @@ Requirements:
 * The ``Container`` type must meet the :doc:`ContainerBasedSequence requirements <../../named_requirements/algorithms/container_based_sequence>` 
   which iterators must meet the `Random Access Iterators` requirements from [random.access.iterators]  
   and `Swappable` requirements from the [swappable.requirements] ISO C++ Standard section.
-* The type of dereferenced ``RandomAccessIterator`` or dereferenced ``Container`` iterator must meet the `MoveAssignable`
-  requirements from [moveassignable] and the `MoveConstructible` requirements from [moveconstructible] ISO C++ Standard sections.
+* The type of dereferenced ``RandomAccessIterator`` or dereferenced ``Container`` iterator must meet the MoveAssignable requirements from [moveassignable] section of ISO C++ Standard and the MoveConstructible requirements from [moveconstructible] section of ISO C++ Standard.
 
 Sorts a sequence or a container. The sort is neither stable nor deterministic: relative
 ordering of elements with equal keys is not preserved and not guaranteed to repeat if the same

--- a/source/elements/oneTBB/source/algorithms/functions/parallel_sort_func.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/parallel_sort_func.rst
@@ -32,12 +32,12 @@ Function template that sorts a sequence.
 Requirements:
 
 * The ``RandomAccessIterator`` type must meet the `Random Access Iterators` requirements from
-  [random.access.iterators], `ValueSwappable` requirements from the [swappable.requirements] ISO C++ Standard section.
+  [random.access.iterators] and `ValueSwappable` requirements from the [swappable.requirements] ISO C++ Standard section.
 * The ``Compare`` type must meet the `Compare` type requirements from the [alg.sorting] ISO C++ Standard section.
 * The ``Container`` type must meet the :doc:`ContainerBasedSequence requirements <../../named_requirements/algorithms/container_based_sequence>` 
   which iterators must meet the `Random Access Iterators` requirements from [random.access.iterators]  
   and `Swappable` requirements from the [swappable.requirements] ISO C++ Standard section.
-* The type of dereferenced ``RandomAccessIterator`` or ``Container`` iterator must meet the `MoveAssignable`
+* The type of dereferenced ``RandomAccessIterator`` or dereferenced ``Container`` iterator must meet the `MoveAssignable`
   requirements from [moveassignable] and the `MoveConstructible` requirements from [moveconstructible] ISO C++ Standard sections.
 
 Sorts a sequence or a container. The sort is neither stable nor deterministic: relative


### PR DESCRIPTION
The `oneapi::tbb::parallel_sort()` algorithm may use `std::sort()`, so it has additional `MoveAssignable` requirements from [moveassignable] and the `MoveConstructible` requirements from [moveconstructible] ISO C++ Standard sections.

Signed-off-by: Kochin Ivan <kochin.ivan@intel.com>