### PR TITLE
[oneMKL][Sparse BLAS] Add `sycl::queue &` to `sparse::init_matrix_handle()` API

### DIFF
--- a/source/elements/oneMKL/source/domains/spblas/matrixinit.rst
+++ b/source/elements/oneMKL/source/domains/spblas/matrixinit.rst
@@ -24,19 +24,22 @@ The oneapi::mkl::sparse::init_matrix_handle function initializes the
 
    namespace oneapi::mkl::sparse {
 
-      void init_matrix_handle (oneapi::mkl::sparse::matrix_handle_t *p_handle);
+      void init_matrix_handle (sycl::queue                          &queue,
+                               oneapi::mkl::sparse::matrix_handle_t *p_handle);
 
    }
 
-
 .. container:: section
 
+
     .. rubric:: Input parameters
+
+    queue
+       The SYCL command queue which will be used for SYCL kernels execution.
 
     p_handle
        The address of the sparse::matrix_handle_t ``p_handle`` object to be initialized.
        This initialization routine must only be called on an uninitialized matrix_handle_t object.
-
 
 .. container:: section
 

--- a/source/elements/oneMKL/source/domains/spblas/releasematrixhandle.rst
+++ b/source/elements/oneMKL/source/domains/spblas/releasematrixhandle.rst
@@ -47,7 +47,7 @@ before releasing any data in case of USM.
 
     dependencies
        List of events that ``p_handle`` depends on.
-       The call waits on the events(if any) before resetting the ``p_handle`` to default values.
+       The call waits on the events (if any) before resetting the ``p_handle`` to default values.
 
 .. container:: section
 


### PR DESCRIPTION
## Proposal
* Change the `oneapi::mkl::sparse::init_matrix_handle()` API to also include a `sycl::queue &queue` as a function argument.
* We recommend this change should go into the finalized version 1.3 release of the oneAPI Specification.
* The rationale is that in implementations of the oneMKL specification, such as [oneMKL Interfaces](https://github.com/oneapi-src/oneMKL/) repository, dispatching directly to a backend library from the spec APIs is easier when the `queue` is part of the API for 
    * Without the `queue` in there, implementations need to maintain an implementation of `oneapi::mkl::sparse::matrix_handle_t`.
    * With the `queue` in there, implementations can directly forward the arguments to different backend implementations such as the Intel oneMKL library or the cuSPARSE library.
* Also adds a space character in `release_matrix_handle()` documentation that was missed out; just a minor typo.