### PR TITLE
[oneMKL][BLAS] make incx, incy argument descriptions in Level 2 BLAS consistent

### DIFF
--- a/source/elements/oneMKL/source/domains/blas/axpy_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/axpy_batch.rst
@@ -105,19 +105,19 @@ where:
       Buffer holding input vectors ``X`` with size ``stridex`` * ``batch_size``.
 
    incx 
-      Stride of vector ``X``.
+      Stride of vector ``X``. Must not be zero.
 
    stridex 
-      Stride between different ``X`` vectors.
+      Stride between different ``X`` vectors. Must be at least zero.
 
    y
       Buffer holding input/output vectors ``Y`` with size ``stridey`` * ``batch_size``.
 
    incy 
-      Stride of vector ``Y``.
+      Stride of vector ``Y``. Must not be zero.
    
    stridey 
-      Stride between different ``Y`` vectors.
+      Stride between different ``Y`` vectors. Must be at least (1 + (``n``-1)*abs(``incy``)).
 
    batch_size 
       Specifies the number of ``axpy`` operations to perform.
@@ -248,7 +248,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
       See :ref:`matrix-storage` for more details.
 
    incx
-      Array of ``group_count`` integers. ``incx[i]`` specifies the stride of vector ``X`` in group ``i``.
+      Array of ``group_count`` integers. ``incx[i]`` specifies the stride of vector ``X`` in group ``i``. Must not be zero.
  
    y
       Array of pointers to input/output vectors ``Y`` with size ``total_batch_count``.
@@ -256,7 +256,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
       See :ref:`matrix-storage` for more details.
 
    incy
-      Array of ``group_count`` integers. ``incy[i]`` specifies the stride of vector ``Y`` in group ``i``.
+      Array of ``group_count`` integers. ``incy[i]`` specifies the stride of vector ``Y`` in group ``i``. Must not be zero.
 
    group_count
       Number of groups. Must be at least 0.
@@ -335,19 +335,19 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
       Pointer to input vectors ``X`` with size ``stridex`` * ``batch_size``.
 
    incx 
-      Stride of vector ``X``.
+      Stride of vector ``X``. Must not be zero.
    
    stridex 
-      Stride between different ``X`` vectors.
+      Stride between different ``X`` vectors. Must be at least zero.
 
    y
       Pointer to input/output vectors ``Y`` with size ``stridey`` * ``batch_size``.
 
    incy 
-      Stride of vector ``Y``.
+      Stride of vector ``Y``. Must not be zero.
    
    stridey 
-      Stride between different ``Y`` vectors.
+      Stride between different ``Y`` vectors. Must be at least (1 + (``n``-1)*abs(``incy``)).
 
    batch_size 
       Specifies the number of ``axpy`` operations to perform.

--- a/source/elements/oneMKL/source/domains/blas/copy_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/copy_batch.rst
@@ -98,19 +98,19 @@ where:
       Buffer holding input vectors ``X`` with size ``stridex`` * ``batch_size``.
 
    incx 
-      Stride of vector ``X``.
+      Stride of vector ``X``. Must not be zero.
 
    stridex 
-      Stride between different ``X`` vectors.
+      Stride between different ``X`` vectors. Must be at least zero.
 
    y
       Buffer holding input/output vectors ``Y`` with size ``stridey`` * ``batch_size``.
 
    incy 
-      Stride of vector ``Y``.
+      Stride of vector ``Y``. Must not be zero.
    
    stridey 
-      Stride between different ``Y`` vectors.
+      Stride between different ``Y`` vectors. Must be at least (1 + (``n``-1)*abs(``incy``)).
 
    batch_size 
       Specifies the number of ``copy`` operations to perform.
@@ -233,7 +233,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
       See :ref:`matrix-storage` for more details.
 
    incx
-      Array of ``group_count`` integers. ``incx[i]`` specifies the stride of vector ``X`` in group ``i``.
+      Array of ``group_count`` integers. ``incx[i]`` specifies the stride of vector ``X`` in group ``i``. Must not be zero.
  
    y
       Array of pointers to input/output vectors ``Y`` with size ``total_batch_count``.
@@ -241,7 +241,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
       See :ref:`matrix-storage` for more details.
 
    incy
-      Array of ``group_count`` integers. ``incy[i]`` specifies the stride of vector ``Y`` in group ``i``.
+      Array of ``group_count`` integers. ``incy[i]`` specifies the stride of vector ``Y`` in group ``i``. Must not be zero.
 
    group_count
       Number of groups. Must be at least 0.
