### PR TITLE
Fix syr2k b and ldb description in spec.

### DIFF
--- a/source/elements/oneMKL/source/domains/blas/syr2k.rst
+++ b/source/elements/oneMKL/source/domains/blas/syr2k.rst
@@ -22,7 +22,7 @@ If ``trans`` = ``transpose::nontrans``, the operation is defined as:
 
       C \leftarrow alpha*(A*B^T + B*A^T) + beta*C
 
-where ``A`` is ``n`` x ``k`` and ``B`` is ``k`` x ``n``.
+where ``A`` and ``B`` are ``n`` x ``k`` matrices.
 
 If ``trans`` = ``transpose::trans``, the operation is defined as:
 
@@ -31,7 +31,7 @@ If ``trans`` = ``transpose::trans``, the operation is defined as:
       C \leftarrow alpha*(A^T*B + B^T*A) + beta * C
 
 
-where ``A`` is ``k`` x ``n`` and ``B`` is ``n`` x ``k``.
+where ``A`` and ``B`` are ``k`` x ``n`` matrices.
 
 
 In both cases:
@@ -170,15 +170,15 @@ syr2k (Buffer Version)
            - ``trans`` = ``transpose::nontrans``
            - ``trans`` = ``transpose::trans`` or ``transpose::conjtrans``
          * - Column major
-           - ``B`` is an ``k``-by-``n`` matrix so the array ``b``
-             must have size at least ``ldb``\ \*\ ``n``.
            - ``B`` is an ``n``-by-``k`` matrix so the array ``b``
-             must have size at least ``ldb``\ \*\ ``k``
+             must have size at least ``ldb``\ \*\ ``k``.
+           - ``B`` is an ``k``-by-``n`` matrix so the array ``b``
+             must have size at least ``ldb``\ \*\ ``n``
          * - Row major
+           - ``B`` is an ``n``-by-``k`` matrix so the array ``b``
+             must have size at least ``ldb``\ \*\ ``n``.
            - ``B`` is an ``k``-by-``n`` matrix so the array ``b``
              must have size at least ``ldb``\ \*\ ``k``.
-           - ``B`` is an ``n``-by-``k`` matrix so the array ``b``
-             must have size at least ``ldb``\ \*\ ``n``.
 
       See :ref:`matrix-storage`
       for more details.
@@ -193,11 +193,11 @@ syr2k (Buffer Version)
            - ``trans`` = ``transpose::nontrans``
            - ``trans`` = ``transpose::trans`` or ``transpose::conjtrans``
          * - Column major
-           - ``ldb`` must be at least ``k``.
            - ``ldb`` must be at least ``n``.
+           - ``ldb`` must be at least ``k``.
          * - Row major
-           - ``ldb`` must be at least ``n``.
            - ``ldb`` must be at least ``k``.
+           - ``ldb`` must be at least ``n``.
 
    beta
       Scaling factor for matrix ``C``.
@@ -357,15 +357,15 @@ syr2k (USM Version)
            - ``trans`` = ``transpose::nontrans``
            - ``trans`` = ``transpose::trans`` or ``transpose::conjtrans``
          * - Column major
-           - ``B`` is an ``k``-by-``n`` matrix so the array ``b``
-             must have size at least ``ldb``\ \*\ ``n``.
            - ``B`` is an ``n``-by-``k`` matrix so the array ``b``
-             must have size at least ``ldb``\ \*\ ``k``
+             must have size at least ``ldb``\ \*\ ``k``.
+           - ``B`` is an ``k``-by-``n`` matrix so the array ``b``
+             must have size at least ``ldb``\ \*\ ``n``
          * - Row major
+           - ``B`` is an ``n``-by-``k`` matrix so the array ``b``
+             must have size at least ``ldb``\ \*\ ``n``.
            - ``B`` is an ``k``-by-``n`` matrix so the array ``b``
              must have size at least ``ldb``\ \*\ ``k``.
-           - ``B`` is an ``n``-by-``k`` matrix so the array ``b``
-             must have size at least ``ldb``\ \*\ ``n``.
    
       See :ref:`matrix-storage` for
       more details.
@@ -380,11 +380,11 @@ syr2k (USM Version)
            - ``trans`` = ``transpose::nontrans``
            - ``trans`` = ``transpose::trans`` or ``transpose::conjtrans``
          * - Column major
-           - ``ldb`` must be at least ``k``.
            - ``ldb`` must be at least ``n``.
+           - ``ldb`` must be at least ``k``.
          * - Row major
-           - ``ldb`` must be at least ``n``.
            - ``ldb`` must be at least ``k``.
+           - ``ldb`` must be at least ``n``.
 
    beta
       Scaling factor for matrix ``C``.


### PR DESCRIPTION
In `syr2k`, the description  of the size of the `b` matrix and its leading dimension did not give sense given the (correct) mathematical description of the mathematical operation performed. This PR fixes the inconsistency.