### PR TITLE
[oneMKL][BLAS] value_or_pointer wrapper for BLAS USM scalar parameters

### DIFF
--- a/source/elements/oneMKL/source/domains/blas/axpby.rst
+++ b/source/elements/oneMKL/source/domains/blas/axpby.rst
@@ -127,9 +127,9 @@ axpby (USM Version)
    namespace oneapi::mkl::blas::column_major {
        sycl::event axpby(sycl::queue &queue,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x, std::int64_t incx,
-                        const T beta,
+                        value_or_pointer<T> beta,
                         T *y, std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
    }
@@ -138,9 +138,9 @@ axpby (USM Version)
    namespace oneapi::mkl::blas::row_major {
        sycl::event axpby(sycl::queue &queue,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x, std::int64_t incx,
-                        const T beta,
+                        value_or_pointer<T> beta,
                         T *y, std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
    }
@@ -156,10 +156,10 @@ axpby (USM Version)
       Number of elements in vector ``x`` and ``y``.
 
    alpha
-      Specifies the scalar alpha.
+      Specifies the scalar alpha. See :ref:`value_or_pointer` for more details.
 
    beta
-      Specifies the scalar beta.
+      Specifies the scalar beta. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to the input vector ``x``. The allocated memory must be

--- a/source/elements/oneMKL/source/domains/blas/axpy.rst
+++ b/source/elements/oneMKL/source/domains/blas/axpy.rst
@@ -138,7 +138,7 @@ axpy (USM Version)
    namespace oneapi::mkl::blas::column_major {
        sycl::event axpy(sycl::queue &queue,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x,
                         std::int64_t incx,
                         T *y,
@@ -150,7 +150,7 @@ axpy (USM Version)
    namespace oneapi::mkl::blas::row_major {
        sycl::event axpy(sycl::queue &queue,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x,
                         std::int64_t incx,
                         T *y,
@@ -169,7 +169,7 @@ axpy (USM Version)
       Number of elements in vector ``x``.
 
    alpha
-      Specifies the scalar alpha.
+      Specifies the scalar alpha. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to the input vector ``x``. The array holding the vector

--- a/source/elements/oneMKL/source/domains/blas/axpy_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/axpy_batch.rst
@@ -292,7 +292,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
    namespace oneapi::mkl::blas::column_major {
        sycl::event axpy_batch(sycl::queue &queue,
                               std::int64_t n,
-                              T alpha,
+                              value_or_pointer<T> alpha,
                               const T *x,
                               std::int64_t incx,
                               std::int64_t stridex,
@@ -307,7 +307,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
    namespace oneapi::mkl::blas::row_major {
        sycl::event axpy_batch(sycl::queue &queue,
                               std::int64_t n,
-                              T alpha,
+                              value_or_pointer<T> alpha,
                               const T *x,
                               std::int64_t incx,
                               std::int64_t stridex,
@@ -329,7 +329,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
       Number of elements in ``X`` and ``Y``.
 
    alpha
-       Specifies the scalar ``alpha``.
+       Specifies the scalar ``alpha``. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to input vectors ``X`` with size ``stridex`` * ``batch_size``.

--- a/source/elements/oneMKL/source/domains/blas/gbmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/gbmv.rst
@@ -195,12 +195,12 @@ gbmv (USM Version)
                         std::int64_t n,
                         std::int64_t kl,
                         std::int64_t ku,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -214,12 +214,12 @@ gbmv (USM Version)
                         std::int64_t n,
                         std::int64_t kl,
                         std::int64_t ku,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -253,7 +253,7 @@ gbmv (USM Version)
       zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix
@@ -276,7 +276,7 @@ gbmv (USM Version)
       Stride of vector ``x``. Must not be zero.
 
    beta
-      Scaling factor for vector ``y``.
+      Scaling factor for vector ``y``. See :ref:`value_or_pointer` for more details.
 
    y
       Pointer to input/output vector ``y``. The length ``len`` of

--- a/source/elements/oneMKL/source/domains/blas/gemm.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemm.rst
@@ -308,12 +308,12 @@ gemm (USM Version)
                         std::int64_t m,
                         std::int64_t n,
                         std::int64_t k,
-                        Ts alpha,
+                        value_or_pointer<Ts> alpha,
                         const Ta *a,
                         std::int64_t lda,
                         const Tb *b,
                         std::int64_t ldb,
-                        Ts beta,
+                        value_or_poitner<Ts> beta,
                         Tc *c,
                         std::int64_t ldc,
                         const std::vector<sycl::event> &dependencies = {})
@@ -327,12 +327,12 @@ gemm (USM Version)
                         std::int64_t m,
                         std::int64_t n,
                         std::int64_t k,
-                        Ts alpha,
+                        value_or_pointer<Ts> alpha,
                         const Ta *a,
                         std::int64_t lda,
                         const Tb *b,
                         std::int64_t ldb,
-                        Ts beta,
+                        value_or_pointer<Ts> beta,
                         Tc *c,
                         std::int64_t ldc,
                         const std::vector<sycl::event> &dependencies = {})
@@ -373,7 +373,7 @@ gemm (USM Version)
 
 
    alpha
-      Scaling factor for the matrix-matrix product.
+      Scaling factor for the matrix-matrix product. See :ref:`value_or_pointer` for more details.
 
 
    a
@@ -453,7 +453,7 @@ gemm (USM Version)
            - ``ldb`` must be at least ``k``.
 
    beta
-      Scaling factor for matrix ``C``.
+      Scaling factor for matrix ``C``. See :ref:`value_or_pointer` for more details.
 
    c
       The pointer to input/output matrix ``C``. It must have a

--- a/source/elements/oneMKL/source/domains/blas/gemm_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemm_batch.rst
@@ -593,14 +593,14 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
                               std::int64_t m,
                               std::int64_t n,
                               std::int64_t k,
-                              T alpha,
+                              value_or_pointer<T> alpha,
                               const T *a,
                               std::int64_t lda,
                               std::int64_t stridea,
                               const T *b,
                               std::int64_t ldb,
                               std::int64_t strideb,
-                              T beta,
+                              value_or_pointer<T> beta,
                               T *c,
                               std::int64_t ldc,
                               std::int64_t stridec,
@@ -616,14 +616,14 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
                               std::int64_t m,
                               std::int64_t n,
                               std::int64_t k,
-                              T alpha,
+                              value_or_pointer<T> alpha,
                               const T *a,
                               std::int64_t lda,
                               std::int64_t stridea,
                               const T *b,
                               std::int64_t ldb,
                               std::int64_t strideb,
-                              T beta,
+                              value_or_pointer<T> beta,
                               T *c,
                               std::int64_t ldc,
                               std::int64_t stridec,
@@ -657,7 +657,7 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
       least zero.
 
    alpha
-      Scaling factor for the matrix-matrix products.
+      Scaling factor for the matrix-matrix products. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrices ``A`` with size ``stridea`` * ``batch_size``.
@@ -704,7 +704,7 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
       Stride between different ``B`` matrices.
 
    beta
-      Scaling factor for the matrices ``C``.
+      Scaling factor for the matrices ``C``. See :ref:`value_or_pointer` for more details.
 
    c
       Pointer to input/output matrices ``C`` with size ``stridec`` * ``batch_size``.

--- a/source/elements/oneMKL/source/domains/blas/gemm_bias.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemm_bias.rst
@@ -311,14 +311,14 @@ gemm_bias (USM Version)
                              std::int64_t m,
                              std::int64_t n,
                              std::int64_t k,
-                             float alpha,
+                             value_or_pointer<float> alpha,
                              const Ta *a,
                              std::int64_t lda,
                              Ta ao,
                              const Tb *b,
                              std::int64_t ldb,
                              Tb bo,
-                             float beta,
+                             value_or_pointer<float> beta,
                              std::int32_t *c,
                              std::int64_t ldc,
                              const std::int32_t *co,
@@ -334,14 +334,14 @@ gemm_bias (USM Version)
                              std::int64_t m,
                              std::int64_t n,
                              std::int64_t k,
-                             float alpha,
+                             value_or_pointer<float> alpha,
                              const Ta *a,
                              std::int64_t lda,
                              Ta ao,
                              const Tb *b,
                              std::int64_t ldb,
                              Tb bo,
-                             float beta,
+                             value_or_pointer<float> beta,
                              std::int32_t *c,
                              std::int64_t ldc,
                              const std::int32_t *co,
@@ -385,7 +385,7 @@ gemm_bias (USM Version)
       at least zero.
  
    alpha
-      Scaling factor for the matrix-matrix product.
+      Scaling factor for the matrix-matrix product. See :ref:`value_or_pointer` for more details.
  
    a
       Pointer to input matrix ``A``.
@@ -470,7 +470,7 @@ gemm_bias (USM Version)
       Specifies the scalar offset value for matrix ``B``.
  
    beta
-      Scaling factor for matrix ``C``.
+      Scaling factor for matrix ``C``. See :ref:`value_or_pointer` for more details.
  
    c
       Pointer to input/output matrix ``C``. It must have a

--- a/source/elements/oneMKL/source/domains/blas/gemmt.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemmt.rst
@@ -259,12 +259,12 @@ gemmt (USM Version)
                          onemkl::transpose transb,
                          std::int64_t n,
                          std::int64_t k,
-                         T alpha,
+                         value_or_pointer<T> alpha,
                          const T *a,
                          std::int64_t lda,
                          const T *b,
                          std::int64_t ldb,
-                         T beta,
+                         value_or_pointer<T> beta,
                          T *c,
                          std::int64_t ldc,
                          const std::vector<sycl::event> &dependencies = {})
@@ -278,12 +278,12 @@ gemmt (USM Version)
                          onemkl::transpose transb,
                          std::int64_t n,
                          std::int64_t k,
-                         T alpha,
+                         value_or_pointer<T> alpha,
                          const T *a,
                          std::int64_t lda,
                          const T *b,
                          std::int64_t ldb,
-                         T beta,
+                         value_or_pointer<T> beta,
                          T *c,
                          std::int64_t ldc,
                          const std::vector<sycl::event> &dependencies = {})
@@ -323,7 +323,7 @@ gemmt (USM Version)
       at least zero.
 
    alpha
-      Scaling factor for the matrix-matrix product.
+      Scaling factor for the matrix-matrix product. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``.
@@ -402,7 +402,7 @@ gemmt (USM Version)
            - ``ldb`` must be at least ``k``.
       
    beta
-      Scaling factor for matrix ``C``.
+      Scaling factor for matrix ``C``. See :ref:`value_or_pointer` for more details.
 
    c
       Pointer to input/output matrix ``C``. Must have size at least

--- a/source/elements/oneMKL/source/domains/blas/gemv.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemv.rst
@@ -177,12 +177,12 @@ gemv (USM Version)
                         onemkl::transpose trans,
                         std::int64_t m,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -194,12 +194,12 @@ gemv (USM Version)
                         onemkl::transpose trans,
                         std::int64_t m,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -227,7 +227,7 @@ gemv (USM Version)
       of ``n`` must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to the input matrix ``A``. Must have a size of at
@@ -251,7 +251,7 @@ gemv (USM Version)
       The stride of vector ``x``. Must not be zero.
 
    beta
-      The scaling factor for vector ``y``.
+      The scaling factor for vector ``y``. See :ref:`value_or_pointer` for more details.
 
    y
       Pointer to input/output vector ``y``. The length ``len`` of

--- a/source/elements/oneMKL/source/domains/blas/gemv_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemv_batch.rst
@@ -380,14 +380,14 @@ total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by th
                               onemkl::transpose trans,
                               std::int64_t m,
                               std::int64_t n,
-                              T alpha,
+                              value_or_pointer<T> alpha,
                               const T *a,
                               std::int64_t lda,
                               std::int64_t stridea,
                               const T *x,
                               std::int64_t incx,
                               std::int64_t stridex,
-                              T beta,
+                              value_or_pointer<T> beta,
                               T *y,
                               std::int64_t incy,
                               std::int64_t stridey,
@@ -401,14 +401,14 @@ total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by th
                               onemkl::transpose trans,
                               std::int64_t m,
                               std::int64_t n,
-                              T alpha,
+                              value_or_pointer<T> alpha,
                               const T *a,
                               std::int64_t lda,
                               std::int64_t stridea,
                               const T *x,
                               std::int64_t incx,
                               std::int64_t stridex,
-                              T beta,
+                              value_or_pointer<T> beta,
                               T *y,
                               std::int64_t incy,
                               std::int64_t stridey,
@@ -435,7 +435,7 @@ total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by th
       Number of columns of op(``A``). Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector products.
+      Scaling factor for the matrix-vector products. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to the input matrices ``A`` with size ``stridea`` * ``batch_size``.
@@ -458,7 +458,7 @@ total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by th
       Stride between different consecutive ``X`` vectors, must be at least 0.
 
    beta
-      Scaling factor for the vector ``Y``.
+      Scaling factor for the vector ``Y``. See :ref:`value_or_pointer` for more details.
 
    y
       Pointer to the input/output vectors ``Y`` with size ``stridey`` * ``batch_size``.

--- a/source/elements/oneMKL/source/domains/blas/ger.rst
+++ b/source/elements/oneMKL/source/domains/blas/ger.rst
@@ -159,7 +159,7 @@ ger (USM Version)
        sycl::event ger(sycl::queue &queue,
                        std::int64_t m,
                        std::int64_t n,
-                       T alpha,
+                       value_or_pointer<T> alpha,
                        const T *x,
                        std::int64_t incx,
                        const T *y,
@@ -174,7 +174,7 @@ ger (USM Version)
        sycl::event ger(sycl::queue &queue,
                        std::int64_t m,
                        std::int64_t n,
-                       T alpha,
+                       value_or_pointer<T> alpha,
                        const T *x,
                        std::int64_t incx,
                        const T *y,
@@ -198,7 +198,7 @@ ger (USM Version)
       Number of columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to input vector ``x``. The array holding input vector

--- a/source/elements/oneMKL/source/domains/blas/gerc.rst
+++ b/source/elements/oneMKL/source/domains/blas/gerc.rst
@@ -161,7 +161,7 @@ gerc (USM Version)
        sycl::event gerc(sycl::queue &queue,
                         std::int64_t m,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x,
                         std::int64_t incx,
                         const T *y,
@@ -176,7 +176,7 @@ gerc (USM Version)
        sycl::event gerc(sycl::queue &queue,
                         std::int64_t m,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x,
                         std::int64_t incx,
                         const T *y,
@@ -200,7 +200,7 @@ gerc (USM Version)
       Number of columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to the input vector ``x``. The array holding input

--- a/source/elements/oneMKL/source/domains/blas/geru.rst
+++ b/source/elements/oneMKL/source/domains/blas/geru.rst
@@ -159,7 +159,7 @@ geru (USM Version)
        sycl::event geru(sycl::queue &queue,
                         std::int64_t m,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x,
                         std::int64_t incx,
                         const T *y,
@@ -174,7 +174,7 @@ geru (USM Version)
        sycl::event geru(sycl::queue &queue,
                         std::int64_t m,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x,
                         std::int64_t incx,
                         const T *y,
@@ -198,7 +198,7 @@ geru (USM Version)
       Number of columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to the input vector ``x``. The array holding input

--- a/source/elements/oneMKL/source/domains/blas/hbmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/hbmv.rst
@@ -169,12 +169,12 @@ hbmv (USM Version)
                         onemkl::uplo upper_lower,
                         std::int64_t n,
                         std::int64_t k,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -186,12 +186,12 @@ hbmv (USM Version)
                         onemkl::uplo upper_lower,
                         std::int64_t n,
                         std::int64_t k,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -215,7 +215,7 @@ hbmv (USM Version)
       zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to the input matrix ``A``. The array holding input
@@ -237,7 +237,7 @@ hbmv (USM Version)
       Stride of vector ``x``. Must not be zero.
 
    beta
-      Scaling factor for vector ``y``.
+      Scaling factor for vector ``y``. See :ref:`value_or_pointer` for more details.
 
    y
       Pointer to input/output vector ``y``. The array holding

--- a/source/elements/oneMKL/source/domains/blas/hemm.rst
+++ b/source/elements/oneMKL/source/domains/blas/hemm.rst
@@ -210,12 +210,12 @@ hemm (USM Version)
                         onemkl::uplo upper_lower,
                         std::int64_t m,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *b,
                         std::int64_t ldb,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *c,
                         std::int64_t ldc,
                         const std::vector<sycl::event> &dependencies = {})
@@ -228,12 +228,12 @@ hemm (USM Version)
                         onemkl::uplo upper_lower,
                         std::int64_t m,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *b,
                         std::int64_t ldb,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *c,
                         std::int64_t ldc,
                         const std::vector<sycl::event> &dependencies = {})
@@ -266,7 +266,7 @@ hemm (USM Version)
       The value of ``n`` must be at least zero.
 
    alpha
-      Scaling factor for the matrix-matrix product.
+      Scaling factor for the matrix-matrix product. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``. Must have size at least
@@ -293,7 +293,7 @@ hemm (USM Version)
       least ``n`` if column major layout is used to store matrices.
 
    beta
-      Scaling factor for matrix ``C``.
+      Scaling factor for matrix ``C``. See :ref:`value_or_pointer` for more details.
 
    c
       The pointer to input/output matrix ``C``. It must have a

--- a/source/elements/oneMKL/source/domains/blas/hemv.rst
+++ b/source/elements/oneMKL/source/domains/blas/hemv.rst
@@ -161,12 +161,12 @@ hemv (USM Version)
        sycl::event hemv(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -177,12 +177,12 @@ hemv (USM Version)
        sycl::event hemv(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -202,7 +202,7 @@ hemv (USM Version)
       Number of rows and columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix
@@ -223,7 +223,7 @@ hemv (USM Version)
       Stride of vector ``x``. Must not be zero.
 
    beta
-      Scaling factor for vector ``y``.
+      Scaling factor for vector ``y``. See :ref:`value_or_pointer` for more details.
 
    y
       Pointer to input/output vector ``y``. The array holding

--- a/source/elements/oneMKL/source/domains/blas/her.rst
+++ b/source/elements/oneMKL/source/domains/blas/her.rst
@@ -151,7 +151,7 @@ her (USM Version)
        sycl::event her(sycl::queue &queue,
                        onemkl::uplo upper_lower,
                        std::int64_t n,
-                       Treal alpha,
+                       value_or_pointer<Treal> alpha,
                        const T *x,
                        std::int64_t incx,
                        T *a,
@@ -164,7 +164,7 @@ her (USM Version)
        sycl::event her(sycl::queue &queue,
                        onemkl::uplo upper_lower,
                        std::int64_t n,
-                       Treal alpha,
+                       value_or_pointer<Treal> alpha,
                        const T *x,
                        std::int64_t incx,
                        T *a,
@@ -186,7 +186,7 @@ her (USM Version)
       Number of rows and columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to input vector ``x``. The array holding input vector

--- a/source/elements/oneMKL/source/domains/blas/her2.rst
+++ b/source/elements/oneMKL/source/domains/blas/her2.rst
@@ -160,7 +160,7 @@ her2 (USM Version)
        sycl::event her2(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x,
                         std::int64_t incx,
                         const T *y,
@@ -175,7 +175,7 @@ her2 (USM Version)
        sycl::event her2(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x,
                         std::int64_t incx,
                         const T *y,
@@ -199,7 +199,7 @@ her2 (USM Version)
       Number of columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to input vector ``x``. The array holding input vector

--- a/source/elements/oneMKL/source/domains/blas/her2k.rst
+++ b/source/elements/oneMKL/source/domains/blas/her2k.rst
@@ -253,12 +253,12 @@ her2k (USM Version)
                          onemkl::transpose trans,
                          std::int64_t n,
                          std::int64_t k,
-                         T alpha,
+                         value_or_pointer<T> alpha,
                          const T *a,
                          std::int64_t lda,
                          const T *b,
                          std::int64_t ldb,
-                         Treal beta,
+                         value_or_pointer<Treal> beta,
                          T *c,
                          std::int64_t ldc,
                          const std::vector<sycl::event> &dependencies = {})
@@ -271,12 +271,12 @@ her2k (USM Version)
                          onemkl::transpose trans,
                          std::int64_t n,
                          std::int64_t k,
-                         T alpha,
+                         value_or_pointer<T> alpha,
                          const T *a,
                          std::int64_t lda,
                          const T *b,
                          std::int64_t ldb,
-                         Treal beta,
+                         value_or_pointer<Treal> beta,
                          T *c,
                          std::int64_t ldc,
                          const std::vector<sycl::event> &dependencies = {})
@@ -307,7 +307,7 @@ her2k (USM Version)
       ``k`` must be at least equal to zero.
 
    alpha
-      Complex scaling factor for the rank-2k update.
+      Complex scaling factor for the rank-2k update. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``.
@@ -387,7 +387,7 @@ her2k (USM Version)
            - ``ldb`` must be at least ``k``.
 
    beta
-      Real scaling factor for matrix ``C``.
+      Real scaling factor for matrix ``C``. See :ref:`value_or_pointer` for more details.
 
    c
       Pointer to input/output matrix ``C``. Must have size at least

--- a/source/elements/oneMKL/source/domains/blas/herk.rst
+++ b/source/elements/oneMKL/source/domains/blas/herk.rst
@@ -204,10 +204,10 @@ herk (USM Version)
                         onemkl::transpose trans,
                         std::int64_t n,
                         std::int64_t k,
-                        Treal alpha,
+                        value_or_pointer<Treal> alpha,
                         const T *a,
                         std::int64_t lda,
-                        Treal beta,
+                        value_or_pointer<Treal> beta,
                         T *c,
                         std::int64_t ldc,
                         const std::vector<sycl::event> &dependencies = {})
@@ -220,10 +220,10 @@ herk (USM Version)
                         onemkl::transpose trans,
                         std::int64_t n,
                         std::int64_t k,
-                        Treal alpha,
+                        value_or_pointer<Treal> alpha,
                         const T *a,
                         std::int64_t lda,
-                        Treal beta,
+                        value_or_pointer<Treal> beta,
                         T *c,
                         std::int64_t ldc,
                         const std::vector<sycl::event> &dependencies = {})
@@ -255,7 +255,7 @@ herk (USM Version)
       The value of ``k`` must be at least zero.
 
    alpha
-      Real scaling factor for the rank-k update.
+      Real scaling factor for the rank-k update. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``.
@@ -296,7 +296,7 @@ herk (USM Version)
            - ``lda`` must be at least ``n``.
 
    beta
-      Real scaling factor for matrix ``C``.
+      Real scaling factor for matrix ``C``. See :ref:`value_or_pointer` for more details.
 
    c
       Pointer to input/output matrix ``C``. Must have size at least

--- a/source/elements/oneMKL/source/domains/blas/hpmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/hpmv.rst
@@ -158,11 +158,11 @@ hpmv (USM Version)
        sycl::event hpmv(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -173,11 +173,11 @@ hpmv (USM Version)
        sycl::event hpmv(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -197,7 +197,7 @@ hpmv (USM Version)
       Number of rows and columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix
@@ -218,7 +218,7 @@ hpmv (USM Version)
       Stride of vector ``x``. Must not be zero.
 
    beta
-      Scaling factor for vector ``y``.
+      Scaling factor for vector ``y``. See :ref:`value_or_pointer` for more details.
 
    y
       Pointer to input/output vector ``y``. The array holding

--- a/source/elements/oneMKL/source/domains/blas/hpr.rst
+++ b/source/elements/oneMKL/source/domains/blas/hpr.rst
@@ -148,7 +148,7 @@ hpr (USM Version)
        sycl::event hpr(sycl::queue &queue,
                        onemkl::uplo upper_lower,
                        std::int64_t n,
-                       Treal alpha,
+                       value_or_pointer<Treal> alpha,
                        const T *x,
                        std::int64_t incx,
                        T *a,
@@ -160,7 +160,7 @@ hpr (USM Version)
        sycl::event hpr(sycl::queue &queue,
                        onemkl::uplo upper_lower,
                        std::int64_t n,
-                       Treal alpha,
+                       value_or_pointer<Treal> alpha,
                        const T *x,
                        std::int64_t incx,
                        T *a,
@@ -181,7 +181,7 @@ hpr (USM Version)
       Number of rows and columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to input vector ``x``. The array holding input vector

--- a/source/elements/oneMKL/source/domains/blas/hpr2.rst
+++ b/source/elements/oneMKL/source/domains/blas/hpr2.rst
@@ -157,7 +157,7 @@ hpr2 (USM Version)
        sycl::event hpr2(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x,
                         std::int64_t incx,
                         const T *y,
@@ -171,7 +171,7 @@ hpr2 (USM Version)
        sycl::event hpr2(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x,
                         std::int64_t incx,
                         const T *y,
@@ -194,7 +194,7 @@ hpr2 (USM Version)
       Number of rows and columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to input vector ``x``. The array holding input vector

--- a/source/elements/oneMKL/source/domains/blas/imatcopy.rst
+++ b/source/elements/oneMKL/source/domains/blas/imatcopy.rst
@@ -178,7 +178,7 @@ imatcopy (USM Version)
                             oneapi::mkl::transpose trans,
                             std::int64_t m,
                             std::int64_t n,
-                            T alpha,
+                            value_or_pointer<T> alpha,
                             T *matrix_in_out,
                             std::int64_t ld_in,
                             std::int64_t ld_out,
@@ -190,7 +190,7 @@ imatcopy (USM Version)
                             oneapi::mkl::transpose trans,
                             std::int64_t m,
                             std::int64_t n,
-                            T alpha,
+                            value_or_pointer<T> alpha,
                             T *matrix_in_out,
                             std::int64_t ld_in,
                             std::int64_t ld_out,
@@ -214,7 +214,7 @@ imatcopy (USM Version)
       Number of columns for the matrix ``C`` on input. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix transpose or copy operation.
+      Scaling factor for the matrix transpose or copy operation. See :ref:`value_or_pointer` for more details.
 
    matrix_in_out
          Pointer to input/output matrix ``C``. Must have size as follows:

--- a/source/elements/oneMKL/source/domains/blas/imatcopy_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/imatcopy_batch.rst
@@ -386,7 +386,7 @@ matrices is given by the ``batch_size`` parameter.
                                   oneapi::mkl::transpose trans,
                                   std::int64_t m,
                                   std::int64_t n,
-                                  T alpha,
+                                  value_or_pointer<T> alpha,
                                   const T *matrix_array_in_out,
                                   std::int64_t ld_in,
                                   std::int64_t ld_out,
@@ -400,7 +400,7 @@ matrices is given by the ``batch_size`` parameter.
                                   oneapi::mkl::transpose trans,
                                   std::int64_t m,
                                   std::int64_t n,
-                                  T alpha,
+                                  value_or_pointer<T> alpha,
                                   const T *matrix_array_in_out,
                                   std::int64_t ld_in,
                                   std::int64_t ld_out,
@@ -426,7 +426,7 @@ matrices is given by the ``batch_size`` parameter.
       Number of columns for each matrix ``C`` on input. Must be at least 0.
 
    alpha
-      Scaling factor for the matrix transpose or copy operation.
+      Scaling factor for the matrix transpose or copy operation. See :ref:`value_or_pointer` for more details.
 
    matrix_array_in_out
       Array holding the matrices ``C``. Must have size at least

--- a/source/elements/oneMKL/source/domains/blas/omatadd.rst
+++ b/source/elements/oneMKL/source/domains/blas/omatadd.rst
@@ -249,10 +249,10 @@ omatadd (USM Version)
                            oneapi::mkl::transpose transb,
                            std::int64_t m,
                            std::int64_t n,
-                           T alpha,
+                           value_or_pointer<T> alpha,
                            const T *a,
                            std::int64_t lda,
-                           T beta,
+                           value_or_pointer<T> beta,
                            const T *b,
                            std::int64_t ldb,
                            T *c,
@@ -267,10 +267,10 @@ omatadd (USM Version)
                            oneapi::mkl::transpose transb,
                            std::int64_t m,
                            std::int64_t n,
-                           T alpha,
+                           value_or_pointer<T> alpha,
                            const T *a,
                            std::int64_t lda,
-                           T beta,
+                           value_or_pointer<T> beta,
                            const T *b,
                            std::int64_t ldb,
                            T *c,
@@ -300,7 +300,7 @@ omatadd (USM Version)
       Number of columns for the result matrix ``C``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix ``A``.
+      Scaling factor for the matrix ``A``. See :ref:`value_or_pointer` for more details.
 
    a
       Array holding the input matrix ``A``.
@@ -335,7 +335,7 @@ omatadd (USM Version)
            - ``lda`` must be at least ``m``.
 
    beta
-      Scaling factor for the matrices ``B``.
+      Scaling factor for the matrices ``B``. See :ref:`value_or_pointer` for more details.
 
    b
       Array holding the input matrices ``B``.

--- a/source/elements/oneMKL/source/domains/blas/omatadd_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/omatadd_batch.rst
@@ -570,11 +570,11 @@ in-place operations:
                                  oneapi::mkl::transpose transb,
                                  std::int64_t m,
                                  std::int64_t n,
-                                 T alpha,
+                                 value_or_pointer<T> alpha,
                                  const T *a,
                                  std::int64_t lda,
                                  std::int64_t stride_a,
-                                 T beta,
+                                 value_or_pointer<T> beta,
                                  T *b,
                                  std::int64_t ldb,
                                  std::int64_t stride_b,
@@ -592,11 +592,11 @@ in-place operations:
                                  oneapi::mkl::transpose transb,
                                  std::int64_t m,
                                  std::int64_t n,
-                                 T alpha,
+                                 value_or_pointer<T> alpha,
                                  const T *a,
                                  std::int64_t lda,
                                  std::int64_t stride_a,
-                                 T beta,
+                                 value_or_pointer<T> beta,
                                  T *b,
                                  std::int64_t ldb,
                                  std::int64_t stride_b,
@@ -629,7 +629,7 @@ in-place operations:
       Number of columns for the result matrix ``C``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrices ``A``.
+      Scaling factor for the matrices ``A``. See :ref:`value_or_pointer` for more details.
 
    a
       Array holding the input matrices ``A``. Must have size at least ``stride_a`` * ``batch_size``.
@@ -667,7 +667,7 @@ in-place operations:
            - ``stride_a`` must be at least ``lda*n``.
 
    beta
-      Scaling factor for the matrices ``B``.
+      Scaling factor for the matrices ``B``. See :ref:`value_or_pointer` for more details.
 
    b
       Array holding the input matrices ``B``. Must have size at least

--- a/source/elements/oneMKL/source/domains/blas/omatcopy.rst
+++ b/source/elements/oneMKL/source/domains/blas/omatcopy.rst
@@ -187,7 +187,7 @@ omatcopy (USM Version)
                             oneapi::mkl::transpose trans,
                             std::int64_t m,
                             std::int64_t n,
-                            T alpha,
+                            value_or_pointer<T> alpha,
                             const T *a,
                             std::int64_t lda,
                             T *b,
@@ -201,7 +201,7 @@ omatcopy (USM Version)
                             oneapi::mkl::transpose trans,
                             std::int64_t m,
                             std::int64_t n,
-                            T alpha,
+                            value_or_pointer<T> alpha,
                             const T *a,
                             std::int64_t lda,
                             T *b,
@@ -227,7 +227,7 @@ omatcopy (USM Version)
       Number of columns for the matrix ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix transposition or copy.
+      Scaling factor for the matrix transposition or copy. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``. Must have size at least

--- a/source/elements/oneMKL/source/domains/blas/omatcopy2.rst
+++ b/source/elements/oneMKL/source/domains/blas/omatcopy2.rst
@@ -213,7 +213,7 @@ omatcopy2 (USM Version)
                              oneapi::mkl::transpose trans,
                              std::int64_t m,
                              std::int64_t n,
-                             T alpha,
+                             value_or_pointer<T> alpha,
                              const T *a,
                              std::int64_t lda,
                              std::int64_t stridea,
@@ -229,7 +229,7 @@ omatcopy2 (USM Version)
                              oneapi::mkl::transpose trans,
                              std::int64_t m,
                              std::int64_t n,
-                             T alpha,
+                             value_or_pointer<T> alpha,
                              const T *a,
                              std::int64_t lda,
                              std::int64_t stridea,
@@ -257,7 +257,7 @@ omatcopy2 (USM Version)
       Number of columns for the matrix ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix transposition or copy.
+      Scaling factor for the matrix transposition or copy. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``. Must have size at least

--- a/source/elements/oneMKL/source/domains/blas/omatcopy_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/omatcopy_batch.rst
@@ -430,7 +430,7 @@ the ``batch_size`` parameter.
            transpose trans,
            std::int64_t m,
            std::int64_t n,
-           T alpha,
+           value_or_pointer<T> alpha,
            const T *a,
            std::int64_t lda,
            std::int64_t stride_a,
@@ -447,7 +447,7 @@ the ``batch_size`` parameter.
            transpose trans,
            std::int64_t m,
            std::int64_t n,
-           T alpha,
+           value_or_pointer<T> alpha,
            const T *a,
            std::int64_t lda,
            std::int64_t stride_a,
@@ -476,7 +476,7 @@ the ``batch_size`` parameter.
       Number of columns for each matrix B. Must be at least 0.
 
    alpha
-      Scaling factor for the matrix transpose or copy operation.
+      Scaling factor for the matrix transpose or copy operation. See :ref:`value_or_pointer` for more details.
 
    a
       Array holding the matrices A. Must have size at least

--- a/source/elements/oneMKL/source/domains/blas/rot.rst
+++ b/source/elements/oneMKL/source/domains/blas/rot.rst
@@ -184,8 +184,8 @@ rot (USM Version)
                        std::int64_t incx,
                        T *y,
                        std::int64_t incy,
-                       Tc c,
-                       Ts s,
+                       value_or_pointer<Tc> c,
+                       value_or_pointer<Ts> s,
                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
@@ -197,8 +197,8 @@ rot (USM Version)
                        std::int64_t incx,
                        T *y,
                        std::int64_t incy,
-                       Tc c,
-                       Ts s,
+                       value_or_pointer<Tc> c,
+                       value_or_pointer<Ts> s,
                        const std::vector<sycl::event> &dependencies = {})
    }
 
@@ -231,10 +231,10 @@ rot (USM Version)
       Stride of vector ``y``.
 
    c
-      Scaling factor.
+      Scaling factor. See :ref:`value_or_pointer` for more details.
 
    s
-      Scaling factor.
+      Scaling factor. See :ref:`value_or_pointer` for more details.
 
    dependencies
       List of events to wait for before starting computation, if any.

--- a/source/elements/oneMKL/source/domains/blas/rotmg.rst
+++ b/source/elements/oneMKL/source/domains/blas/rotmg.rst
@@ -173,7 +173,7 @@ rotmg (USM Version)
                          T *d1,
                          T *d2,
                          T *x1,
-                         T  y1,
+                         value_or_pointer<T>  y1,
                          T *param,
                          const std::vector<sycl::event> &dependencies = {})
    }
@@ -184,7 +184,7 @@ rotmg (USM Version)
                          T *d1,
                          T *d2,
                          T *x1,
-                         T  y1,
+                         value_or_pointer<T>  y1,
                          T *param,
                          const std::vector<sycl::event> &dependencies = {})
    }
@@ -208,7 +208,7 @@ rotmg (USM Version)
       Pointer to the ``x``-coordinate of the input vector.
 
    y1
-      Scalar specifying the ``y``-coordinate of the input vector.
+      Scalar specifying the ``y``-coordinate of the input vector. See :ref:`value_or_pointer` for more details.
 
    dependencies
       List of events to wait for before starting computation, if any.

--- a/source/elements/oneMKL/source/domains/blas/sbmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/sbmv.rst
@@ -169,12 +169,12 @@ sbmv (USM Version)
                         onemkl::uplo upper_lower,
                         std::int64_t n,
                         std::int64_t k,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -186,12 +186,12 @@ sbmv (USM Version)
                         onemkl::uplo upper_lower,
                         std::int64_t n,
                         std::int64_t k,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -215,7 +215,7 @@ sbmv (USM Version)
       zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix
@@ -236,7 +236,7 @@ sbmv (USM Version)
       Stride of vector ``x``. Must not be zero.
 
    beta
-      Scaling factor for vector ``y``.
+      Scaling factor for vector ``y``. See :ref:`value_or_pointer` for more details.
 
    y
       Pointer to input/output vector ``y``. The array holding

--- a/source/elements/oneMKL/source/domains/blas/scal.rst
+++ b/source/elements/oneMKL/source/domains/blas/scal.rst
@@ -136,7 +136,7 @@ scal (USM Version)
    namespace oneapi::mkl::blas::column_major {
        sycl::event scal(sycl::queue &queue,
                         std::int64_t n,
-                        Ts alpha,
+                        value_or_pointer<Ts> alpha,
                         T *x,
                         std::int64_t incx,
                         const std::vector<sycl::event> &dependencies = {})
@@ -146,7 +146,7 @@ scal (USM Version)
    namespace oneapi::mkl::blas::row_major {
        sycl::event scal(sycl::queue &queue,
                         std::int64_t n,
-                        Ts alpha,
+                        value_or_pointer<Ts> alpha,
                         T *x,
                         std::int64_t incx,
                         const std::vector<sycl::event> &dependencies = {})
@@ -163,7 +163,7 @@ scal (USM Version)
       Number of elements in vector ``x``.
 
    alpha
-      Specifies the scalar ``alpha``.
+      Specifies the scalar ``alpha``. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to the input vector ``x``. The array must be of size at

--- a/source/elements/oneMKL/source/domains/blas/spmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/spmv.rst
@@ -155,11 +155,11 @@ spmv (USM Version)
        sycl::event spmv(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -170,11 +170,11 @@ spmv (USM Version)
        sycl::event spmv(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -194,7 +194,7 @@ spmv (USM Version)
       Number of rows and columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix
@@ -212,7 +212,7 @@ spmv (USM Version)
       Stride of vector ``x``. Must not be zero.
 
    beta
-      Scaling factor for vector ``y``.
+      Scaling factor for vector ``y``. See :ref:`value_or_pointer` for more details.
 
    y
       Pointer to input/output vector ``y``. The array holding

--- a/source/elements/oneMKL/source/domains/blas/spr.rst
+++ b/source/elements/oneMKL/source/domains/blas/spr.rst
@@ -141,7 +141,7 @@ spr (USM Version)
        sycl::event spr(sycl::queue &queue,
                        onemkl::uplo upper_lower,
                        std::int64_t n,
-                       T alpha,
+                       value_or_pointer<T> alpha,
                        const T *x,
                        std::int64_t incx,
                        T *a,
@@ -153,7 +153,7 @@ spr (USM Version)
        sycl::event spr(sycl::queue &queue,
                        onemkl::uplo upper_lower,
                        std::int64_t n,
-                       T alpha,
+                       value_or_pointer<T> alpha,
                        const T *x,
                        std::int64_t incx,
                        T *a,
@@ -174,7 +174,7 @@ spr (USM Version)
       Number of rows and columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to input vector ``x``. The array holding input vector

--- a/source/elements/oneMKL/source/domains/blas/spr2.rst
+++ b/source/elements/oneMKL/source/domains/blas/spr2.rst
@@ -152,7 +152,7 @@ spr2 (USM Version)
        sycl::event spr2(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x,
                         std::int64_t incx,
                         const T *y,
@@ -166,7 +166,7 @@ spr2 (USM Version)
        sycl::event spr2(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x,
                         std::int64_t incx,
                         const T *y,
@@ -189,7 +189,7 @@ spr2 (USM Version)
       Number of rows and columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to input vector ``x``. The array holding input vector

--- a/source/elements/oneMKL/source/domains/blas/symm.rst
+++ b/source/elements/oneMKL/source/domains/blas/symm.rst
@@ -209,12 +209,12 @@ symm (USM Version)
                         onemkl::uplo upper_lower,
                         std::int64_t m,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *b,
                         std::int64_t ldb,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *c,
                         std::int64_t ldc,
                         const std::vector<sycl::event> &dependencies = {})
@@ -227,12 +227,12 @@ symm (USM Version)
                         onemkl::uplo upper_lower,
                         std::int64_t m,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *b,
                         std::int64_t ldb,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *c,
                         std::int64_t ldc,
                         const std::vector<sycl::event> &dependencies = {})
@@ -263,7 +263,7 @@ symm (USM Version)
       be at least zero.
 
    alpha
-      Scaling factor for the matrix-matrix product.
+      Scaling factor for the matrix-matrix product. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``. Must have size at least
@@ -290,7 +290,7 @@ symm (USM Version)
       least ``n`` if column major layout is used to store matrices.
       
    beta
-      Scaling factor for matrix ``C``.
+      Scaling factor for matrix ``C``. See :ref:`value_or_pointer` for more details.
 
    c
       The pointer to input/output matrix ``C``. It must have a

--- a/source/elements/oneMKL/source/domains/blas/symv.rst
+++ b/source/elements/oneMKL/source/domains/blas/symv.rst
@@ -111,6 +111,9 @@ symv (Buffer Version)
    incx
       Stride of vector ``x``. Must not be zero.
 
+   beta
+      Scaling factor for the vector ``y``.
+
    y
       Buffer holding input/output vector ``y``. The buffer must be of
       size at least (1 + (``n`` - 1)*abs(``incy``)). See :ref:`matrix-storage`
@@ -160,12 +163,12 @@ symv (USM Version)
        sycl::event symv(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -176,12 +179,12 @@ symv (USM Version)
        sycl::event symv(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         const T *x,
                         std::int64_t incx,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *y,
                         std::int64_t incy,
                         const std::vector<sycl::event> &dependencies = {})
@@ -201,7 +204,7 @@ symv (USM Version)
       Number of rows and columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``. The array holding input matrix
@@ -220,6 +223,9 @@ symv (USM Version)
 
    incx
       Stride of vector ``x``. Must not be zero.
+
+   beta
+      Scaling factor for the vector ``y``. See :ref:`value_or_pointer` for more details.
 
    y
       Pointer to input/output vector ``y``. The array holding

--- a/source/elements/oneMKL/source/domains/blas/syr.rst
+++ b/source/elements/oneMKL/source/domains/blas/syr.rst
@@ -149,7 +149,7 @@ syr (USM Version)
        sycl::event syr(sycl::queue &queue,
                        onemkl::uplo upper_lower,
                        std::int64_t n,
-                       T alpha,
+                       value_or_pointer<T> alpha,
                        const T *x,
                        std::int64_t incx,
                        T *a,
@@ -162,7 +162,7 @@ syr (USM Version)
        sycl::event syr(sycl::queue &queue,
                        onemkl::uplo upper_lower,
                        std::int64_t n,
-                       T alpha,
+                       value_or_pointer<T> alpha,
                        const T *x,
                        std::int64_t incx,
                        T *a,
@@ -184,7 +184,7 @@ syr (USM Version)
       Number of columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to input vector ``x``. The array holding input vector

--- a/source/elements/oneMKL/source/domains/blas/syr2.rst
+++ b/source/elements/oneMKL/source/domains/blas/syr2.rst
@@ -161,7 +161,7 @@ syr2 (USM Version)
        sycl::event syr2(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x,
                         std::int64_t incx,
                         const T *y,
@@ -176,7 +176,7 @@ syr2 (USM Version)
        sycl::event syr2(sycl::queue &queue,
                         onemkl::uplo upper_lower,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *x,
                         std::int64_t incx,
                         const T *y,
@@ -200,7 +200,7 @@ syr2 (USM Version)
       Number of columns of ``A``. Must be at least zero.
 
    alpha
-      Scaling factor for the matrix-vector product.
+      Scaling factor for the matrix-vector product. See :ref:`value_or_pointer` for more details.
 
    x
       Pointer to input vector ``x``. The array holding input vector

--- a/source/elements/oneMKL/source/domains/blas/syr2k.rst
+++ b/source/elements/oneMKL/source/domains/blas/syr2k.rst
@@ -253,12 +253,12 @@ syr2k (USM Version)
                          onemkl::transpose trans,
                          std::int64_t n,
                          std::int64_t k,
-                         T alpha,
+                         value_or_pointer<T> alpha,
                          const T *a,
                          std::int64_t lda,
                          const T *b,
                          std::int64_t ldb,
-                         T beta,
+                         value_or_pointer<T> beta,
                          T *c,
                          std::int64_t ldc,
                          const std::vector<sycl::event> &dependencies = {})
@@ -271,12 +271,12 @@ syr2k (USM Version)
                          onemkl::transpose trans,
                          std::int64_t n,
                          std::int64_t k,
-                         T alpha,
+                         value_or_pointer<T> alpha,
                          const T *a,
                          std::int64_t lda,
                          const T *b,
                          std::int64_t ldb,
-                         T beta,
+                         value_or_pointer<T> beta,
                          T *c,
                          std::int64_t ldc,
                          const std::vector<sycl::event> &dependencies = {})
@@ -307,7 +307,7 @@ syr2k (USM Version)
       must be at least zero.
 
    alpha
-      Scaling factor for the rank-2k update.
+      Scaling factor for the rank-2k update. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``.
@@ -387,7 +387,7 @@ syr2k (USM Version)
            - ``ldb`` must be at least ``n``.
 
    beta
-      Scaling factor for matrix ``C``.
+      Scaling factor for matrix ``C``. See :ref:`value_or_pointer` for more details.
 
    c
       Pointer to input/output matrix ``C``. Must have size at least

--- a/source/elements/oneMKL/source/domains/blas/syrk.rst
+++ b/source/elements/oneMKL/source/domains/blas/syrk.rst
@@ -199,10 +199,10 @@ syrk (USM Version)
                         onemkl::transpose trans,
                         std::int64_t n,
                         std::int64_t k,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *c,
                         std::int64_t ldc,
                         const std::vector<sycl::event> &dependencies = {})
@@ -215,10 +215,10 @@ syrk (USM Version)
                         onemkl::transpose trans,
                         std::int64_t n,
                         std::int64_t k,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
-                        T beta,
+                        value_or_pointer<T> beta,
                         T *c,
                         std::int64_t ldc,
                         const std::vector<sycl::event> &dependencies = {})
@@ -249,7 +249,7 @@ syrk (USM Version)
       least zero.
 
    alpha
-      Scaling factor for the rank-k update.
+      Scaling factor for the rank-k update. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``.
@@ -290,7 +290,7 @@ syrk (USM Version)
            - ``lda`` must be at least ``n``.
 
    beta
-      Scaling factor for matrix ``C``.
+      Scaling factor for matrix ``C``. See :ref:`value_or_pointer` for more details.
 
    c
       Pointer to input/output matrix ``C``. Must have size at least

--- a/source/elements/oneMKL/source/domains/blas/syrk_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/syrk_batch.rst
@@ -389,11 +389,11 @@ in ``a`` and ``c`` are given by the ``batch_size`` parameter.
                               transpose trans,
                               std::int64_t n,
                               std::int64_t k,
-                              T alpha,
+                              value_or_pointer<T> alpha,
                               const T *a,
                               std::int64_t lda,
                               std::int64_t stride_a,
-                              T beta,
+                              value_or_pointer<T> beta,
                               T *c,
                               std::int64_t ldc,
                               std::int64_t stride_c,
@@ -408,11 +408,11 @@ in ``a`` and ``c`` are given by the ``batch_size`` parameter.
                               transpose trans,
                               std::int64_t n,
                               std::int64_t k,
-                              T alpha,
+                              value_or_pointer<T> alpha,
                               const T *a,
                               std::int64_t lda,
                               std::int64_t stride_a,
-                              T beta,
+                              value_or_pointer<T> beta,
                               T *c,
                               std::int64_t ldc,
                               std::int64_t stride_c,
@@ -446,7 +446,7 @@ in ``a`` and ``c`` are given by the ``batch_size`` parameter.
       Must be at least zero.
 
    alpha
-      Scaling factor for the rank-k updates.
+      Scaling factor for the rank-k updates. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrices ``A`` with size ``stridea`` * ``batch_size``.
@@ -471,7 +471,7 @@ in ``a`` and ``c`` are given by the ``batch_size`` parameter.
       Stride between different ``A`` matrices.
 
    beta
-      Scaling factor for the matrices ``C``.
+      Scaling factor for the matrices ``C``. See :ref:`value_or_pointer` for more details.
 
    c
       Pointer to input/output matrices ``C`` with size ``stridec`` * ``batch_size``.

--- a/source/elements/oneMKL/source/domains/blas/trmm.rst
+++ b/source/elements/oneMKL/source/domains/blas/trmm.rst
@@ -199,7 +199,7 @@ trmm (USM Version)
                         onemkl::diag unit_diag,
                         std::int64_t m,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         T *b,
@@ -215,7 +215,7 @@ trmm (USM Version)
                         onemkl::diag unit_diag,
                         std::int64_t m,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         T *b,
@@ -256,7 +256,7 @@ trmm (USM Version)
       must be at least zero.
 
    alpha
-      Scaling factor for the matrix-matrix product.
+      Scaling factor for the matrix-matrix product. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``. Must have size at least

--- a/source/elements/oneMKL/source/domains/blas/trsm.rst
+++ b/source/elements/oneMKL/source/domains/blas/trsm.rst
@@ -198,7 +198,7 @@ trsm (USM Version)
                         onemkl::diag unit_diag,
                         std::int64_t m,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         T *b,
@@ -215,7 +215,7 @@ trsm (USM Version)
                         onemkl::diag unit_diag,
                         std::int64_t m,
                         std::int64_t n,
-                        T alpha,
+                        value_or_pointer<T> alpha,
                         const T *a,
                         std::int64_t lda,
                         T *b,
@@ -255,7 +255,7 @@ trsm (USM Version)
       must be at least zero.
 
    alpha
-      Scaling factor for the solution.
+      Scaling factor for the solution. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrix ``A``. Must have size at least

--- a/source/elements/oneMKL/source/domains/blas/trsm_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/trsm_batch.rst
@@ -410,7 +410,7 @@ in ``a`` and ``b`` are given by the ``batch_size`` parameter.
                               onemkl::diag unit_diag,
                               std::int64_t m,
                               std::int64_t n,
-                              T alpha,
+                              value_or_pointer<T> alpha,
                               const T *a,
                               std::int64_t lda,
                               std::int64_t stridea,
@@ -430,7 +430,7 @@ in ``a`` and ``b`` are given by the ``batch_size`` parameter.
                               onemkl::diag unit_diag,
                               std::int64_t m,
                               std::int64_t n,
-                              T alpha,
+                              value_or_pointer<T> alpha,
                               const T *a,
                               std::int64_t lda,
                               std::int64_t stridea,
@@ -471,7 +471,7 @@ in ``a`` and ``b`` are given by the ``batch_size`` parameter.
       Number of columns of the ``B`` matrices. Must be at least zero.
 
    alpha
-      Scaling factor for the solutions.
+      Scaling factor for the solutions. See :ref:`value_or_pointer` for more details.
 
    a
       Pointer to input matrices ``A`` with size ``stridea`` * ``batch_size``.

--- a/source/elements/oneMKL/source/domains/dense_linear_algebra.inc.rst
+++ b/source/elements/oneMKL/source/domains/dense_linear_algebra.inc.rst
@@ -13,11 +13,14 @@ This section contains information about dense linear algebra routines:
 
 :ref:`onemkl_blas` provides vector, matrix-vector, and matrix-matrix routines for dense matrices and vector operations.
 
+:ref:`value_or_pointer` describes some details of how scalar parameters (such as ``alpha`` and ``beta``) are handled so that users may pass either values or pointers for these parameters.
+
 :ref:`onemkl_lapack` provides more complex dense linear algebra routines, e.g., matrix factorization, solving dense systems of linear equations, least square problems, eigenvalue and singular value problems, and performing a number of related computational tasks.
 
 .. toctree::
     :hidden:
 
     matrix-storage.rst
+    value_or_pointer.rst
     blas/blas.rst
     lapack/lapack.rst

--- a/source/elements/oneMKL/source/domains/value_or_pointer.rst
+++ b/source/elements/oneMKL/source/domains/value_or_pointer.rst
@@ -1,0 +1,106 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+.. _value_or_pointer:
+
+Scalar Arguments in BLAS
+========================
+
+.. container::
+
+   The USM version of oneMKL BLAS routines for DPC++ will accept either
+   a scalar (for example ``float``) or pointer (``float*``) for parameters
+   that represent a single fixed value (not a vector or matrix). These
+   parameters are often named ``alpha`` or ``beta`` in BLAS.
+
+   .. container:: section
+
+      .. rubric:: Basic Use
+         :name: basic-use
+         :class: sectiontitle
+
+      Users can call ``gemv`` with pointers:
+
+        .. code-block::
+
+          float *alpha_ptr = sycl::malloc_shared<float>(1, queue);
+          float *beta_ptr = sycl::malloc_shared<float>(1, queue);
+          // fill alpha_ptr and beta_ptr with desired values
+          oneapi::mkl::blas::column_major::gemv(queue, trans, m, n, alpha_ptr, lda, x, incx, beta_ptr,
+                                                y, incy).wait();
+
+      or with literal values:
+
+        .. code-block::
+
+          oneapi::mkl::blas::column_major::gemv(queue, trans, m, n, 2, lda, x, incx, 2.7,
+                                                y, incy).wait();
+
+      Users can even mix scalar and pointer parameters in a single call:
+
+        .. code-block::
+
+          float *alpha_ptr = sycl::malloc_shared<float>(1, queue);
+          oneapi::mkl::blas::column_major::gemv(queue, trans, m, n, alpha_ptr, lda, x, incx, 2.7,
+                                             y, incy).wait();
+
+      Pointers provided for scalar parameters may be SYCL-managed pointers
+      to either device or host memory (for example pointers created with
+      ``sycl::malloc_device``, ``sycl::malloc_shared``, or
+      ``sycl::malloc_host``), or they may be raw pointers created with
+      ``malloc`` or ``new``.
+
+      For most users, this is all they need to know. A few details about how
+      this is implemented are provided below.
+
+   .. container:: section
+
+      .. rubric:: Wrapper type
+         :name: wrapper-time
+         :class: sectiontitle
+
+      The USM version of oneMKL BLAS routines use a templated
+      ``value_or_pointer<T>`` wrapper to enable either pointers or values
+      to be passed to routines that take a scalar parameter. This type is in
+      the ``oneapi::mkl::`` namespace and defined in the header file
+      ``oneapi/mkl/types.hpp``.
+
+      In general, users should not explicitly use this type in their
+      code. There is no need to construct an object of type
+      ``value_or_pointer`` in order to use the oneMKL functions that
+      include it in their function signatures. Instead, values and pointers
+      in user code will be implicitly converted to this type when a user
+      calls a oneMKL function.
+
+      The ``value_or_pointer<T>`` wrapper has two constructors, one that
+      converts a value of type ``T`` (or anything convertible to ``T``) to
+      ``value_or_pointer<T>``, and another that converts a pointer to ``T``
+      to ``value_or_pointer<T>``. Internally, the oneMKL functions can
+      behave slightly differently depending on whether the underlying data
+      is a value or a pointer, and if it points to host-side memory or
+      device-side memory, but these uses should be transparent to users.
+
+   .. container:: section
+
+      .. rubric:: Dependencies
+         :name: dependencies
+         :class: sectiontitle
+
+      For scalar parameters passed to oneMKL BLAS routines as pointers, the
+      timing of pointer dereferencing depends on whether it is a USM-managed
+      pointer or a raw pointer.
+
+      For a USM-managed pointer, it is dereferenced at kernel launch after
+      the dependencies passed to the function have been resolved, so the
+      value may be assigned asynchronously in another event passed as a
+      dependency to the routine.
+
+      A raw pointer (such as those allocated with ``malloc`` or ``new``) is
+      dereferenced at the function call, so it must be valid when the
+      function is called. In this case the data must be valid when the
+      function is called and it may not be assigned asynchronously.
+
+
+      **Parent topic:** :ref:`onemkl_dense_linear_algebra`
+


### PR DESCRIPTION
Allow either values or pointers for scalar parameters to BLAS functions with USM interfaces.

This would allow users to provide values in device memory for these scalar parameters.