### PR TITLE
[BLAS] add optional index_base parameter to iamax, iamin

### DIFF
--- a/source/elements/oneMKL/source/domains/blas/iamax.rst
+++ b/source/elements/oneMKL/source/domains/blas/iamax.rst
@@ -18,8 +18,11 @@ has the maximum absolute value of all elements in vector ``x`` (real
 variants), or such that (\|Re(``x[i]``)\| + \|Im(``x[i]``)\|) is maximal
 (complex variants).
 
-If either ``n`` or ``incx`` are not positive, the routine returns
-``0``.
+The index is zero-based if ``base`` is set to ``index_base::zero`` (default)
+or one-based if it is set to ``index_base::one``.
+
+If either ``n`` or ``incx`` is not positive, the routine returns
+``0``, regardless of the base of the index selected.
 
 If more than one vector element is found with the same largest
 absolute value, the index of the first one encountered is returned.
@@ -38,13 +41,6 @@ index of the first ``NaN``.
       * -  ``std::complex<float>`` 
       * -  ``std:complex<double>`` 
 
-.. container:: Note
-
-   .. rubric:: Note
-      :class: NoteTipHead
-
-   The index is zero-based.
-
 .. _onemkl_blas_iamax_buffer:
 
 iamax (Buffer Version)
@@ -59,7 +55,8 @@ iamax (Buffer Version)
                   std::int64_t n,
                   sycl::buffer<T,1> &x,
                   std::int64_t incx,
-                  sycl::buffer<std::int64_t,1> &result)
+                  sycl::buffer<std::int64_t,1> &result,
+                  index_base base = index_base::zero)
    }
 .. code-block:: cpp
 
@@ -68,7 +65,8 @@ iamax (Buffer Version)
                   std::int64_t n,
                   sycl::buffer<T,1> &x,
                   std::int64_t incx,
-                  sycl::buffer<std::int64_t,1> &result)
+                  sycl::buffer<std::int64_t,1> &result,
+                  index_base base = index_base::zero)
    }
 
 .. container:: section
@@ -89,12 +87,16 @@ iamax (Buffer Version)
    incx
       The stride of vector ``x``.
 
+   base
+      Indicates how the output value is indexed. If omitted, defaults to zero-based
+      indexing.
+
 .. container:: section
 
    .. rubric:: Output Parameters
 
    result
-      The buffer where the zero-based index ``i`` of the maximal element
+      The buffer where the index ``i`` of the maximal element
       is stored.
 
 .. container:: section
@@ -165,6 +167,10 @@ iamax (USM Version)
    incx
       The stride of vector ``x``.
 
+   base
+      Indicates how the output value is indexed. If omitted, defaults to zero-based
+      indexing.
+
    dependencies
       List of events to wait for before starting computation, if any.
       If omitted, defaults to no dependencies.
@@ -174,7 +180,7 @@ iamax (USM Version)
    .. rubric:: Output Parameters
 
    result
-      The pointer to where the zero-based index ``i`` of the maximal
+      The pointer to where the index ``i`` of the maximal
       element is stored.
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/blas/iamax.rst
+++ b/source/elements/oneMKL/source/domains/blas/iamax.rst
@@ -18,8 +18,8 @@ has the maximum absolute value of all elements in vector ``x`` (real
 variants), or such that (\|Re(``x[i]``)\| + \|Im(``x[i]``)\|) is maximal
 (complex variants).
 
-The index is zero-based if ``base`` is set to ``index_base::zero`` (default)
-or one-based if it is set to ``index_base::one``.
+The index is zero-based if ``base`` is set to ``oneapi::mkl::index_base::zero`` (default)
+or one-based if it is set to ``oneapi::mkl::index_base::one``.
 
 If either ``n`` or ``incx`` is not positive, the routine returns
 ``0``, regardless of the base of the index selected.
@@ -56,7 +56,7 @@ iamax (Buffer Version)
                   sycl::buffer<T,1> &x,
                   std::int64_t incx,
                   sycl::buffer<std::int64_t,1> &result,
-                  index_base base = index_base::zero)
+                  oneapi::mkl::index_base base = oneapi::mkl::index_base::zero)
    }
 .. code-block:: cpp
 
@@ -66,7 +66,7 @@ iamax (Buffer Version)
                   sycl::buffer<T,1> &x,
                   std::int64_t incx,
                   sycl::buffer<std::int64_t,1> &result,
-                  index_base base = index_base::zero)
+                  oneapi::mkl::index_base base = oneapi::mkl::index_base::zero)
    }
 
 .. container:: section
@@ -135,6 +135,7 @@ iamax (USM Version)
                          const T *x,
                          std::int64_t incx,
                          std::int64_t *result,
+                         oneapi::mkl::index_base base = oneapi::mkl::index_base::zero,
                          const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
@@ -145,6 +146,7 @@ iamax (USM Version)
                          const T *x,
                          std::int64_t incx,
                          std::int64_t *result,
+                         oneapi::mkl::index_base base = oneapi::mkl::index_base::zero,
                          const std::vector<sycl::event> &dependencies = {})
    }
 

--- a/source/elements/oneMKL/source/domains/blas/iamin.rst
+++ b/source/elements/oneMKL/source/domains/blas/iamin.rst
@@ -18,8 +18,8 @@ the minimum absolute value of all elements in vector ``x`` (real
 variants), or such that (\|Re(``x[i]``)\| + \|Im(``x[i]``)\|) is minimal
 (complex variants).
 
