### PR TITLE
[oneDNN Graph] align with oneDNN v3.2 public release in dnnl_graph.hpp

### DIFF
--- a/source/elements/oneDNN/include/dnnl_graph.hpp
+++ b/source/elements/oneDNN/include/dnnl_graph.hpp
@@ -136,6 +136,8 @@ struct logical_tensor {
     s8,
     /// 8-bit unsigned integer.
     u8,
+    /// Boolean data type. Size is C++ implementation defined.
+    boolean
   };
 
   /// Layout type
@@ -455,6 +457,7 @@ struct op {
     Mish ,
     MishBackward ,
     Multiply ,
+    Pow ,
     PReLU ,
     PReLUBackward ,
     Quantize ,
@@ -470,6 +473,7 @@ struct op {
     ReLUBackward ,
     Reorder ,
     Round ,
+    Select ,
     Sigmoid ,
     SigmoidBackward ,
     SoftMax ,


### PR DESCRIPTION
We has aligned the public spec with oneDNN v3.2 public release before in [PR486](https://github.com/oneapi-src/oneAPI-spec/pull/486), but we missed corresponding changes in dnnl_graph.hpp, now we want to fix it.