### PR TITLE
[oneTBB] Add a function to create a set of NUMA bound task arenas

### DIFF
--- a/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
+++ b/source/elements/oneTBB/source/task_scheduler/task_arena/task_arena_cls.rst
@@ -376,7 +376,7 @@ to the corresponding NUMA node.
         }
 
         arenas[0].execute([] {
-            /* parallel work */
+            /* executed by the main thread pinned to the NUMA node for arenas[0] */
         });
 
         for (int i = 1; i < arenas.size(); i++) {


### PR DESCRIPTION
Add a page that describes helper APIs to simplify constrained arena creations. Currently it is a single function `oneapi::tbb::create_numa_task_arenas` from [corresponding RFC](https://github.com/uxlfoundation/oneTBB/blob/981eb42aee3730ced4c296e16a3154e1803bd088/rfcs/proposed/numa_support/create-numa-arenas.md).