### PR TITLE
[oneDPL] Fix the default template argument for the new value type in replace[_if]

### DIFF
--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -868,7 +868,8 @@ In-place Mutating Operations
     // replace
     template <typename ExecutionPolicy, std::ranges::random_access_range R,
               typename Proj = std::identity,
-              typename T1 = /*projected-value-type*/<std::ranges::iterator_t<R>, Proj>, typename T2 = T1>
+              typename T1 = /*projected-value-type*/<std::ranges::iterator_t<R>, Proj>,
+              typename T2 = std::ranges::range_value_t<R>>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
                std::ranges::sized_range<R> &&
                std::indirectly_writable<std::ranges::iterator_t<R>, const T2&> &&
@@ -882,7 +883,7 @@ In-place Mutating Operations
     // replace_if
     template <typename ExecutionPolicy, std::ranges::random_access_range R,
               typename Proj = std::identity,
-              typename T = /*projected-value-type*/<std::ranges::iterator_t<R>, Proj>,
+              typename T = std::ranges::range_value_t<R>,
               std::indirect_unary_predicate< std::projected<std::ranges::iterator_t<R>, Proj> > Pred>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
                std::ranges::sized_range<R> &&


### PR DESCRIPTION
Reviewers of the C++26 working draft have found that, citing,
> The default template argument for the type of the new value in `range::replace` and `ranges::replace_if` should not have projections applied.

While this comment has not yet been resolved, it seems correct: the standard wording for these algorithms does not imply that the new value can be used as an argument to the projection or in an expression with projected values.

It seems appropriate therefore to proactively fix the respective signatures in the oneDPL specification.