### PR TITLE
Fix ILP32 data model detection with GCC on 32bit ARM

### DIFF
--- a/source/elements/oneVPL/include/vpl/mfxdefs.h
+++ b/source/elements/oneVPL/include/vpl/mfxdefs.h
@@ -68,7 +68,7 @@ extern "C"
     #define MFX_PACK_BEGIN_STRUCT_W_PTR()    MFX_PACK_BEGIN_X(4)
     #define MFX_PACK_BEGIN_STRUCT_W_L_TYPE() MFX_PACK_BEGIN_X(8)
 /* 32-bit ILP32 data model Linux* */
-#elif defined(__ILP32__)
+#elif defined(__ILP32__) || defined(__arm__)
     #define MFX_PACK_BEGIN_STRUCT_W_PTR()    MFX_PACK_BEGIN_X(4)
     #define MFX_PACK_BEGIN_STRUCT_W_L_TYPE() MFX_PACK_BEGIN_X(4)
 #else


### PR DESCRIPTION
Unfortunately, GCC does not define `__ILP32__` on 32 bit ARM (contrary to e.g. x86), so rely on `__arm__` instead.

This does not change API/ABI, but fixes a compilation error for one specific architecture and compiler combination.

Avoids broken workarounds in every downstream user of mfxdefs.h,  e.g.:  
https://github.com/oneapi-src/oneVPL/commit/6182082a12#diff-1e7de1ae2d05   https://github.com/intel/cartwheel-ffmpeg/issues/215