### PR TITLE
[oneDPL][ranges] Add partial_sort and partial_sort_copy

### DIFF
--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -394,19 +394,19 @@ Sorting, Merge, and Heap Operations
                       Comp comp = {}, Proj proj = {});
 
     // partial_sort_copy
-    template <typename ExecutionPolicy, std::ranges::random_access_range R1,
-              std::ranges::random_access_range R2, typename Comp = std::ranges::less,
+    template <typename ExecutionPolicy, std::ranges::random_access_range R,
+              std::ranges::random_access_range OutR, typename Comp = std::ranges::less,
               typename Proj1 = std::identity, typename Proj2 = std::identity>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
-               std::ranges::sized_range<R1> && std::ranges::sized_range<R2> &&
-               std::indirectly_copyable<std::ranges::iterator_t<R1>, std::ranges::iterator_t<R2>> &&
-               std::sortable<std::ranges::iterator_t<R2>, Comp, Proj2> &&
+               std::ranges::sized_range<R> && std::ranges::sized_range<OutR> &&
+               std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR>> &&
+               std::sortable<std::ranges::iterator_t<OutR>, Comp, Proj2> &&
                std::indirect_strict_weak_order<Comp,
-                                               std::projected<std::ranges::iterator_t<R1>, Proj1>,
-                                               std::projected<std::ranges::iterator_t<R2>, Proj2> >
-      std::ranges::partial_sort_copy_result<std::ranges::borrowed_iterator_t<R1>,
-                                            std::ranges::borrowed_iterator_t<R2>>
-        partial_sort_copy (ExecutionPolicy&& pol, R1&& r1, R2&& r2, Comp comp = {},
+                                               std::projected<std::ranges::iterator_t<R>, Proj1>,
+                                               std::projected<std::ranges::iterator_t<OutR>, Proj2> >
+      std::ranges::partial_sort_copy_result<std::ranges::borrowed_iterator_t<R>,
+                                            std::ranges::borrowed_iterator_t<OutR>>
+        partial_sort_copy (ExecutionPolicy&& pol, R&& r, OutR&& result, Comp comp = {},
                            Proj1 proj1 = {}, Proj2 proj2 = {});
 
     // is_sorted


### PR DESCRIPTION
Adding `partial_sort` and `partial_sort_copy` parallel range algorithms into oneDPL specification.