@@ -314,19 +314,19 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
       Pointer to input vectors ``X`` with size ``stridex`` * ``batch_size``.
 
    incx 
-      Stride of vector ``X``.
+      Stride of vector ``X``. Must not be zero.
    
    stridex 
-      Stride between different ``X`` vectors.
+      Stride between different ``X`` vectors. Must be at least zero.
 
    y
       Pointer to input/output vectors ``Y`` with size ``stridey`` * ``batch_size``.
 
    incy 
-      Stride of vector ``Y``.
+      Stride of vector ``Y``. Must not be zero.
    
    stridey 
-      Stride between different ``Y`` vectors.
+      Stride between different ``Y`` vectors. Must be at least (1 + (``n``-1)*abs(``incy``)).
 
    batch_size 
       Specifies the number of ``copy`` operations to perform.

--- a/source/elements/oneMKL/source/domains/blas/gbmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/gbmv.rst
@@ -135,7 +135,7 @@ gbmv (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    beta
       Scaling factor for vector ``y``.
@@ -273,7 +273,7 @@ gbmv (USM Version)
       :ref:`matrix-storage` for more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    beta
       Scaling factor for vector ``y``.

--- a/source/elements/oneMKL/source/domains/blas/gemv.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemv.rst
@@ -120,7 +120,7 @@ gemv (Buffer Version)
       1)*abs(``incx``)). See :ref:`matrix-storage` for more details.
 
    incx
-      The stride of vector ``x``.
+      The stride of vector ``x``. Must not be zero.
 
    beta
       The scaling factor for vector ``y``.
@@ -133,7 +133,7 @@ gemv (Buffer Version)
       :ref:`matrix-storage` for more details.
 
    incy
-      The stride of vector ``y``.
+      The stride of vector ``y``. Must not be zero.
 
 .. container:: section
 
@@ -248,7 +248,7 @@ gemv (USM Version)
       more details.
 
    incx
-      The stride of vector ``x``.
+      The stride of vector ``x``. Must not be zero.
 
    beta
       The scaling factor for vector ``y``.
@@ -262,7 +262,7 @@ gemv (USM Version)
       more details.
 
    incy
-      The stride of vector ``y``.
+      The stride of vector ``y``. Must not be zero.
 
    dependencies
       List of events to wait for before starting computation, if any.

--- a/source/elements/oneMKL/source/domains/blas/gemv_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemv_batch.rst
@@ -134,13 +134,13 @@ parameter.
       ``n`` if row major layout is used.
 
    stridea
-      Stride between different ``A`` matrices.
+      Stride between different ``A`` matrices. Must be at least zero.
 
    x
       Buffer holding the input vectors ``X`` with size ``stridex`` * ``batch_size``.
 
    incx
-      The stride of the vector ``X``. It must be positive.
+      The stride of the vector ``X``.  Must not be zero.
 
    stridex
       Stride between different consecutive ``X`` vectors, must be at least 0.
@@ -152,12 +152,10 @@ parameter.
       Buffer holding input/output vectors ``Y`` with size ``stridey`` * ``batch_size``.
 
    incy
-      Stride between two consecutive elements of the ``y`` vectors.
+      Stride between two consecutive elements of the ``Y`` vectors. Must not be zero.
 
    stridey
-      Stride between two consecutive ``Y`` vectors. Must be at least
-      (1 + (len-1)*abs(incy)) where ``len`` is ``m`` if the matrix ``A``
-      is non transpose or ``n`` otherwise.
+      Stride between two consecutive ``Y`` vectors. Must be at least (1 + (``m`` - 1)*abs(``incy``)) if layout is column major or (1 + (``n`` - 1)*abs(``incy``)) if row major layout is used.
 
    batch_size
       Specifies the number of matrix-vector operations to perform.
@@ -328,8 +326,8 @@ total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by th
 
    incx
       Array of ``group_count`` integers. ``incx[i]`` specifies the
-      stride of ``X`` for every vector in group ``i``. All
-      entries must be positive.
+      stride of ``X`` for every vector in group ``i``. Must not
+      be zero.
              
    beta
       Array of ``group_count`` scalar elements. ``beta[i]`` specifies
@@ -343,10 +341,8 @@ total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by th
 
    incy
       Array of ``group_count`` integers. ``incy[i]`` specifies the