-The index is zero-based if ``base`` is set to ``index_base::zero`` (default)
-or one-based if it is set to ``index_base::one``.
+The index is zero-based if ``base`` is set to ``oneapi::mkl::index_base::zero`` (default)
+or one-based if it is set to ``oneapi::mkl::index_base::one``.
 
 If either ``n`` or ``incx`` is not positive, the routine returns
 ``0``, regardless of the base of the index selected.
@@ -57,7 +57,7 @@ iamin (Buffer Version)
                   sycl::buffer<T,1> &x,
                   std::int64_t incx,
                   sycl::buffer<std::int64_t,1> &result,
-                  index_base base = index_base::zero)
+                  oneapi::mkl::index_base base = oneapi::mkl::index_base::zero)
    }
 .. code-block:: cpp
 
@@ -67,7 +67,7 @@ iamin (Buffer Version)
                   sycl::buffer<T,1> &x,
                   std::int64_t incx,
                   sycl::buffer<std::int64_t,1> &result,
-                  index_base base = index_base::zero)
+                  oneapi::mkl::index_base base = oneapi::mkl::index_base::zero)
    }
 
 .. container:: section
@@ -136,7 +136,7 @@ iamin (USM Version)
                          const T *x,
                          std::int64_t incx,
                          std::int64_t *result,
-                         index_base base = index_base::zero,
+                         oneapi::mkl::index_base base = oneapi::mkl::index_base::zero,
                          const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
@@ -147,7 +147,7 @@ iamin (USM Version)
                          const T *x,
                          std::int64_t incx,
                          std::int64_t *result,
-                         index_base base = index_base::zero,
+                         oneapi::mkl::index_base base = oneapi::mkl::index_base::zero,
                          const std::vector<sycl::event> &dependencies = {})
    }
 

--- a/source/elements/oneMKL/source/domains/blas/iamin.rst
+++ b/source/elements/oneMKL/source/domains/blas/iamin.rst
@@ -18,8 +18,11 @@ the minimum absolute value of all elements in vector ``x`` (real
 variants), or such that (\|Re(``x[i]``)\| + \|Im(``x[i]``)\|) is minimal
 (complex variants).
 
-If either ``n`` or ``incx`` are not positive, the routine returns
-``0``.
+The index is zero-based if ``base`` is set to ``index_base::zero`` (default)
+or one-based if it is set to ``index_base::one``.
+
+If either ``n`` or ``incx`` is not positive, the routine returns
+``0``, regardless of the base of the index selected.
 
 If more than one vector element is found with the same smallest
 absolute value, the index of the first one encountered is returned.
@@ -38,12 +41,6 @@ index of the first ``NaN``.
       * -  ``std::complex<float>`` 
       * -  ``std::complex<double>`` 
 
-.. container:: Note
-
-   .. rubric:: Note
-      :class: NoteTipHead
-
-   The index is zero-based.
 
 .. _onemkl_blas_iamin_buffer:
 
@@ -59,7 +56,8 @@ iamin (Buffer Version)
                   std::int64_t n,
                   sycl::buffer<T,1> &x,
                   std::int64_t incx,
-                  sycl::buffer<std::int64_t,1> &result)
+                  sycl::buffer<std::int64_t,1> &result,
+                  index_base base = index_base::zero)
    }
 .. code-block:: cpp
 
@@ -68,7 +66,8 @@ iamin (Buffer Version)
                   std::int64_t n,
                   sycl::buffer<T,1> &x,
                   std::int64_t incx,
-                  sycl::buffer<std::int64_t,1> &result)
+                  sycl::buffer<std::int64_t,1> &result,
+                  index_base base = index_base::zero)
    }
 
 .. container:: section
@@ -89,12 +88,16 @@ iamin (Buffer Version)
    incx
       Stride of vector x.
 
+   base
+      Indicates how the output value is indexed. If omitted, defaults to zero-based
+      indexing.
+
 .. container:: section
 
    .. rubric:: Output Parameters
 
    result
-      Buffer where the zero-based index ``i`` of the minimum element
+      Buffer where the index ``i`` of the minimum element
       will be stored.
 
 .. container:: section
@@ -133,6 +136,7 @@ iamin (USM Version)
                          const T *x,
                          std::int64_t incx,
                          std::int64_t *result,
+                         index_base base = index_base::zero,
                          const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
@@ -143,6 +147,7 @@ iamin (USM Version)
                          const T *x,
                          std::int64_t incx,
                          std::int64_t *result,
+                         index_base base = index_base::zero,
                          const std::vector<sycl::event> &dependencies = {})
    }
 
@@ -165,12 +170,20 @@ iamin (USM Version)
    incx
       Stride of vector x.
 
+   base
+      Indicates how the output value is indexed. If omitted, defaults to zero-based
+      indexing.
+
+   dependencies
+      List of events to wait for before starting computation, if any.
+      If omitted, defaults to no dependencies.
+
 .. container:: section
 
    .. rubric:: Output Parameters
 
    result
-      Pointer to where the zero-based index ``i`` of the minimum
+      Pointer to where the index ``i`` of the minimum
       element will be stored.
 
 .. container:: section


### PR DESCRIPTION
Adds optional index_base parameter so iamax and iamin can return 1-based indices if user desires.