### PR TITLE
[oneMKL][LAPACK] Add missing constraint on parameter 'n' for orgqr functions

### DIFF
--- a/source/elements/oneMKL/source/domains/lapack/orgqr.rst
+++ b/source/elements/oneMKL/source/domains/lapack/orgqr.rst
@@ -81,7 +81,7 @@ m
    The number of rows in the matrix :math:`A` (:math:`0 \le m`).
 
 n
-   The number of columns in the matrix :math:`A` (:math:`0 \le n`).
+   The number of columns in the matrix :math:`A` (:math:`0 \le n \le m`).
 
 k
    The number of elementary reflectors whose product defines the
@@ -161,7 +161,7 @@ m
    The number of rows in the matrix :math:`A` (:math:`0 \le m`).
 
 n
-   The number of columns in the matrix :math:`A` (:math:`0 \le n`).
+   The number of columns in the matrix :math:`A` (:math:`0 \le n \le m`).
 
 k
    The number of elementary reflectors whose product defines the

--- a/source/elements/oneMKL/source/domains/lapack/orgqr_batch.rst
+++ b/source/elements/oneMKL/source/domains/lapack/orgqr_batch.rst
@@ -61,7 +61,7 @@ m
   Number of rows in the matrices :math:`A_i` (:math:`0 \le m`).
 
 n
-  Number of columns in the matrices :math:`A_i` (:math:`0 \le n`).
+  Number of columns in the matrices :math:`A_i` (:math:`0 \le n \le m`).
 
 k
   Number of elementary reflectors whose product defines the matrices :math:`Q_i` (:math:`0 \le k \le n`).
@@ -258,7 +258,7 @@ m
   Number of rows in the matrices :math:`A_i` (:math:`0 \le m`).
 
 n
-  Number of columns in the matrices :math:`A_i` (:math:`0 \le n`).
+  Number of columns in the matrices :math:`A_i` (:math:`0 \le n \le m`).
 
 k
   Number of elementary reflectors whose product defines the matrices :math:`Q_i` (:math:`0 \le k \le n`).


### PR DESCRIPTION
Changes made: Add constraint 'n <= m'

Rationale: The existing specification erroneously omits this constraint