### PR TITLE
[oneDPL] Fix set_difference_result

### DIFF
--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -474,7 +474,6 @@ Set operations
                std::mergeable<std::ranges::iterator_t<R1>, std::ranges::iterator_t<R2>,
                               std::ranges::iterator_t<OutR>, Comp, Proj1, Proj2>
       std::ranges::set_difference_result<std::ranges::borrowed_iterator_t<R1>,
-                                         std::ranges::borrowed_iterator_t<R2>,
                                          std::ranges::borrowed_iterator_t<OutR>>
         set_difference (ExecutionPolicy&& pol, R1&& r1, R2&& r2, OutR&& result, Comp comp = {},
                         Proj1 proj1 = {}, Proj2 proj2 = {});


### PR DESCRIPTION
Align the specification with [p3179r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html#modify_set_difference). #630 mistakenly added an extra return type into the alias. 