### PR TITLE
[oneMKL] [BLAS] Add half/bfloat16 support for select L1 APIs

### DIFF
--- a/source/elements/oneMKL/source/domains/blas/axpy.rst
+++ b/source/elements/oneMKL/source/domains/blas/axpy.rst
@@ -32,6 +32,8 @@ where:
       :header-rows: 1
 
       * -  T 
+      * -  ``half`` 
+      * -  ``bfloat16`` 
       * -  ``float`` 
       * -  ``double`` 
       * -  ``std::complex<float>`` 

--- a/source/elements/oneMKL/source/domains/blas/dot.rst
+++ b/source/elements/oneMKL/source/domains/blas/dot.rst
@@ -26,6 +26,10 @@ The ``dot`` routines perform a dot product between two vectors:
 
       * -  T 
         -  T_res 
+      * -  ``half`` 
+        -  ``half`` 
+      * -  ``bfloat16`` 
+        -  ``bfloat16`` 
       * -  ``float`` 
         -  ``float`` 
       * -  ``double`` 

--- a/source/elements/oneMKL/source/domains/blas/nrm2.rst
+++ b/source/elements/oneMKL/source/domains/blas/nrm2.rst
@@ -30,6 +30,10 @@ where:
 
       * -  T 
         -  T_res 
+      * -  ``half`` 
+        -  ``half`` 
+      * -  ``bfloat16`` 
+        -  ``bfloat16`` 
       * -  ``float`` 
         -  ``float`` 
       * -  ``double`` 

--- a/source/elements/oneMKL/source/domains/blas/rot.rst
+++ b/source/elements/oneMKL/source/domains/blas/rot.rst
@@ -35,6 +35,10 @@ the sum of two of these scalar-vector products as follow:
 
       * -  T 
         -  T_scalar 
+      * -  ``half`` 
+        -  ``half`` 
+      * -  ``bfloat16`` 
+        -  ``bfloat16`` 
       * -  ``float`` 
         -  ``float`` 
       * -  ``double`` 

--- a/source/elements/oneMKL/source/domains/blas/scal.rst
+++ b/source/elements/oneMKL/source/domains/blas/scal.rst
@@ -32,6 +32,10 @@ where:
 
       * -  T 
         -  T_scalar 
+      * -  ``half`` 
+        -  ``half`` 
+      * -  ``bfloat16`` 
+        -  ``bfloat16`` 
       * -  ``float`` 
         -  ``float`` 
       * -  ``double`` 


### PR DESCRIPTION
This PR is adding half/bfloat16 support for select L1 routines: nrm2, dot, axpy, rot, scal.

This is a request from DPCT (Data Parallel Compatibility Tool).