### PR TITLE
[oneDPL][ranges] Add generate

### DIFF
--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -607,6 +607,16 @@ In-place Mutating Operations
       std::ranges::borrowed_iterator_t<R>
         fill (ExecutionPolicy&& pol, R&& r, const T& value);
 
+    // generate
+    template <typename ExecutionPolicy, std::ranges::random_access_range R,
+              std::copy_constructible F>
+      requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
+               std::ranges::sized_range<R> && std::invocable<F&> &&
+               std::indirectly_writable<std::ranges::iterator_t<R>,
+                                        std::indirect_result_t<F&>>
+      std::ranges::borrowed_iterator_t<R>
+        generate (ExecutionPolicy&& pol, R&& r, F gen);
+
     // replace
     template <typename ExecutionPolicy, std::ranges::random_access_range R,
               typename Proj = std::identity,


### PR DESCRIPTION
Adding `generate` parallel range algorithm into oneDPL specification.