### PR TITLE
[oneMKL][LAPACK] Clarify that LAPACK routines require column major storage

### DIFF
--- a/source/elements/oneMKL/source/domains/lapack/lapack.rst
+++ b/source/elements/oneMKL/source/domains/lapack/lapack.rst
@@ -8,7 +8,7 @@ LAPACK Routines
 +++++++++++++++
 
 oneMKL provides a DPC++ interface to select routines from the Linear Algebra PACKage (LAPACK), as well as several LAPACK-like extension routines.
-LAPACK routines support and require column major layout of matrices.
+LAPACK routines require column major layout of matrices.
 
 .. include:: lapack-linear-equation-routines.inc.rst
 .. include:: lapack-singular-value-eigenvalue-routines.inc.rst

--- a/source/elements/oneMKL/source/domains/lapack/lapack.rst
+++ b/source/elements/oneMKL/source/domains/lapack/lapack.rst
@@ -8,6 +8,7 @@ LAPACK Routines
 +++++++++++++++
 
 oneMKL provides a DPC++ interface to select routines from the Linear Algebra PACKage (LAPACK), as well as several LAPACK-like extension routines.
+LAPACK routines support and require column major layout of matrices.
 
 .. include:: lapack-linear-equation-routines.inc.rst
 .. include:: lapack-singular-value-eigenvalue-routines.inc.rst

--- a/source/elements/oneMKL/source/domains/matrix-storage.rst
+++ b/source/elements/oneMKL/source/domains/matrix-storage.rst
@@ -13,7 +13,8 @@ Matrix Storage
 
    The oneMKL BLAS and LAPACK routines for DPC++ use several matrix and
    vector storage formats. These are the same formats used in
-   traditional Fortran BLAS/LAPACK.
+   traditional Fortran BLAS/LAPACK. LAPACK routines support and require
+   column major layout.
 
    .. container:: section
 

--- a/source/elements/oneMKL/source/domains/matrix-storage.rst
+++ b/source/elements/oneMKL/source/domains/matrix-storage.rst
@@ -13,8 +13,8 @@ Matrix Storage
 
    The oneMKL BLAS and LAPACK routines for DPC++ use several matrix and
    vector storage formats. These are the same formats used in
-   traditional Fortran BLAS/LAPACK. LAPACK routines support and require
-   column major layout.
+   traditional Fortran BLAS/LAPACK. LAPACK routines require column
+   major layout.
 
    .. container:: section
 


### PR DESCRIPTION
This addresses #470 by specifying that LAPACK routines require column major storage. The clarification is added to both the main LAPACK page (https://spec.oneapi.io/versions/1.2-rev-1/elements/oneMKL/source/domains/lapack/lapack.html) and the matrix storage page (https://spec.oneapi.io/versions/1.2-rev-1/elements/oneMKL/source/domains/matrix-storage.html).
Note that the links are to the current 1.2 revision of the specification.