### PR TITLE
Update SYCL component for oneAPI 1.2 release

### DIFF
--- a/scripts/oneapi.py
+++ b/scripts/oneapi.py
@@ -284,7 +284,7 @@ dirs = [
     'oneMKL',
     'oneTBB',
     'oneVPL',
-    'dpcpp',
+    'sycl',
     'l0',
     'oneDPL',
     'oneDNN',

--- a/source/architecture.rst
+++ b/source/architecture.rst
@@ -6,7 +6,7 @@ Software Architecture
 =====================
 
 oneAPI provides a common developer interface across a range of data
-parallel accelerators (see the figure below).  Programmers use DPC++
+parallel accelerators (see the figure below).  Programmers use SYCL
 for both API programming and direct programming.  The capabilities of
 a oneAPI platform are determined by the Level Zero interface, which
 provides system software a common abstraction for a oneAPI device.
@@ -89,7 +89,7 @@ API Programming Example
 
 API programming requires the programmer to specify the target device and the
 memory communication strategy.  In the following example, we call the
-oneMKL matrix multiply routine, GEMM.  We are writing in DPC++ and
+oneMKL matrix multiply routine, GEMM.  We are writing in SYCL and
 omitting irrelevant details.
 
 We create a queue initialized with a *gpu_selector* to specify that we
@@ -136,7 +136,7 @@ With direct programming, we specify the target device and the memory
 communication strategy, as we do for API programming.  In addition, we
 must define and submit a command group to perform the computation.
 In the following example, we write a simple data parallel matrix
-multiply.  We are writing in DPC++ and omitting irrelevant
+multiply.  We are writing in SYCL and omitting irrelevant
 details.
 
 We create a queue initialized with a *gpu_selector* to specify that the

--- a/source/conf/common_conf.py
+++ b/source/conf/common_conf.py
@@ -53,8 +53,6 @@ env = {
 
 prolog_template = string.Template(
     r"""
-.. |dpcpp_full_name| replace:: oneAPI Data Parallel C++
-.. |dpcpp_version| replace:: $oneapi_version
 .. |dpl_full_name| replace:: oneAPI DPC++ Library
 .. |dpl_version| replace:: $oneapi_version
 .. |ccl_full_name| replace:: oneAPI Collective Communications Library

--- a/source/elements/dpcpp/source/index.rst
+++ b/source/elements/dpcpp/source/index.rst
@@ -11,70 +11,50 @@ DPC++
 Overview
 --------
 
-Data Parallel C++ (DPC++) is an LLVM project to implement SYCL that provides direct programming
-capabilities for C++ programmers, and oneAPI libraries such as oneMKL.  It provides the
-features needed to define data parallel functions and to launch them
-on devices.  DPC++ is made up of the following components:
+The oneAPI programming language is a combination of SYCL and a set of SYCL
+extensions that are listed below.  The SYCL programming language is based on
+standard C++ and provides features to define data parallel functions and to
+launch them on accelerator devices.  Unlike some other parallel languages, SYCL
+allows an application to mix both host code and device code together in the
+same source file, which provides a more intuitive parallel programming
+environment.
 
-- C++.  Every DPC++ program is also a C++ program.  A
-  compliant DPC++ implementation must support the C++17 Core Language
-  (as specified in Sections 1-19 of ISO/IEC 14882:2017) or
-  newer.  See the `C++ Standard`_.
+A conformant oneAPI implementation must implement the
+`SYCL 2020 Specification`_, which is published by The Khronos Group.
 
-- SYCL.  DPC++ builds on the SYCL specification from The Khronos Group.
-  The SYCL language enables
-  the definition of data parallel functions that can be offloaded to
-  devices and defines runtime APIs and classes that are used to
-  orchestrate the offloaded functions.
+A conformant oneAPI implementation must also implement the set of SYCL
+extensions listed in the `Extensions Table`_.  These extensions provide
+additional functionality beyond what is specified in the SYCL language.  Some
+of these extensions are required only on certain devices types, as indicated in
+the table.
 
-- DPC++ Language extensions. A compliant DPC++ implementation must
-  support the specified language features.  Some
-  extensions are required only when the DPC++
-  implementation supports a specific class of device, as summarized in the
-  `Extensions Table`_. An implementation supports a class of device if
-  it can target hardware that responds “true” for a DPC++
-  device type query, either through explicit support built into the
-  implementation, or by using a lower layer that can support those
-  device classes such as the oneAPI Level Zero 
-  (Level Zero).  A DPC++ implementation must pass the 
-  conformance tests for all extensions that are required (`Extensions
-  Table`_) for the classes of devices that the implementation can
-  support.  (See `SYCL Extensions`_.)
-
-This specification requires a minimum of C++17 Core Language support and
-DPC++ extensions. These version and feature coverage requirements
-will evolve over time, with specific versions of C++ and SYCL being required,
-some additional extensions being required, and some DPC++ extensions no longer
-required if covered by newer C++ or SYCL versions directly.
-
-.. table:: DPC++ Extensions Table: Support requirements for DPC++
-           implementations above SYCL 2020
+.. table:: Table of SYCL Extensions
    :name: Extensions Table
 
-   ===========================  ====================  ====================  ====================  =============
-   Feature                      CPU                   GPU                   FPGA                  Test [#test]_
-   ===========================  ====================  ====================  ====================  =============
-   `Accessor properties`_       Required              Required              Required              NA [#na]_
-   `CXX standard library`_      Required              Required              Not required [#tmp]_  NA [#na]_
-   `Data flow pipes`_           Not required          Not required          Required              `fpga_tests <https://github.com/intel/llvm/tree/sycl/sycl/test/fpga_tests>`__
-   `Enqueued barriers`_         Required              Required              Required              NA [#na]_
-   `Extended atomics`_          Required              Required              Required              NA [#na]_
-   `Filter selector`_           Required              Required              Required              NA [#na]_
-   `FPGA LSU controls`_         Not required          Not required          Required              NA [#na]_
-   `FPGA memory channel`_       Not required          Not required          Required              NA [#na]_
-   `FPGA register`_             Not required          Not required          Required              NA [#na]_
-   `FPGA selector`_             Required              Required              Required              NA [#na]_
-   `GPU device info`_           Required              Required              Required              NA [#na]_
-   `Level zero backend`_        Required [#lzero]_    Required [#lzero]_    Required [#lzero]_    NA [#na]_
-   `Local memory allocations`_  Required              Required              Required              NA [#na]_
-   `Pinned memory property`_    Required              Required              Required              NA [#na]_
-   `Platform context`_          Required              Required              Required              NA [#na]_
-   `Restrict all arguments`_    Required              Required              Required              NA [#na]_
-   `Sub-group mask`_            Required              Required              Required              NA [#na]_
-   ===========================  ====================  ====================  ====================  =============
+   ===========================  ====================  ====================  ====================
+   Extension                    CPU                   GPU                   FPGA
+   ===========================  ====================  ====================  ====================
+   `Accessor properties`_       Required              Required              Required
+   `CXX standard library`_      Required              Required              Not required [#tmp]_
+   `Data flow pipes`_           Not required          Not required          Required
+   `Enqueued barriers`_         Required              Required              Required
+   `Extended atomics`_          Required              Required              Required
+   `Filter selector`_           Required              Required              Required
+   `FPGA LSU controls`_         Not required          Not required          Required
+   `FPGA memory channel`_       Not required          Not required          Required
+   `FPGA register`_             Not required          Not required          Required
+   `FPGA selector`_             Required              Required              Required
+   `GPU device info`_           Required              Required              Required
+   `Level zero backend`_        Required [#lzero]_    Required [#lzero]_    Required [#lzero]_
+   `Local memory allocations`_  Required              Required              Required
+   `Pinned memory property`_    Required              Required              Required
+   `Platform context`_          Required              Required              Required
+   `Restrict all arguments`_    Required              Required              Required
+   `Sub-group mask`_            Required              Required              Required
+   ===========================  ====================  ====================  ====================
 
 
-..   ==========================  ================  ================  ====================  =============
+..   ==========================  ================  ================  ====================
 
 .. _`Accessor properties`: https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions/accessor_properties/SYCL_ONEAPI_accessor_properties.asciidoc
 .. _`CXX standard library`: https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions/C-CXX-StandardLibrary/C-CXX-StandardLibrary.rst
@@ -95,80 +75,8 @@ required if covered by newer C++ or SYCL versions directly.
 .. _`Sub-group mask`: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/SubGroupMask/SubGroupMask.asciidoc
 
 
-.. [#test] Test directory within `extension tests`_
-.. [#na] Not yet available.
 .. [#tmp] Likely to be required in the future
 .. [#lzero] Required if the device backend is Level Zero.
 
 
-Detailed API and Language Descriptions
---------------------------------------
-
-The `SYCL 2020 Specification`_ describes the SYCL APIs and language.  DPC++ extensions on top of SYCL
-are described in the `SYCL Extensions`_ repository.
-
-A brief summary of the extensions is as follows:
-
--  Accessor properties - compile-time accessor properties that are visible to the compiler.
--  CXX standard library - enable subset of the C and C++ standard libraries in device code.
--  Data flow pipes - enable efficient First-In, First-Out (FIFO) communication in DPC++, a mechanism commonly
-   used when describing algorithms for spatial architectures such as FPGAs. 
--  Enqueued barriers - simplifies dependence creation and tracking for some common programming patterns by allowing
-   coarser grained synchronization within a queue without manual creation of fine grained dependencies.
--  Extended atomics - adds *atomic_accessor* on top of SYCL 2020 atomics.
--  Filter selector - adds a device selector which consumes a string of filter definitions, and that can be used to
-   easily restrict the set of devices which are passed to the usual device selection mechanisms.
--  FPGA LSU controls - tuning controls for FPGA load/store operations.
--  FPGA memory channel - placement controls for data with external memory banks (e.g. DDR channel) for tuning
-   FPGA designs.
--  FPGA register - tuning control for FPGA high performance pipelining.
--  FPGA selector - adds a set of device selectors that make it easy to acquire an FPGA hardware or emulation device.
--  GPU device info - adds GPU-specific queries around SIMD width, memory bandwidth, unique identifiers, and
-   topology of the compute structures.
--  Level zero backend - defines interoperability with Level Zero as a backend to SYCL.
--  Local memory allocations - adds ability for local memory allocations to be declared within a kernel, as opposed
-   to through an accessor that is passed to a kernel.  Makes kernels more self contained and easier to read and optimize.
--  Pinned memory property - optimization indicating that a buffer should use a specific memory resource if possible,
-   to accelerate movement of data between host and devices in some implementations.
--  Platform context - adds a default context per SYCL platform, which simplifies and improves performance in common
-   coding patterns.
--  Restrict all arguments - defines an attribute that can be applied to kernels (including lambda definitions of kernels)
-   which signals that there will be no memory aliasing between any pointer arguments that are passed to or captured
-   by a kernel.  This is an optimization attribute that can have large impact when the developer knows more about the
-   kernel arguments than a compiler can infer or safely assume.
--  Sub-group mask - adds a new opaque type and operations on it, which can be used to represent and manage sets of
-   work-items within a sub-group.
-
-Open Source Implementation
---------------------------
-
-An `open source implementation`_ is available under
-an LLVM license.  Details on incomplete features and known issues are
-available in the `Release Notes`_ (and the `Getting Started Guide`_
-until the release notes are available).
-
-Testing
--------
-
-A DPC++ implementation must pass the `extension tests`_ for any
-extension implemented from the `Extensions Table`_.  Each extension in
-the `Extensions Table`_ lists the name of the directory that contains
-corresponding tests, within the `extension tests`_ tree.
-
-Acknowledgment
----------------
-
-We thank the DPC++ and oneDPL `Technical Advisory Board <https://github.com/oneapi-src/oneAPI-tab>`__ for their valuable feedback,
-and the Khronos SYCL working group for their efforts defining and evolving the SYCL specification.
-
-
-.. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL 2020 Specification`: https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html
-.. _`SYCL Extensions`: https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions
-.. _`open source implementation`: https://github.com/intel/llvm/tree/sycl/
-.. _`conformance test suite`: https://github.com/KhronosGroup/SYCL-CTS
-.. _`extension tests`: https://github.com/intel/llvm/tree/sycl/sycl/test
-.. _`Release Notes`: https://github.com/intel/llvm/tree/sycl/sycl/ReleaseNotes.md
-.. _`Getting Started Guide`: https://github.com/intel/llvm/blob/sycl/sycl/doc/GetStartedGuide.md#known-issues-and-limitations
-.. _`joining the Khronos Group`: https://www.khronos.org/members/
-.. _`Khronos SYCL GitHub project`: https://github.com/KhronosGroup/SYCL-Docs

--- a/source/elements/element_list.rst
+++ b/source/elements/element_list.rst
@@ -2,8 +2,8 @@
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 
-- :ref:`oneDPCPP-section`: oneAPI's core language for programming
-  accelerators and multiprocessors. DPCPP allows developers to reuse
+- :ref:`sycl-section`: oneAPI's core language for programming
+  accelerators and multiprocessors. SYCL allows developers to reuse
   code across hardware targets (CPUs and accelerators such as GPUs and
   FPGAs) and tune for a specific architecture
 - :ref:`oneDPL-section`: A companion to the DPC++ Compiler for

--- a/source/elements/sycl/source/conf.py
+++ b/source/elements/sycl/source/conf.py
@@ -21,7 +21,7 @@ import sys
 from os.path import join
 
 
-project = 'dpcpp'
+project = 'sycl'
 
 repo_root = join('..', '..', '..', '..')
 exec(open(join(repo_root, 'source', 'conf', 'common_conf.py')).read())

--- a/source/elements/sycl/source/index.rst
+++ b/source/elements/sycl/source/index.rst
@@ -2,11 +2,11 @@
 ..
 .. SPDX-License-Identifier: CC-BY-4.0
 
-.. _onedpcpp-section:
+.. _sycl-section:
 
-=====
-DPC++
-=====
+====
+SYCL
+====
 
 Overview
 --------

--- a/source/elements/sycl/source/index.rst
+++ b/source/elements/sycl/source/index.rst
@@ -31,48 +31,58 @@ the table.
 .. table:: Table of SYCL Extensions
    :name: Extensions Table
 
-   ===========================  ====================  ====================  ====================
-   Extension                    CPU                   GPU                   FPGA
-   ===========================  ====================  ====================  ====================
-   `Accessor properties`_       Required              Required              Required
-   `CXX standard library`_      Required              Required              Not required [#tmp]_
-   `Data flow pipes`_           Not required          Not required          Required
-   `Enqueued barriers`_         Required              Required              Required
-   `Extended atomics`_          Required              Required              Required
-   `Filter selector`_           Required              Required              Required
-   `FPGA LSU controls`_         Not required          Not required          Required
-   `FPGA memory channel`_       Not required          Not required          Required
-   `FPGA register`_             Not required          Not required          Required
-   `FPGA selector`_             Required              Required              Required
-   `GPU device info`_           Required              Required              Required
-   `Level zero backend`_        Required [#lzero]_    Required [#lzero]_    Required [#lzero]_
-   `Local memory allocations`_  Required              Required              Required
-   `Pinned memory property`_    Required              Required              Required
-   `Platform context`_          Required              Required              Required
-   `Restrict all arguments`_    Required              Required              Required
-   `Sub-group mask`_            Required              Required              Required
-   ===========================  ====================  ====================  ====================
+   ==================================================  ====================  ====================  ====================
+   Extension                                           CPU                   GPU                   FPGA
+   ==================================================  ====================  ====================  ====================
+   `C-CXX-StandardLibrary`_                            Required              Required              Not required [#tmp]_
+   `sycl_ext_oneapi_accessor_properties`_              Required              Required              Required
+   `sycl_ext_oneapi_assert`_                           Required              Required              Required
+   `sycl_ext_oneapi_backend_level_zero`_               Required [#lzero]_    Required [#lzero]_    Required [#lzero]_
+   `sycl_ext_oneapi_default_context`_                  Required              Required              Required
+   `sycl_ext_oneapi_discard_queue_events`_             Required              Required              Required
+   `sycl_ext_oneapi_dot_accumulate`_                   Required              Required              Required
+   `sycl_ext_oneapi_enqueue_barrier`_                  Required              Required              Required
+   `sycl_ext_oneapi_filter_selector`_                  Required              Required              Required
+   `sycl_ext_oneapi_local_memory`_                     Required              Required              Required
+   `sycl_ext_oneapi_srgb`_                             Required              Required              Required
+   `sycl_ext_oneapi_sub_group_mask`_                   Required              Required              Required
+   `sycl_ext_oneapi_use_pinned_host_memory_property`_  Required              Required              Required
+   `sycl_ext_oneapi_usm_device_read_only`_             Required              Required              Required
+   `sycl_ext_intel_buffer_location`_                   Not required          Not required          Required
+   `sycl_ext_intel_dataflow_pipes`_                    Not required          Not required          Required
+   `sycl_ext_intel_device_info`_                       Required              Required              Required
+   `sycl_ext_intel_fpga_device_selector`_              Required              Required              Required
+   `sycl_ext_intel_fpga_lsu`_                          Not required          Not required          Required
+   `sycl_ext_intel_fpga_reg`_                          Not required          Not required          Required
+   `sycl_ext_intel_kernel_args_restrict`_              Required              Required              Required
+   `sycl_ext_intel_mem_channel_property`_              Not required          Not required          Required
+   `sycl_ext_intel_usm_address_spaces`_                Required              Required              Required
+   ==================================================  ====================  ====================  ====================
 
 
-..   ==========================  ================  ================  ====================
-
-.. _`Accessor properties`: https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions/accessor_properties/SYCL_ONEAPI_accessor_properties.asciidoc
-.. _`CXX standard library`: https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions/C-CXX-StandardLibrary/C-CXX-StandardLibrary.rst
-.. _`Data flow pipes`: https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions/DataFlowPipes/data_flow_pipes.asciidoc
-.. _`Enqueued barriers`: https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions/EnqueueBarrier/enqueue_barrier.asciidoc
-.. _`Extended atomics`: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/ExtendedAtomics/SYCL_INTEL_extended_atomics.asciidoc
-.. _`Filter selector`: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/FilterSelector/FilterSelector.adoc
-.. _`FPGA LSU controls`: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/IntelFPGA/FPGALsu.md
-.. _`FPGA memory channel`: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/MemChannel/MemChannel.asciidoc
-.. _`FPGA register`: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/IntelFPGA/FPGAReg.md
-.. _`FPGA selector`: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/IntelFPGA/FPGASelector.md
-.. _`GPU device info`: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/IntelGPU/IntelGPUDeviceInfo.md
-.. _`Level zero backend`: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/LevelZeroBackend/LevelZeroBackend.md
-.. _`Local memory allocations`: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/LocalMemory/LocalMemory.asciidoc
-.. _`Pinned memory property`: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/UsePinnedMemoryProperty/UsePinnedMemoryPropery.adoc
-.. _`Platform context`: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/PlatformContext/PlatformContext.adoc
-.. _`Restrict all arguments`: https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions/KernelRestrictAll/SYCL_INTEL_kernel_restrict_all.asciidoc
-.. _`Sub-group mask`: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/SubGroupMask/SubGroupMask.asciidoc
+.. _`C-CXX-StandardLibrary`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/C-CXX-StandardLibrary.rst
+.. _`sycl_ext_oneapi_accessor_properties`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_oneapi_accessor_properties.asciidoc
+.. _`sycl_ext_oneapi_assert`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_oneapi_assert.asciidoc
+.. _`sycl_ext_oneapi_backend_level_zero`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_oneapi_backend_level_zero.md
+.. _`sycl_ext_oneapi_default_context`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_oneapi_default_context.asciidoc
+.. _`sycl_ext_oneapi_discard_queue_events`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_oneapi_discard_queue_events.asciidoc
+.. _`sycl_ext_oneapi_dot_accumulate`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_oneapi_dot_accumulate.asciidoc
+.. _`sycl_ext_oneapi_enqueue_barrier`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_oneapi_enqueue_barrier.asciidoc
+.. _`sycl_ext_oneapi_filter_selector`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_oneapi_filter_selector.asciidoc
+.. _`sycl_ext_oneapi_local_memory`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc
+.. _`sycl_ext_oneapi_srgb`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_oneapi_srgb.asciidoc
+.. _`sycl_ext_oneapi_sub_group_mask`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_oneapi_sub_group_mask.asciidoc
+.. _`sycl_ext_oneapi_use_pinned_host_memory_property`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_oneapi_use_pinned_host_memory_property.asciidoc
+.. _`sycl_ext_oneapi_usm_device_read_only`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_oneapi_usm_device_read_only.asciidoc
+.. _`sycl_ext_intel_buffer_location`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_intel_buffer_location.asciidoc
+.. _`sycl_ext_intel_dataflow_pipes`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_intel_dataflow_pipes.asciidoc
+.. _`sycl_ext_intel_device_info`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_intel_device_info.md
+.. _`sycl_ext_intel_fpga_device_selector`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_intel_fpga_device_selector.md
+.. _`sycl_ext_intel_fpga_lsu`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_intel_fpga_lsu.md
+.. _`sycl_ext_intel_fpga_reg`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_intel_fpga_reg.md
+.. _`sycl_ext_intel_kernel_args_restrict`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_intel_kernel_args_restrict.asciidoc
+.. _`sycl_ext_intel_mem_channel_property`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_intel_mem_channel_property.asciidoc
+.. _`sycl_ext_intel_usm_address_spaces`: https://github.com/intel/llvm/blob/2022-06/sycl/doc/extensions/supported/sycl_ext_intel_usm_address_spaces.asciidoc
 
 
 .. [#tmp] Likely to be required in the future

--- a/source/index.rst
+++ b/source/index.rst
@@ -20,7 +20,7 @@ for creating parallel applications:
 
    introduction
    architecture
-   elements/dpcpp/source/index
+   elements/sycl/source/index
    elements/oneDPL/source/index
    elements/oneDNN/source/index
    elements/oneCCL/source/index


### PR DESCRIPTION
* Rename the component from "DPC++" to "SYCL".  We no longer use the name "DPC++" to refer to a specification in its own right.  Instead, "DPC++" refers to an implementation of the SYCL spec.
* Simplify the description of the SYCL component to state that this component includes the SYCL 2020 specification and a specific list of extensions.
* Update the list of extensions to match the "supported" extensions in the DPC++ 2022.2 compiler release.  Use tags in URLs, so the extension pointers are stable for the oneAPI spec.