### PR TITLE
[oneMKL-BLAS] Update precision support for gemm, gemm batch, rot

### DIFF
--- a/source/elements/oneMKL/source/domains/blas/gemm.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemm.rst
@@ -41,22 +41,38 @@ op(``X``) = ``X``\ :sup:`H`,
    .. list-table:: 
      :header-rows: 1
 
-     * -  Ts 
-       -  Ta 
-       -  Tb 
-       -  Tc 
-     * -  ``float`` 
+     * - | Ta
+         | (A matrix) 
+       - | Tb
+         | (B matrix) 
+       - | Tc 
+         | (C matrix) 
+       - | Ts
+         | (alpha/beta) 
+     * -  ``std::int8_t`` 
+       -  ``std::int8_t`` 
+       -  ``std::int32_t`` 
+       -  ``float`` 
+     * -  ``std::int8_t`` 
+       -  ``std::int8_t`` 
+       -  ``float`` 
+       -  ``float`` 
+     * -  ``half`` 
        -  ``half`` 
-       -  ``half`` 
+       -  ``float`` 
        -  ``float`` 
      * -  ``half`` 
        -  ``half`` 
        -  ``half`` 
        -  ``half`` 
-     * -  ``float``
-       -  ``bfloat16``
-       -  ``bfloat16``
-       -  ``float``
+     * -  ``bfloat16`` 
+       -  ``bfloat16`` 
+       -  ``float`` 
+       -  ``float`` 
+     * -  ``bfloat16`` 
+       -  ``bfloat16`` 
+       -  ``bfloat16`` 
+       -  ``float`` 
      * -  ``float`` 
        -  ``float`` 
        -  ``float`` 

--- a/source/elements/oneMKL/source/domains/blas/gemm_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemm_batch.rst
@@ -22,12 +22,54 @@ operation perform a matrix-matrix product with general matrices.
    .. list-table:: 
       :header-rows: 1
 
-      * -  T 
-      * -  ``half``
+      * - | Ta
+          | (A matrix) 
+        - | Tb
+          | (B matrix) 
+        - | Tc 
+          | (C matrix) 
+        - | Ts
+          | (alpha/beta) 
+      * -  ``std::int8_t`` 
+        -  ``std::int8_t`` 
+        -  ``std::int32_t`` 
+        -  ``float`` 
+      * -  ``std::int8_t`` 
+        -  ``std::int8_t`` 
+        -  ``float`` 
+        -  ``float`` 
+      * -  ``half`` 
+        -  ``half`` 
+        -  ``float`` 
+        -  ``float`` 
+      * -  ``half`` 
+        -  ``half`` 
+        -  ``half`` 
+        -  ``half`` 
+      * -  ``bfloat16`` 
+        -  ``bfloat16`` 
+        -  ``float`` 
+        -  ``float`` 
+      * -  ``bfloat16`` 
+        -  ``bfloat16`` 
+        -  ``bfloat16`` 
+        -  ``float`` 
       * -  ``float`` 
+        -  ``float`` 
+        -  ``float`` 
+        -  ``float`` 
       * -  ``double`` 
+        -  ``double`` 
+        -  ``double`` 
+        -  ``double`` 
       * -  ``std::complex<float>`` 
+        -  ``std::complex<float>`` 
+        -  ``std::complex<float>`` 
+        -  ``std::complex<float>`` 
       * -  ``std::complex<double>`` 
+        -  ``std::complex<double>`` 
+        -  ``std::complex<double>`` 
+        -  ``std::complex<double>`` 
 
 .. _onemkl_blas_gemm_batch_buffer:
 

--- a/source/elements/oneMKL/source/domains/blas/rot.rst
+++ b/source/elements/oneMKL/source/domains/blas/rot.rst
@@ -15,10 +15,10 @@ Performs rotation of points in the plane.
 
 Given two vectors ``x`` and ``y`` of ``n`` elements, the ``rot`` routines
 compute four scalar-vector products and update the input vectors with
-the sum of two of these scalar-vector products as follow:
+the sum of two of these scalar-vector products as follows:
 
 .. math::
-  
+
    \left[\begin{array}{c}
       x\\y
    \end{array}\right]
@@ -28,25 +28,50 @@ the sum of two of these scalar-vector products as follow:
       -s*x + c*y
    \end{array}\right]
 
+If ``s`` is a complex type, the operation is defined as:
+
+.. math::
+   \left[\begin{array}{c}
+      x\\y
+   \end{array}\right]
+   \leftarrow
+   \left[\begin{array}{c}
+       \phantom{-}c*x + s*y\\
+       -conj(s)*x + c*y
+   \end{array}\right]
+
 ``rot`` supports the following precisions.
 
-   .. list-table:: 
-      :header-rows: 1
+.. list-table:: 
+   :header-rows: 1
 
-      * -  T 
-        -  T_scalar 
-      * -  ``half`` 
-        -  ``half`` 
-      * -  ``bfloat16`` 
-        -  ``bfloat16`` 
-      * -  ``float`` 
-        -  ``float`` 
-      * -  ``double`` 
-        -  ``double`` 
-      * -  ``std::complex<float>`` 
-        -  ``float`` 
-      * -  ``std::complex<double>`` 
-        -  ``double`` 
+   * -  T
+     -  T_scalarC
+     -  T_scalarS
+   * -  ``sycl::half``
+     -  ``sycl::half``
+     -  ``sycl::half``
+   * -  ``oneapi::mkl::bfloat16``
+     -  ``oneapi::mkl::bfloat16``
+     -  ``oneapi::mkl::bfloat16``
+   * -  ``float``
+     -  ``float``
+     -  ``float``
+   * -  ``double``
+     -  ``double``
+     -  ``double``
+   * -  ``std::complex<float>``
+     -  ``float``
+     -  ``std::complex<float>``
+   * -  ``std::complex<double>``
+     -  ``double``
+     -  ``std::complex<double>``
+   * -  ``std::complex<float>``
+     -  ``float``
+     -  ``float``
+   * -  ``std::complex<double>``
+     -  ``double``
+     -  ``double``
 
 .. _onemkl_blas_rot_buffer:
 
@@ -64,8 +89,8 @@ rot (Buffer Version)
                 std::int64_t incx,
                 sycl::buffer<T,1> &y,
                 std::int64_t incy,
-                T_scalar c,
-                T_scalar s)
+                T_scalarC c,
+                T_scalarS s)
    }
 .. code-block:: cpp
 
@@ -76,8 +101,8 @@ rot (Buffer Version)
                 std::int64_t incx,
                 sycl::buffer<T,1> &y,
                 std::int64_t incy,
-                T_scalar c,
-                T_scalar s)
+                T_scalarC c,
+                T_scalarS s)
    }
 
 .. container:: section
@@ -159,8 +184,8 @@ rot (USM Version)
                        std::int64_t incx,
                        T *y,
                        std::int64_t incy,
-                       T_scalar c,
-                       T_scalar s,
+                       T_scalarC c,
+                       T_scalarS s,
                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
@@ -172,8 +197,8 @@ rot (USM Version)
                        std::int64_t incx,
                        T *y,
                        std::int64_t incy,
-                       T_scalar c,
-                       T_scalar s,
+                       T_scalarC c,
+                       T_scalarS s,
                        const std::vector<sycl::event> &dependencies = {})
    }
 


### PR DESCRIPTION
This PR updates the precision support tables for `gemm`, `gemm_batch`, and `rot` BLAS routines with newly supported precisions.