### PR TITLE
[oneMKL][spblas] add missing 'const' keyword for alpha, beta, and input array, and remove 'y' from input list in sparse::trsv() spec.

### DIFF
--- a/source/elements/oneMKL/source/domains/spblas/gemvdot.rst
+++ b/source/elements/oneMKL/source/domains/spblas/gemvdot.rst
@@ -45,10 +45,10 @@ gemvdot (Buffer version)
 
       void gemvdot (sycl::queue                          &queue,
                     oneapi::mkl::transpose               transpose_val,
-                    fp                                   alpha,
+                    const fp                             alpha,
                     oneapi::mkl::sparse::matrix_handle_t A_handle,
                     sycl::buffer<fp, 1>                  &x,
-                    fp                                   beta,
+                    const fp                             beta,
                     sycl::buffer<fp, 1>                  &y,
                     sycl::buffer<fp, 1>                  &d);
 
@@ -135,10 +135,10 @@ gemvdot (USM version)
 
       sycl::event gemvdot (sycl::queue                           &queue,
                            oneapi::mkl::transpose                transpose_val,
-                           fp                                    alpha,
+                           const fp                              alpha,
                            oneapi::mkl::sparse::matrix_handle_t  A_handle,
-                           fp                                    *x,
-                           fp                                    beta,
+                           const fp                              *x,
+                           const fp                              beta,
                            fp                                    *y,
                            fp                                    *d,
                            const std::vector<sycl::event>        &dependencies = {});

--- a/source/elements/oneMKL/source/domains/spblas/symv.rst
+++ b/source/elements/oneMKL/source/domains/spblas/symv.rst
@@ -39,10 +39,10 @@ symv (Buffer version)
 
       void symv (sycl::queue                          &queue,
                  oneapi::mkl::uplo                    uplo_val,
-                 fp                                   alpha,
+                 const fp                             alpha,
                  oneapi::mkl::sparse::matrix_handle_t A_handle,
                  sycl::buffer<fp, 1>                  &x,
-                 fp                                   beta,
+                 const fp                             beta,
                  sycl::buffer<fp, 1>                  &y);
 
    }
@@ -125,10 +125,10 @@ symv (USM version)
 
       sycl::event symv (sycl::queue                           &queue,
                         oneapi::mkl::uplo                     uplo_val,
-                        fp                                    alpha,
+                        const fp                              alpha,
                         oneapi::mkl::sparse::matrix_handle_t  A_handle,
-                        fp                                    *x,
-                        fp                                    beta,
+                        const fp                              *x,
+                        const fp                              beta,
                         fp                                    *y,
                         const std::vector<sycl::event>        &dependencies = {});
 

--- a/source/elements/oneMKL/source/domains/spblas/trmv.rst
+++ b/source/elements/oneMKL/source/domains/spblas/trmv.rst
@@ -39,10 +39,10 @@ trmv (Buffer version)
                  oneapi::mkl::uplo                    uplo_val
                  oneapi::mkl::transpose               transpose_val,
                  oneapi::mkl::diag                    diag_val
-                 fp                                   alpha,
+                 const fp                             alpha,
                  oneapi::mkl::sparse::matrix_handle_t A_handle,
                  sycl::buffer<fp, 1>                  &x,
-                 fp                                   beta,
+                 const fp                             beta,
                  sycl::buffer<fp, 1>                  &y);
 
    }
@@ -138,10 +138,10 @@ trmv (USM version)
                         oneapi::mkl::uplo                     uplo_val
                         oneapi::mkl::transpose                transpose_val,
                         oneapi::mkl::diag                     diag_val
-                        fp                                    alpha,
+                        const fp                              alpha,
                         oneapi::mkl::sparse::matrix_handle_t  A_handle,
-                        fp                                    *x,
-                        fp                                    beta,
+                        const fp                              *x,
+                        const fp                              beta,
                         fp                                    *y
                         const std::vector<sycl::event>        &dependencies = {});
 

--- a/source/elements/oneMKL/source/domains/spblas/trsv.rst
+++ b/source/elements/oneMKL/source/domains/spblas/trsv.rst
@@ -82,11 +82,6 @@ trsv (Buffer version)
         equal to the number of columns of  matrix :math:`\text{op}(A)`.
 
 
-   y
-        SYCL memory object containing an array of size at least
-        equal to the number of rows of matrix :math:`\text{op}(A)`.
-
-
 .. container:: section
 
 
@@ -129,7 +124,7 @@ trsv (USM version)
                         oneapi::mkl::transpose                transpose_val,
                         oneapi::mkl::diag                     diag_val
                         oneapi::mkl::sparse::matrix_handle_t  A_handle,
-                        fp                                    *x,
+                        const fp                              *x,
                         fp                                    *y
                         const std::vector<sycl::event>        &dependencies = {});
 
@@ -169,11 +164,6 @@ trsv (USM version)
    x
         Device-accessible USM object containing an array of size at least
         equal to the number of columns of matrix :math:`\text{op}(A)`.
-
-
-   y
-        Device-accessible USM object containing an array of size at least
-        equal to the number of rows of matrix :math:`\text{op}(A)`.
 
 
    dependencies


### PR DESCRIPTION
**Goal:**
In this PR, I'd like to update some missing `const` keyword for constant parameters within the spec for `spblas` domain in order to achieve consistency in the spec, and fix some minor information.

**Details:**

- add some missing `const` keyword for constant parameters (e.g. `alpha` and `beta`) in the APIs.
- add `const` keyword for input vector/matrix in some spblas APIs.
- remove `y` vector from the input list of `sparse::trsv()` API spec, since `y` is not an input for `sparse::trsv()` API.