### PR TITLE
[oneTBB] Add missed deleted assignment operator

### DIFF
--- a/source/elements/oneTBB/source/algorithms/functions/collaborative_once_flag_cls.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/collaborative_once_flag_cls.rst
@@ -20,6 +20,7 @@ Special class that ``collaborative_call_once`` uses to perform a call only once.
             public:
                 collaborative_once_flag();
                 collaborative_once_flag(const collaborative_once_flag&) = delete;
+                collaborative_once_flag& operator=(const collaborative_once_flag&) = delete;
             };
         } // namespace tbb
     } // namespace oneapi


### PR DESCRIPTION
`Member functions` section contains only default constructor. This means that `collaborative_once_flag` can't be copied or assigned. But there is missed declaration of deleted `operator=`. This patch fix it.

Notify: @alexey-katranov 

Signed-off-by: Ilya Isaev <ilya.isaev@intel.com>