### PR TITLE
[DO NOT MERGE] Fix rendering of custom latex commands in html spec

### DIFF
--- a/source/conf/common_conf.py
+++ b/source/conf/common_conf.py
@@ -187,43 +187,44 @@ imgmath_latex_preamble = r'''
 '''
 
 mathjax3_config = {
-'tex': {
-    'macros': {
-        'src': '\\operatorname{src}',
-        'srclayer': '\\operatorname{src\\_layer}',
-        'srciter': '\\operatorname{src\\_iter}',
-        'srciterc': '\\operatorname{src\\_iter\\_c}',
-        'weights': '\\operatorname{weights}',
-        'weightslayer': '\\operatorname{weights\\_layer}',
-        'weightsiter': '\\operatorname{weights\\_iter}',
-        'weightspeephole': '\\operatorname{weights\\_peephole}',
-        'weightsprojection': '\\operatorname{weights\\_projection}',
-        'bias': '\\operatorname{bias}',
-        'dst': '\\operatorname{dst}',
-        'dstlayer': '\\operatorname{dst\\_layer}',
-        'dstiter': '\\operatorname{dst\\_iter}',
-        'dstiterc': '\\operatorname{dst\\_iter\\_c}',
-        'diffsrc': '\\operatorname{diff\\_src}',
-        'diffsrclayer': '\\operatorname{diff\\_src\\_layer}',
-        'diffsrciter': '\\operatorname{diff\\_src\\_iter}',
-        'diffsrciterc': '\\operatorname{diff\\_src\\_iter\\_c}',
-        'diffweights': '\\operatorname{diff\\_weights}',
-        'diffweightslayer': '\\operatorname{diff\\_weights\\_layer}',
-        'diffweightsiter': '\\operatorname{diff\\_weights\\_iter}',
-        'diffweightspeephole': '\\operatorname{diff\\_weights\\_peephole}',
-        'diffweightsprojection': '\\operatorname{diff\\_weights\\_projection}',
-        'diffbias': '\\operatorname{diff\\_bias}',
-        'diffdst': '\\operatorname{diff\\_dst}',
-        'diffdstlayer': '\\operatorname{diff\\_dst\\_layer}',
-        'diffdstiter': '\\operatorname{diff\\_dst\\_iter}',
-        'diffdstiterc': '\\operatorname{diff\\_dst\\_iter\\_c}',
-        'diffgamma': '\\operatorname{diff\\_\\gamma}',
-        'diffbeta': '\\operatorname{diff\\_\\beta}',
-        'workspace': '\\operatorname{workspace}',
-        'srcshape': '\\operatorname{src\\_shape}'
+    'tex': {
+        'macros': {
+            'src': '\\operatorname{src}',
+            'srclayer': '\\operatorname{src\\_layer}',
+            'srciter': '\\operatorname{src\\_iter}',
+            'srciterc': '\\operatorname{src\\_iter\\_c}',
+            'weights': '\\operatorname{weights}',
+            'weightslayer': '\\operatorname{weights\\_layer}',
+            'weightsiter': '\\operatorname{weights\\_iter}',
+            'weightspeephole': '\\operatorname{weights\\_peephole}',
+            'weightsprojection': '\\operatorname{weights\\_projection}',
+            'bias': '\\operatorname{bias}',
+            'dst': '\\operatorname{dst}',
+            'dstlayer': '\\operatorname{dst\\_layer}',
+            'dstiter': '\\operatorname{dst\\_iter}',
+            'dstiterc': '\\operatorname{dst\\_iter\\_c}',
+            'diffsrc': '\\operatorname{diff\\_src}',
+            'diffsrclayer': '\\operatorname{diff\\_src\\_layer}',
+            'diffsrciter': '\\operatorname{diff\\_src\\_iter}',
+            'diffsrciterc': '\\operatorname{diff\\_src\\_iter\\_c}',
+            'diffweights': '\\operatorname{diff\\_weights}',
+            'diffweightslayer': '\\operatorname{diff\\_weights\\_layer}',
+            'diffweightsiter': '\\operatorname{diff\\_weights\\_iter}',
+            'diffweightspeephole': '\\operatorname{diff\\_weights\\_peephole}',
+            'diffweightsprojection': '\\operatorname{diff\\_weights\\_projection}',  # noqa: E501
+            'diffbias': '\\operatorname{diff\\_bias}',
+            'diffdst': '\\operatorname{diff\\_dst}',
+            'diffdstlayer': '\\operatorname{diff\\_dst\\_layer}',
+            'diffdstiter': '\\operatorname{diff\\_dst\\_iter}',
+            'diffdstiterc': '\\operatorname{diff\\_dst\\_iter\\_c}',
+            'diffgamma': '\\operatorname{diff\\_\\gamma}',
+            'diffbeta': '\\operatorname{diff\\_\\beta}',
+            'workspace': '\\operatorname{workspace}',
+            'srcshape': '\\operatorname{src\\_shape}',
         }
     }
 }
+
 
 def supsub_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     node = docutils.nodes.superscript()

--- a/source/conf/common_conf.py
+++ b/source/conf/common_conf.py
@@ -143,6 +143,7 @@ latex_elements = {
 \newcommand{\diffgamma}{\operatorname{diff\_\gamma}}
 \newcommand{\diffbeta}{\operatorname{diff\_\beta}}
 \newcommand{\workspace}{\operatorname{workspace}}
+\newcommand{\srcshape}{\operatorname{src\_shape}}
 ''',
     # Latex figure (float) alignment
     #
@@ -150,6 +151,79 @@ latex_elements = {
     'extraclassoptions': 'openany,oneside',
 }
 
+imgmath_latex_preamble = r'''
+\newcommand{\src}{\operatorname{src}}
+\newcommand{\srclayer}{\operatorname{src\_layer}}
+\newcommand{\srciter}{\operatorname{src\_iter}}
+\newcommand{\srciterc}{\operatorname{src\_iter\_c}}
+\newcommand{\weights}{\operatorname{weights}}
+\newcommand{\weightslayer}{\operatorname{weights\_layer}}
+\newcommand{\weightsiter}{\operatorname{weights\_iter}}
+\newcommand{\weightspeephole}{\operatorname{weights\_peephole}}
+\newcommand{\weightsprojection}{\operatorname{weights\_projection}}
+\newcommand{\bias}{\operatorname{bias}}
+\newcommand{\dst}{\operatorname{dst}}
+\newcommand{\dstlayer}{\operatorname{dst\_layer}}
+\newcommand{\dstiter}{\operatorname{dst\_iter}}
+\newcommand{\dstiterc}{\operatorname{dst\_iter\_c}}
+\newcommand{\diffsrc}{\operatorname{diff\_src}}
+\newcommand{\diffsrclayer}{\operatorname{diff\_src\_layer}}
+\newcommand{\diffsrciter}{\operatorname{diff\_src\_iter}}
+\newcommand{\diffsrciterc}{\operatorname{diff\_src\_iter\_c}}
+\newcommand{\diffweights}{\operatorname{diff\_weights}}
+\newcommand{\diffweightslayer}{\operatorname{diff\_weights\_layer}}
+\newcommand{\diffweightsiter}{\operatorname{diff\_weights\_iter}}
+\newcommand{\diffweightspeephole}{\operatorname{diff\_weights\_peephole}}
+\newcommand{\diffweightsprojection}{\operatorname{diff\_weights\_projection}}
+\newcommand{\diffbias}{\operatorname{diff\_bias}}
+\newcommand{\diffdst}{\operatorname{diff\_dst}}
+\newcommand{\diffdstlayer}{\operatorname{diff\_dst\_layer}}
+\newcommand{\diffdstiter}{\operatorname{diff\_dst\_iter}}
+\newcommand{\diffdstiterc}{\operatorname{diff\_dst\_iter\_c}}
+\newcommand{\diffgamma}{\operatorname{diff\_\gamma}}
+\newcommand{\diffbeta}{\operatorname{diff\_\beta}}
+\newcommand{\workspace}{\operatorname{workspace}}
+\newcommand{\srcshape}{\operatorname{src\_shape}}
+'''
+
+mathjax3_config = {
+'tex': {
+    'macros': {
+        'src': '\\operatorname{src}',
+        'srclayer': '\\operatorname{src\\_layer}',
+        'srciter': '\\operatorname{src\\_iter}',
+        'srciterc': '\\operatorname{src\\_iter\\_c}',
+        'weights': '\\operatorname{weights}',
+        'weightslayer': '\\operatorname{weights\\_layer}',
+        'weightsiter': '\\operatorname{weights\\_iter}',
+        'weightspeephole': '\\operatorname{weights\\_peephole}',
+        'weightsprojection': '\\operatorname{weights\\_projection}',
+        'bias': '\\operatorname{bias}',
+        'dst': '\\operatorname{dst}',
+        'dstlayer': '\\operatorname{dst\\_layer}',
+        'dstiter': '\\operatorname{dst\\_iter}',
+        'dstiterc': '\\operatorname{dst\\_iter\\_c}',
+        'diffsrc': '\\operatorname{diff\\_src}',
+        'diffsrclayer': '\\operatorname{diff\\_src\\_layer}',
+        'diffsrciter': '\\operatorname{diff\\_src\\_iter}',
+        'diffsrciterc': '\\operatorname{diff\\_src\\_iter\\_c}',
+        'diffweights': '\\operatorname{diff\\_weights}',
+        'diffweightslayer': '\\operatorname{diff\\_weights\\_layer}',
+        'diffweightsiter': '\\operatorname{diff\\_weights\\_iter}',
+        'diffweightspeephole': '\\operatorname{diff\\_weights\\_peephole}',
+        'diffweightsprojection': '\\operatorname{diff\\_weights\\_projection}',
+        'diffbias': '\\operatorname{diff\\_bias}',
+        'diffdst': '\\operatorname{diff\\_dst}',
+        'diffdstlayer': '\\operatorname{diff\\_dst\\_layer}',
+        'diffdstiter': '\\operatorname{diff\\_dst\\_iter}',
+        'diffdstiterc': '\\operatorname{diff\\_dst\\_iter\\_c}',
+        'diffgamma': '\\operatorname{diff\\_\\gamma}',
+        'diffbeta': '\\operatorname{diff\\_\\beta}',
+        'workspace': '\\operatorname{workspace}',
+        'srcshape': '\\operatorname{src\\_shape}'
+        }
+    }
+}
 
 def supsub_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     node = docutils.nodes.superscript()


### PR DESCRIPTION
I tried to add the custom latex commands in common_conf.py, however, it still does not render properly in html build. Any idea?

![image](https://user-images.githubusercontent.com/22825297/201109487-dfa5f684-9df5-4faa-9400-01faaaa12790.png)

Though it works with the same variables setting when building the oneDNN component spec only

![image](https://user-images.githubusercontent.com/22825297/201109893-ac125758-50e7-4137-8667-a2d9aa28a95e.png)
