### PR TITLE
[oneTBB] Add the Core Types preference API to the spec

### DIFF
--- a/source/elements/oneTBB/source/info_namespace.rst
+++ b/source/elements/oneTBB/source/info_namespace.rst
@@ -16,8 +16,13 @@ Interfaces to query information about execution environment.
     namespace oneapi {
     namespace tbb {
         using numa_node_id = /*implementation-defined*/;
+        using core_type_id = /*implementation-defined*/;
+
         namespace info {
             std::vector<numa_node_id> numa_nodes();
+            std::vector<core_type_id> core_types();
+
+            int default_concurrency(task_arena::constraints c);
             int default_concurrency(numa_node_id id = oneapi::tbb::task_arena::automatic);
         }
     } // namespace tbb
@@ -38,6 +43,19 @@ Functions
     .. note::
         If error occurs during system topology parsing, returns vector containing single element
         that equals to ``task_arena::automatic``.
+
+.. cpp:function:: std::vector<core_type_id> core_types()
+
+    Returns the vector of integral indexes that indicate available core types.
+    The indexes are sorted from the least performant to the most performant core type.
+
+    .. note::
+        If error occurs during system topology parsing, returns vector containing single element
+        that equals to ``task_arena::automatic``.
+
+.. cpp:function:: int default_concurrency(task_arena::constraints c)
+
+    Returns concurrency level for the given constraints.
 
 .. cpp:function:: int default_concurrency(numa_node_id id = oneapi::tbb::task_arena::automatic)
 

--- a/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
@@ -159,19 +159,19 @@ Member types and constants
 
 .. cpp:function:: constraints& constraints::set_numa_id(numa_node_id id)
 
-    Sets the `numa_id` to the provided ``id``. Returns the updated constraints object.
+    Sets the `numa_id` to the provided ``id``. Returns the reference to the updated constraints object.
 
 .. cpp:function:: constraints& constraints::set_max_concurrency(int maximal_concurrency)
 
-    Sets the `max_concurrency` to the provided ``maximal_concurrency``. Returns the updated constraints object.
+    Sets the `max_concurrency` to the provided ``maximal_concurrency``. Returns the reference to the updated constraints object.
 
 .. cpp:function:: constraints& constraints::set_core_type(core_type_id id)
 
-    Sets the `core_type` to the provided ``id``. Returns the updated constraints object.
+    Sets the `core_type` to the provided ``id``. Returns the reference to the updated constraints object.
 
 .. cpp:function:: constraints& constraints::set_max_threads_per_core(int threads_number)
 
-    Sets the `max_threads_per_core` to the provided ``threads_number``. Returns the updated constraints object.
+    Sets the `max_threads_per_core` to the provided ``threads_number``. Returns the reference to the updated constraints object.
 
 Member functions
 ----------------

--- a/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
@@ -151,11 +151,11 @@ Member types and constants
 
 .. cpp:function:: constraints::constraints(numa_node_id numa_node_ = task_arena::automatic, int max_concurrency_ = task_arena::automatic)
 
-    Constructs the constriants object with the provided `numa_id` and `max_concurrency` settings.
+    Constructs the constraints object with the provided `numa_id` and `max_concurrency` settings.
 
     .. note::
 
-        To allow using the C++20 designated initialization the constructor is removed for the C++20 and later standard.
+        Starting from C++20 this constructor does not exist.
 
 .. cpp:function:: constraints& constraints::set_numa_id(numa_node_id id)
 

--- a/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
@@ -139,7 +139,7 @@ Member types and constants
 
         core type ID is considered valid if it was obtained through ``tbb::info::core_types()``.
 
-    ``core_type`` - The maximum number of threads that can be scheduled to one core simultaneously.
+    ``max_threads_per_core`` - The maximum number of threads that can be scheduled to one core simultaneously.
 
     Member Functions
     ^^^^^^^^^^^^^^^^

--- a/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
@@ -27,6 +27,9 @@ A class that represents an explicit, user-managed task scheduler arena.
                 };
 
                 struct constraints {
+                    constraints(numa_node_id numa_node_       = task_arena::automatic,
+                                int          max_concurrency_ = task_arena::automatic);
+
                     constraints& set_numa_id(numa_node_id id);
                     constraints& set_max_concurrency(int maximal_concurrency);
                     constraints& set_core_type(core_type_id id);
@@ -117,10 +120,9 @@ Member types and constants
 
     Represents limitations applied to threads within ``task_arena``.
 
-    Member objects
-    ^^^^^^^^^^^^^^
+.. cpp:member:: numa_node_id constraints::numa_id
 
-    ``numa_id`` - An integral logical index uniquely identifying a NUMA node.
+    An integral logical index uniquely identifying a NUMA node.
     If set to non-automatic value, then this NUMA node will be considered as preferred for all the
     threads within the arena.
 
@@ -128,10 +130,14 @@ Member types and constants
 
         NUMA node ID is considered valid if it was obtained through tbb::info::numa_nodes().
 
-    ``max_concurrency`` - The maximum number of threads that can participate in work processing
+.. cpp:member:: int constraints::max_concurrency
+
+    The maximum number of threads that can participate in work processing
     within the ``task_arena`` at the same time.
 
-    ``core_type`` - An integral logical index uniquely identifying a core type.
+.. cpp:member:: core_type_id constraints::core_type
+
+    An integral logical index uniquely identifying a core type.
     If set to non-automatic value, then this core type will be considered as preferred for all the
     threads within the arena.
 
@@ -139,26 +145,33 @@ Member types and constants
 
         core type ID is considered valid if it was obtained through ``tbb::info::core_types()``.
 
-    ``max_threads_per_core`` - The maximum number of threads that can be scheduled to one core simultaneously.
+.. cpp:member:: int constraints::max_threads_per_core
 
-    Member Functions
-    ^^^^^^^^^^^^^^^^
+    The maximum number of threads that can be scheduled to one core simultaneously.
 
-    .. cpp:function:: constraints& set_numa_id(numa_node_id id)
+.. cpp:function:: constraints::constraints(numa_node_id numa_node_ = task_arena::automatic, int max_concurrency_ = task_arena::automatic)
 
-        Sets the `numa_id` to the provided ``id``. Returns the updated constraints object.
+    Constructs the constriants object with the provided `numa_id` and `max_concurrency` settings.
 
-    .. cpp:function:: constraints& set_max_concurrency(int maximal_concurrency)
+    .. note::
 
-        Sets the `max_concurrency` to the provided ``maximal_concurrency``. Returns the updated constraints object.
+        To allow using the C++20 designated initialization the constructor is removed for the C++20 and later standard.
 
-    .. cpp:function:: constraints& set_core_type(core_type_id id)
+.. cpp:function:: constraints& constraints::set_numa_id(numa_node_id id)
 
-        Sets the `core_type` to the provided ``id``. Returns the updated constraints object.
+    Sets the `numa_id` to the provided ``id``. Returns the updated constraints object.
 
-    .. cpp:function:: constraints& set_max_threads_per_core(int threads_number)
+.. cpp:function:: constraints& constraints::set_max_concurrency(int maximal_concurrency)
 
-        Sets the `max_threads_per_core` to the provided ``threads_number``. Returns the updated constraints object.
+    Sets the `max_concurrency` to the provided ``maximal_concurrency``. Returns the updated constraints object.
+
+.. cpp:function:: constraints& constraints::set_core_type(core_type_id id)
+
+    Sets the `core_type` to the provided ``id``. Returns the updated constraints object.
+
+.. cpp:function:: constraints& constraints::set_max_threads_per_core(int threads_number)
+
+    Sets the `max_threads_per_core` to the provided ``threads_number``. Returns the updated constraints object.
 
 Member functions
 ----------------

--- a/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
@@ -120,6 +120,8 @@ Member types and constants
 
     Represents limitations applied to threads within ``task_arena``.
 
+    Starting from C++20 this class should be an aggregate type to support the designated initialization.
+
 .. cpp:member:: numa_node_id constraints::numa_id
 
     An integral logical index uniquely identifying a NUMA node.
@@ -155,7 +157,7 @@ Member types and constants
 
     .. note::
 
-        Starting from C++20 this constructor does not exist.
+        To support designated initialization this constructor is omitted starting from C++20. Aggregate initialization is supposed to be used instead.
 
 .. cpp:function:: constraints& constraints::set_numa_id(numa_node_id id)
 

--- a/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
@@ -27,11 +27,15 @@ A class that represents an explicit, user-managed task scheduler arena.
                 };
 
                 struct constraints {
-                    numa_node_id numa_node;
-                    int max_concurrency;
+                    constraints& set_numa_id(numa_node_id id);
+                    constraints& set_max_concurrency(int maximal_concurrency);
+                    constraints& set_core_type(core_type_id id);
+                    constraints& set_max_threads_per_core(int threads_number);
 
-                    constraints(numa_node_id numa_node_       = task_arena::automatic,
-                                int          max_concurrency_ = task_arena::automatic);
+                    numa_node_id numa_id = task_arena::automatic;
+                    int max_concurrency = task_arena::automatic;
+                    core_type_id core_type = task_arena::automatic;
+                    int max_threads_per_core = task_arena::automatic;
                 };
 
                 task_arena(int max_concurrency = automatic, unsigned reserved_for_masters = 1,
@@ -113,8 +117,12 @@ Member types and constants
 
     Represents limitations applied to threads within ``task_arena``.
 
-    ``numa_node`` - An integral logical index uniquely identifying a NUMA node.
-    All threads joining the ``task_arena`` are bound to this NUMA node.
+    Member objects
+    ^^^^^^^^^^^^^^
+
+    ``numa_id`` - An integral logical index uniquely identifying a NUMA node.
+    If set to non-automatic value, then this NUMA node will be considered as preferred for all the
+    threads within the arena.
 
     .. note::
 
@@ -122,6 +130,35 @@ Member types and constants
 
     ``max_concurrency`` - The maximum number of threads that can participate in work processing
     within the ``task_arena`` at the same time.
+
+    ``core_type`` - An integral logical index uniquely identifying a core type.
+    If set to non-automatic value, then this core type will be considered as preferred for all the
+    threads within the arena.
+
+    .. note::
+
+        core type ID is considered valid if it was obtained through ``tbb::info::core_types()``.
+
+    ``core_type`` - The maximum number of threads that can be scheduled to one core simultaneously.
+
+    Member Functions
+    ^^^^^^^^^^^^^^^^
+
+    .. cpp:function:: constraints& set_numa_id(numa_node_id id)
+
+        Sets the `numa_id` to the provided ``id``. Returns the updated constraints object.
+
+    .. cpp:function:: constraints& set_max_concurrency(int maximal_concurrency)
+
+        Sets the `max_concurrency` to the provided ``maximal_concurrency``. Returns the updated constraints object.
+
+    .. cpp:function:: constraints& set_core_type(core_type_id id)
+
+        Sets the `core_type` to the provided ``id``. Returns the updated constraints object.
+
+    .. cpp:function:: constraints& set_max_threads_per_core(int threads_number)
+
+        Sets the `max_threads_per_core` to the provided ``threads_number``. Returns the updated constraints object.
 
 Member functions
 ----------------


### PR DESCRIPTION
It was decided the Core Types preference API can be added to the oneTBB spec reference. This interface allows setting the preferred core type for the threads within a certain arena on the system with hybrid processors.