-      leading dimension of ``Y`` for every vector in group ``i``.  All
-      entries must be positive and ``incy[i]`` must be at least
-      ``m[i]`` if column major layout is used or at
-      least ``n[i]`` if row major layout is used.
+      leading dimension of ``Y`` for every vector in group ``i``. Must
+      not be zero.
 
    group_count
       Specifies the number of groups. Must be at least 0.
@@ -450,13 +446,13 @@ total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by th
       ``n`` if row major layout is used.
 
    stridea
-      Stride between different ``A`` matrices.
+      Stride between different ``A`` matrices. Must be at least zero.
 
    x
       Pointer to the input vectors ``X`` with size ``stridex`` * ``batch_size``.
 
    incx
-      Stride of the vector ``X``. It must be positive.
+      Stride of the vector ``X``. Must not be zero.
 
    stridex
       Stride between different consecutive ``X`` vectors, must be at least 0.
@@ -468,12 +464,10 @@ total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by th
       Pointer to the input/output vectors ``Y`` with size ``stridey`` * ``batch_size``.
 
    incy
-      Stride between two consecutive elements of the ``y`` vectors.
+      Stride between two consecutive elements of the ``y`` vectors. Must not be zero.
 
    stridey
-      Stride between two consecutive ``Y`` vectors. Must be at least
-      (1 + (len-1)*abs(incy)) where ``len`` is ``m`` if the matrix ``A``
-      is non transpose or ``n`` otherwise.
+      Stride between two consecutive ``Y`` vectors. Must be at least (1 + (``m`` - 1)*abs(``incy``)) if layout is column major or (1 + (``n`` - 1)*abs(``incy``)) if row major layout is used.
 
    batch_size
       Specifies the number of matrix-vector operations to perform.

