### PR TITLE
Fix typo in the parallel_reduce

### DIFF
--- a/source/elements/oneTBB/source/algorithms/functions/parallel_reduce_func.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/parallel_reduce_func.rst
@@ -51,7 +51,7 @@ Requirements:
 * The ``Range`` type must meet the :doc:`Range requirements <../../named_requirements/algorithms/range>`.
 * The ``Body`` type must meet the :doc:`ParallelReduceBody requirements <../../named_requirements/algorithms/par_reduce_body>`.
 * The ``Func`` type must meet the :doc:`ParallelReduceFunc requirements <../../named_requirements/algorithms/par_reduce_func>`.
-* The ``Reduction`` types must meet ::doc:`ParallelReduceReduction requirements <../../named_requirements/algorithms/par_reduce_reduction>`.
+* The ``Reduction`` types must meet :doc:`ParallelReduceReduction requirements <../../named_requirements/algorithms/par_reduce_reduction>`.
 
 The function template ``parallel_reduce`` has two forms:
 The functional form is designed to be easy to use in conjunction with lambda expressions.


### PR DESCRIPTION
Remove extra ':' symbol