### PR TITLE
Clarify lightweight policy requirements

### DIFF
--- a/source/elements/oneTBB/source/flow_graph/examples/lightweight_policy.cpp
+++ b/source/elements/oneTBB/source/flow_graph/examples/lightweight_policy.cpp
@@ -8,10 +8,10 @@ int main() {
     function_node< int, int > add( g, unlimited, [](const int &v) {
         return v+1;
     } );
-    function_node< int, int, lightweight > multiply( g, unlimited, [](const int &v) {
+    function_node< int, int, lightweight > multiply( g, unlimited, [](const int &v) noexcept {
         return v*2;
     } );
-    function_node< int, int, lightweight > cube( g, unlimited, [](const int &v) {
+    function_node< int, int, lightweight > cube( g, unlimited, [](const int &v) noexcept {
         return v*v*v;
     } );
 

--- a/source/elements/oneTBB/source/flow_graph/functional_node_policies.rst
+++ b/source/elements/oneTBB/source/flow_graph/functional_node_policies.rst
@@ -48,9 +48,9 @@ of a predecessor to handle this.
 Lightweight
 -----------
 
-This policy suggests that the node body takes little time to process, as a non-binging hint for
-an implementation to reduce overheads associated with the node execution. Any applied optimization
-must have no observable side effects on the node and graph execution.
+This policy allows to specify that the node body takes little time to process, as a non-binding hint
+for an implementation to reduce overheads associated with the node execution. Any optimization applied
+by an implementation must have no observable side effects on the node and graph execution.
 
 When combined with another policy, the ``lightweight`` policy results in extending the behavior
 of that other policy with the optimization hint. This rule automatically applies to functional nodes

--- a/source/elements/oneTBB/source/flow_graph/functional_node_policies.rst
+++ b/source/elements/oneTBB/source/flow_graph/functional_node_policies.rst
@@ -48,17 +48,17 @@ of a predecessor to handle this.
 Lightweight
 -----------
 
-This policy helps to reduce the overhead associated with the execution scheduling of the node.
+This policy suggests that the node body takes little time to process, as a non-binging hint for
+an implementation to reduce overheads associated with the node execution. Any applied optimization
+must have no observable side effects on the node and graph execution.
 
-For functional nodes that have a default value for the ``Policy`` template parameter, specifying
-the ``lightweight`` policy results in extending the behavior of the default value of ``Policy``
-with the behavior defined by the ``lightweight`` policy. For example, if the default value of
+When combined with another policy, the ``lightweight`` policy results in extending the behavior
+of that other policy with the optimization hint. This rule automatically applies to functional nodes
+that have a default value for the ``Policy`` template parameter. For example, if the default value of
 ``Policy`` is ``queueing``, specifying ``lightweight`` as the ``Policy`` value is equivalent to
 specifying ``queueing_lightweight``.
 
-The ``lightweight`` policy requires a function call ``operator()`` of a node's
-body be ``noexcept``. If it is not the case, specifying ``lightweight`` policy
-to the node has no effect.
+The function call ``operator()`` of a node body must be ``noexcept`` for lightweight policies to have effect.
 
 Example
 ~~~~~~~

--- a/source/elements/oneTBB/source/flow_graph/functional_node_policies.rst
+++ b/source/elements/oneTBB/source/flow_graph/functional_node_policies.rst
@@ -56,6 +56,10 @@ with the behavior defined by the ``lightweight`` policy. For example, if the def
 ``Policy`` is ``queueing``, specifying ``lightweight`` as the ``Policy`` value is equivalent to
 specifying ``queueing_lightweight``.
 
+The ``lightweight`` policy requires a function call ``operator()`` of a node's
+body be ``noexcept``. If it is not the case, specifying ``lightweight`` policy
+to the node has no effect.
+
 Example
 ~~~~~~~
 


### PR DESCRIPTION
Lightweight policy imposes `noexcept` requirement on a function call `operator()` of its node's body.
This patch adds missing description and updates corresponding example.

Notify: @alexey-katranov @vlserov 

Signed-off-by: Fedotov, Aleksei <aleksei.fedotov@intel.com>