### PR TITLE
[oneDPL][ranges] Add lexicographical_compare parallel range algorithm

### DIFF
--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -354,9 +354,7 @@ Sequence Search and Comparison
                                                std::projected<std::ranges::iterator_t<R2>, Proj2> >
                     Comp = std::ranges::less>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
-               std::ranges::sized_range<R1> && std::ranges::sized_range<R2> &&
-               std::indirectly_comparable< std::ranges::iterator_t<R1>, std::ranges::iterator_t<R2>,
-                                           Comp, Proj1, Proj2 >
+               std::ranges::sized_range<R1> && std::ranges::sized_range<R2>
       bool lexicographical_compare (ExecutionPolicy&& pol, R1&& r1, R2&& r2, Comp comp = {},
                                    Proj1 proj1 = {}, Proj2 proj2 = {});
   }


### PR DESCRIPTION
Adding `lexicographical_compare` into oneDPL specification.
An additional change: adding missing spaces in "Sequence Search and Comparison" group. 