### PR TITLE
[oneDPL] Fixing zip_iterator for `value_type` and `base()` return

### DIFF
--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -250,13 +250,12 @@ using the source iterator and unary function object provided.
     {
       public:
         using difference_type = typename std::make_signed<std::size_t>::type;
-        using value_type =
-            std::tuple<typename std::iterator_traits<Iterators>::value_type...>;
+        using value_type = /* unspecified tuple of value types */;
         using reference = /* unspecified tuple of reference types */;
         using pointer =
             std::tuple<typename std::iterator_traits<Iterators>::pointer...>;
 
-        std::tuple<Iterators...> base() const;
+        /* returns unspecified tuple of source Iterators */ base() const;
 
         zip_iterator();
         explicit zip_iterator(Iterators... args);
@@ -287,11 +286,12 @@ using the source iterator and unary function object provided.
     };
 
 ``zip_iterator`` is an iterator-like type defined over one or more iterators. When dereferenced,
-the value returned from ``zip_iterator`` is a tuple of the values returned by dereferencing the
+the value returned from ``zip_iterator`` is an unspecified tuple type of the values returned by dereferencing the
 source iterators over which the ``zip_iterator`` is defined. The arithmetic operators of
 ``zip_iterator`` update the source iterators of a ``zip_iterator`` instance as though the
-operation were applied to each of these iterators. The types ``T`` within the template pack 
-``Iterators...`` must satisfy ``AdaptingIteratorSource``.
+operation were applied to each of these iterators. The types ``T`` within the template pack
+``Iterators...`` must satisfy ``AdaptingIteratorSource``. Member function `base()` returns an unspecified tuple of
+the source iterators.
 
 .. code:: cpp
 


### PR DESCRIPTION
The existing `zip_iterator` class specification uses `std::tuple` as the `value_type` and also the return of `base()`.  
This is problematic for device copyability for dpcpp device backend and is not how oneDPL has implemented `zip_iterator` for quite some time.  `std::tuple` is not required to be trivially copyable, which causes pain when dealing with `zip_iterator` and SYCL kernels, requiring `is_device_copyable` specializations for any types which are composed of `zip_iterator::value_type`.  

We currently leave `pointer` as `std::tuple` (it is still a `std::tuple` in our implementation), but could consider changing it in this PR to be more broad in case of future changes. `pointer` seems less of an issue from a device copyable standpoint, but it still may be nice to use a consistent unspecified tuple across the type, and changing it here would give more freedom in the future.

I view this as a bugfix for the specification, rather than a breaking change, but that is of course up for discussion.