### PR TITLE
Additional requirement for user-specified callable of oneapi::tbb::task::suspend

### DIFF
--- a/source/elements/oneTBB/source/task_scheduler/scheduling_controls/resumable_tasks.rst
+++ b/source/elements/oneTBB/source/task_scheduler/scheduling_controls/resumable_tasks.rst
@@ -23,6 +23,7 @@ Requirements:
 
 The ``oneapi::tbb::task::suspend`` function called within a running task suspends execution of the task and switches the thread to participate in other oneTBB parallel work.
 This function accepts a user callable object with the current execution context ``oneapi::tbb::task::suspend_point`` as an argument.
+The user-specified callable object is executed by the calling thread.
 
 The ``oneapi::tbb::task::suspend_point`` context tag must be passed to the ``oneapi::tbb::task::resume`` function to trigger a program execution at the suspended point.
 The ``oneapi::tbb::task::resume`` function can be called at any point of an application, even on a separate thread.


### PR DESCRIPTION
Added a requirement on the place where user-specified callable of oneapi::tbb::task::suspend should be called.
Signed-off-by: pavelkumbrasev <pavel.kumbrasev@intel.com>