### PR TITLE
[oneMKL][BLAS] Add complex versions of syr, syr2, symv

### DIFF
--- a/source/elements/oneMKL/source/domains/blas/symv.rst
+++ b/source/elements/oneMKL/source/domains/blas/symv.rst
@@ -37,6 +37,8 @@ where:
       * -  T 
       * -  ``float`` 
       * -  ``double`` 
+      * -  ``std::complex<float>`` 
+      * -  ``std::complex<double>`` 
 
 .. _onemkl_blas_symv_buffer:
 

--- a/source/elements/oneMKL/source/domains/blas/syr.rst
+++ b/source/elements/oneMKL/source/domains/blas/syr.rst
@@ -37,6 +37,8 @@ where:
       * -  T 
       * -  ``float`` 
       * -  ``double`` 
+      * -  ``std::complex<float>`` 
+      * -  ``std::complex<double>`` 
 
 .. _onemkl_blas_syr_buffer:
 

--- a/source/elements/oneMKL/source/domains/blas/syr2.rst
+++ b/source/elements/oneMKL/source/domains/blas/syr2.rst
@@ -37,6 +37,8 @@ where:
       * -  T 
       * -  ``float`` 
       * -  ``double`` 
+      * -  ``std::complex<float>`` 
+      * -  ``std::complex<double>`` 
 
 .. _onemkl_blas_syr2_buffer:
 


### PR DESCRIPTION
This PR updates the spec to include complex versions of `syr`, `syr2`, and `symv`.