--- a/source/elements/oneMKL/source/domains/blas/ger.rst
+++ b/source/elements/oneMKL/source/domains/blas/ger.rst
@@ -97,7 +97,7 @@ ger (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Buffer holding input/output vector ``y``. The buffer must be of
@@ -105,7 +105,7 @@ ger (Buffer Version)
       for more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    a
       Buffer holding input matrix ``A``. Must have size at least
@@ -207,7 +207,7 @@ ger (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Pointer to input/output vector ``y``. The array holding
@@ -216,7 +216,7 @@ ger (USM Version)
       more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    a
       Pointer to input matrix ``A``. Must have size at least

--- a/source/elements/oneMKL/source/domains/blas/gerc.rst
+++ b/source/elements/oneMKL/source/domains/blas/gerc.rst
@@ -98,7 +98,7 @@ gerc (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Buffer holding input/output vector ``y``. The buffer must be of
@@ -106,7 +106,7 @@ gerc (Buffer Version)
       for more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    a
       Buffer holding input matrix ``A``. Must have size at least
@@ -209,7 +209,7 @@ gerc (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Pointer to the input/output vector ``y``. The array holding the
@@ -218,7 +218,7 @@ gerc (USM Version)
       more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix

--- a/source/elements/oneMKL/source/domains/blas/geru.rst
+++ b/source/elements/oneMKL/source/domains/blas/geru.rst
@@ -97,7 +97,7 @@ geru (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Buffer holding input/output vector ``y``. The buffer must be of
@@ -105,7 +105,7 @@ geru (Buffer Version)
       for more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    a
       Buffer holding input matrix ``A``. Must have size at least
@@ -207,7 +207,7 @@ geru (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Pointer to input/output vector ``y``. The array holding
@@ -216,7 +216,7 @@ geru (USM Version)
       more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix

--- a/source/elements/oneMKL/source/domains/blas/hbmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/hbmv.rst
@@ -114,7 +114,7 @@ hbmv (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    beta
       Scaling factor for vector ``y``.
@@ -125,7 +125,7 @@ hbmv (Buffer Version)
       for more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
 .. container:: section
 
@@ -234,7 +234,7 @@ hbmv (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    beta
       Scaling factor for vector ``y``.
@@ -246,7 +246,7 @@ hbmv (USM Version)
       more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    dependencies
       List of events to wait for before starting computation, if any.

--- a/source/elements/oneMKL/source/domains/blas/hemv.rst
+++ b/source/elements/oneMKL/source/domains/blas/hemv.rst
@@ -107,7 +107,7 @@ hemv (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    beta
       Scaling factor for vector ``y``.
@@ -118,7 +118,7 @@ hemv (Buffer Version)
       for more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
 .. container:: section
 
@@ -220,7 +220,7 @@ hemv (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    beta
       Scaling factor for vector ``y``.
@@ -232,7 +232,7 @@ hemv (USM Version)
       more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    dependencies
       List of events to wait for before starting computation, if any.

--- a/source/elements/oneMKL/source/domains/blas/her.rst
+++ b/source/elements/oneMKL/source/domains/blas/her.rst
@@ -94,7 +94,7 @@ her (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    a
       Buffer holding input matrix ``A``. Must have size at least
@@ -195,7 +195,7 @@ her (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix

--- a/source/elements/oneMKL/source/domains/blas/her2.rst
+++ b/source/elements/oneMKL/source/domains/blas/her2.rst
@@ -95,7 +95,7 @@ her2 (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Buffer holding input/output vector ``y``. The buffer must be of
@@ -103,7 +103,7 @@ her2 (Buffer Version)
       for more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    a
       Buffer holding input matrix ``A``. Must have size at least
@@ -208,7 +208,7 @@ her2 (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Pointer to input/output vector ``y``. The array holding
@@ -217,7 +217,7 @@ her2 (USM Version)
       more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix

--- a/source/elements/oneMKL/source/domains/blas/hpmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/hpmv.rst
@@ -104,7 +104,7 @@ hpmv (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    beta
       Scaling factor for vector ``y``.
@@ -115,7 +115,7 @@ hpmv (Buffer Version)
       for more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
 .. container:: section
 
@@ -215,7 +215,7 @@ hpmv (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    beta
       Scaling factor for vector ``y``.
@@ -227,7 +227,7 @@ hpmv (USM Version)
       more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    dependencies
       List of events to wait for before starting computation, if any.

--- a/source/elements/oneMKL/source/domains/blas/hpr.rst
+++ b/source/elements/oneMKL/source/domains/blas/hpr.rst
@@ -92,7 +92,7 @@ hpr (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    a
       Buffer holding input matrix ``A``. Must have size at least
@@ -190,7 +190,7 @@ hpr (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix

--- a/source/elements/oneMKL/source/domains/blas/hpr2.rst
+++ b/source/elements/oneMKL/source/domains/blas/hpr2.rst
@@ -93,7 +93,7 @@ hpr2 (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Buffer holding input/output vector ``y``. The buffer must be of
@@ -101,7 +101,7 @@ hpr2 (Buffer Version)
       for more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    a
       Buffer holding input matrix ``A``. Must have size at least
@@ -203,7 +203,7 @@ hpr2 (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Pointer to input/output vector ``y``. The array holding
@@ -212,7 +212,7 @@ hpr2 (USM Version)
       more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix

--- a/source/elements/oneMKL/source/domains/blas/sbmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/sbmv.rst
@@ -114,7 +114,7 @@ sbmv (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    beta
       Scaling factor for vector ``y``.
@@ -125,7 +125,7 @@ sbmv (Buffer Version)
       for more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
 .. container:: section
 
@@ -233,7 +233,7 @@ sbmv (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    beta
       Scaling factor for vector ``y``.
@@ -245,7 +245,7 @@ sbmv (USM Version)
       more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    dependencies
       List of events to wait for before starting computation, if any.

--- a/source/elements/oneMKL/source/domains/blas/spmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/spmv.rst
@@ -101,7 +101,7 @@ spmv (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
    
    beta
       Scaling factor for vector ``y``.
@@ -112,7 +112,7 @@ spmv (Buffer Version)
       for more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
 .. container:: section
 
@@ -209,7 +209,7 @@ spmv (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    beta
       Scaling factor for vector ``y``.
@@ -221,7 +221,7 @@ spmv (USM Version)
       more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    dependencies
       List of events to wait for before starting computation, if any.

--- a/source/elements/oneMKL/source/domains/blas/spr.rst
+++ b/source/elements/oneMKL/source/domains/blas/spr.rst
@@ -89,7 +89,7 @@ spr (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    a
       Buffer holding input matrix ``A``. Must have size at least
@@ -183,7 +183,7 @@ spr (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix

--- a/source/elements/oneMKL/source/domains/blas/spr2.rst
+++ b/source/elements/oneMKL/source/domains/blas/spr2.rst
@@ -93,7 +93,7 @@ spr2 (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Buffer holding input/output vector ``y``. The buffer must be of
@@ -101,7 +101,7 @@ spr2 (Buffer Version)
       for more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    a
       Buffer holding input matrix ``A``. Must have size at least
@@ -198,7 +198,7 @@ spr2 (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Pointer to input/output vector ``y``. The array holding
@@ -207,7 +207,7 @@ spr2 (USM Version)
       more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix

--- a/source/elements/oneMKL/source/domains/blas/symv.rst
+++ b/source/elements/oneMKL/source/domains/blas/symv.rst
@@ -107,7 +107,7 @@ symv (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Buffer holding input/output vector ``y``. The buffer must be of
@@ -115,7 +115,7 @@ symv (Buffer Version)
       for more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
 .. container:: section
 
@@ -217,7 +217,7 @@ symv (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Pointer to input/output vector ``y``. The array holding
@@ -226,7 +226,7 @@ symv (USM Version)
       more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    dependencies
       List of events to wait for before starting computation, if any.

--- a/source/elements/oneMKL/source/domains/blas/syr.rst
+++ b/source/elements/oneMKL/source/domains/blas/syr.rst
@@ -92,7 +92,7 @@ syr (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    a
       Buffer holding input matrix ``A``. Must have size at least
@@ -191,7 +191,7 @@ syr (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix

--- a/source/elements/oneMKL/source/domains/blas/syr2.rst
+++ b/source/elements/oneMKL/source/domains/blas/syr2.rst
@@ -96,7 +96,7 @@ syr2 (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Buffer holding input/output vector ``y``. The buffer must be of
@@ -104,7 +104,7 @@ syr2 (Buffer Version)
       for more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    a
       Buffer holding input matrix ``A``. Must have size at least
@@ -207,7 +207,7 @@ syr2 (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    y
       Pointer to input/output vector ``y``. The array holding
@@ -216,7 +216,7 @@ syr2 (USM Version)
       more details.
 
    incy
-      Stride of vector ``y``.
+      Stride of vector ``y``. Must not be zero.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix

--- a/source/elements/oneMKL/source/domains/blas/tbmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/tbmv.rst
@@ -115,7 +115,7 @@ tbmv (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
 .. container:: section
 
@@ -223,7 +223,7 @@ tbmv (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    dependencies
       List of events to wait for before starting computation, if any.

--- a/source/elements/oneMKL/source/domains/blas/tbsv.rst
+++ b/source/elements/oneMKL/source/domains/blas/tbsv.rst
@@ -117,7 +117,7 @@ tbsv (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
 .. container:: section
 
@@ -225,7 +225,7 @@ tbsv (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    dependencies
       List of events to wait for before starting computation, if any.

--- a/source/elements/oneMKL/source/domains/blas/tpmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/tpmv.rst
@@ -103,7 +103,7 @@ tpmv (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
 .. container:: section
 
@@ -200,7 +200,7 @@ tpmv (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    dependencies
       List of events to wait for before starting computation, if any.

--- a/source/elements/oneMKL/source/domains/blas/tpsv.rst
+++ b/source/elements/oneMKL/source/domains/blas/tpsv.rst
@@ -108,7 +108,7 @@ tpsv (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
 .. container:: section
 
@@ -208,7 +208,7 @@ tpsv (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    dependencies
       List of events to wait for before starting computation, if any.

--- a/source/elements/oneMKL/source/domains/blas/trmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/trmv.rst
@@ -109,7 +109,7 @@ trmv (Buffer Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
 .. container:: section
 
@@ -211,7 +211,7 @@ trmv (USM Version)
       more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    dependencies
       List of events to wait for before starting computation, if any.

--- a/source/elements/oneMKL/source/domains/blas/trsv.rst
+++ b/source/elements/oneMKL/source/domains/blas/trsv.rst
@@ -111,7 +111,7 @@ trsv (Buffer Version)
       See :ref:`matrix-storage` for more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
 .. container:: section
 
@@ -215,7 +215,7 @@ trsv (USM Version)
       :ref:`matrix-storage` for more details.
 
    incx
-      Stride of vector ``x``.
+      Stride of vector ``x``. Must not be zero.
 
    dependencies
       List of events to wait for before starting computation, if any.


### PR DESCRIPTION
This PR clarifies and makes more consistent the descriptions of the `incx` and `incy` parameters (and a couple stride parameters in batch functions).